### PR TITLE
Fixed problems when BC math is missing

### DIFF
--- a/modules/farm/farm_area/farm_area.module
+++ b/modules/farm/farm_area/farm_area.module
@@ -475,7 +475,7 @@ function farm_area_calculate_area_multiple($area_ids, $format = FALSE) {
       if (empty($total_area)) {
         $total_area = 0;
       }
-      $total_area += $area_area;
+      $total_area += floatval($area_area);
     }
   }
 
@@ -600,7 +600,7 @@ function farm_area_convert_area_units($input, $unit) {
     $output = bcmul($input, $conversion[$unit]);
   }
   else {
-    $output = $input * $conversion[$unit];
+    $output = floatval($input) * $conversion[$unit];
   }
 
   // Return the result.


### PR DESCRIPTION
Changed this manually in my 1.1 installation, but thought it was time to contribute the fix.
Not running BC math on my php 7.2 installation.