### PR TITLE
Gitignore docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ libraries
 modules/contrib
 modules/dev
 themes/bootstrap
-
+docker-compose.yml


### PR DESCRIPTION
When using docker on a server or locally when developing, this file always pops up in `git status`

Can we ignore it, until maybe someone decides it should be in the root (and not in the /docker folder)?


I was also thinking if we should gitignore the `db/` and `www/`? But that can be a new PR