### PR TITLE
Set the container names to DNS safe values.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
   db:
     image: mysql:latest
+    container_name: farmos-db
+    network_mode: bridge
     volumes:
       - './.data/db:/var/lib/mysql'
     restart: always
@@ -15,6 +17,8 @@ services:
     depends_on:
       - db
     image: farmos/farmos:7.x-1.x
+    container_name: farmos
+    network_mode: bridge
     volumes:
       - './.data/www:/var/www/html'
     links:


### PR DESCRIPTION
Change `network_mode` to `bridge` to support running on Os X under dlite: https://github.com/nlf/dlite
NOTE: To run farmOS under dlite:

1. Download the latest release from https://github.com/nlf/dlite/releases
2. Copy `dlite` to `/usr/local/bin/dlite`
3. Run `chmod +x /usr/local/bin/dlite`
4. Initialize dlite by running: `dlite init`
5. Start dlite host vm by running `dlite start`
6. Start farmOS with docker-compose
6. Profit!