### PR TITLE
Autofill location into the asset name

### DIFF
--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -244,7 +244,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
     $location = $form_values['logs']['seeding']['location'];
   }
 
-  // The planting will be named based on the season and crop.
+  // The planting will be named based on the season, location and crop.
   $planting_name_parts = array(
     $season,
     $location,

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -258,6 +258,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
   $form['planting']['name'] = array(
     '#type' => 'textfield',
     '#title' => t('Planting asset name'),
+    '#description' => t('The planing asset name will autofill as [Season][Location][Crop(s)] but can be modified here. The transplanting location is used before defaulting to a seeding location.'),
     '#default_value' => implode(' ', $planting_name_parts),
     '#prefix' => '<div id="planting-name">',
     '#suffix' => '</div>',

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -177,6 +177,10 @@ function farm_crop_planting_quick_form($form, &$form_state) {
         '#type' => 'textfield',
         '#title' => t( 'Location'),
         '#autocomplete_path' => 'taxonomy/autocomplete/field_farm_area',
+        '#ajax' => array(
+          'callback' => 'farm_crop_planting_quick_form_name_ajax',
+          'wrapper' => 'planting-name',
+        ),
         '#required' => TRUE,
       ),
       'quantity' => array(
@@ -231,9 +235,19 @@ function farm_crop_planting_quick_form($form, &$form_state) {
     $crop_tags = $form_values['crops'];
   }
 
+  // Get the location.
+  // Use Transplaing, then default to Seeding.
+  $location = '';
+  if (!empty($form_values['logs']['transplanting']['location']) ) {
+    $location = $form_values['logs']['transplanting']['location'];
+  } else if (!empty($form_values['logs']['seeding']['location'])) {
+    $location = $form_values['logs']['seeding']['location'];
+  }
+
   // The planting will be named based on the season and crop.
   $planting_name_parts = array(
     $season,
+    $location,
     implode(', ', $crop_tags),
   );
 


### PR DESCRIPTION
Drupal issue [3023724](https://www.drupal.org/project/farm/issues/3023724)

Uses the transplanting location, then defaults to the seeding location.
Also adds a description to the name field.