### PR TITLE
Farm_area module error

### DIFF
--- a/modules/farm/farm_area/farm_area.module
+++ b/modules/farm/farm_area/farm_area.module
@@ -597,7 +597,7 @@ function farm_area_convert_area_units($input, $unit) {
     $output = bcmul($input, $conversion[$unit]);
   }
   else {
-    $output = $input * $conversion;
+    $output = $input * $conversion[$unit];
   }
 
   // Return the result.

--- a/modules/farm/farm_area/farm_area.module
+++ b/modules/farm/farm_area/farm_area.module
@@ -465,7 +465,7 @@ function farm_area_calculate_area_multiple($area_ids, $format = FALSE) {
   }
 
   // Add up the total area.
-  $total_area = '';
+  $total_area = 0;
   foreach ($area_ids as $area_id) {
     $area_area = farm_area_calculate_area($area_id);
     if (function_exists('bcadd')) {


### PR DESCRIPTION
In my installation, this was flagging up as 2 issues. 
I don't know whether this is just treating the symptoms, rather than the route cause, but this was the problem I had:

`Error: Unsupported operand types in farm_area_convert_area_units() (line 600 of /var/www/html/farmOS/profiles/farm/modules/farm/farm_area/farm_area.module).`

In line 600:

` $output = $input * $conversion;`

$conversion is an array with the conversion factors in, but there is no key specified here, so just added `[$unit]` key:

` $output = $input * $conversion[$unit];`

Second one:
`Warning: A non-numeric value encountered in farm_area_calculate_area_multiple() (line 475 of /var/www/html/farmOS/profiles/farm/modules/farm/farm_area/farm_area.module).`

Line 468 is `$total_area = '';`

So when it was calling '$total_area += $area_area;' on line 475 it was trying to add numeric to a string.

Changed 468 to` $total_area = 0;`
