### PR TITLE
Add configuration UI for administering the farm_access module

### DIFF
--- a/modules/farm/farm_access/farm_access.install
+++ b/modules/farm/farm_access/farm_access.install
@@ -32,6 +32,9 @@ function farm_access_uninstall() {
   foreach ($roles as $name) {
     user_role_delete($name);
   }
+
+  // Clean up variables.
+  variable_del('farm_access_allow_origin');
 }
 
 /**

--- a/modules/farm/farm_access/farm_access.module
+++ b/modules/farm/farm_access/farm_access.module
@@ -33,6 +33,69 @@ function farm_access_hook_info() {
 }
 
 /**
+ * Implements hook_permission().
+ */
+function farm_access_permission() {
+  $perms = array(
+    'administer farm_access module' => array(
+      'title' => t('Administer farm access module'),
+    ),
+  );
+  return $perms;
+}
+
+/**
+ * Implements hook_farm_access_perms().
+ */
+function farm_access_farm_access_perms($role) {
+  $perms = array();
+
+  // Load the list of farm roles.
+  $roles = farm_access_roles();
+
+  // If this role has 'config' access, grant access to farm_access configuration.
+  if (!empty($roles[$role]['access']['config'])) {
+    $perms[] = 'administer farm_access module';
+  }
+
+  return $perms;
+}
+
+/**
+ * Implements hook_menu().
+ */
+function farm_access_menu() {
+
+  // Access configuration form.
+  $items['admin/config/farm/access'] = array(
+    'title' => 'Access',
+    'description' => 'Access configuration settings.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('farm_access_settings_form'),
+    'access arguments' => array('administer farm_access module'),
+  );
+
+  return $items;
+}
+
+/**
+ * Access settings form.
+ */
+function farm_access_settings_form($form, &$form_state) {
+
+  // Metric or US/Imperial.
+  $form['farm_access_allow_origin'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Access-Control-Allow-Origin'),
+    '#description' => t('This will be put in the Access-Control-Allow-Origin header, which is necessary for third-party client-side applications to access farmOS data via the API. Defaults to "https://farmos.app" to work with the farmOS Field Kit application.'),
+    '#default_value' => variable_get('farm_access_allow_origin', 'https://farmos.app'),
+  );
+
+  // Return it as a system settings form.
+  return system_settings_form($form);
+}
+
+/**
  * Load a list of farm roles.
  *
  * @return array

--- a/modules/farm/farm_access/farm_access.module
+++ b/modules/farm/farm_access/farm_access.module
@@ -9,8 +9,8 @@
  */
 function farm_access_init() {
 
-  // Allow API access from https://farmOS.app.
-  drupal_add_http_header('Access-Control-Allow-Origin', 'https://farmos.app');
+  // Allow API access from approved origin (defaults to https://farmos.app).
+  drupal_add_http_header('Access-Control-Allow-Origin', variable_get('farm_access_allow_origin', 'https://farmos.app'));
   drupal_add_http_header('Access-Control-Allow-Credentials', 'true');
   drupal_add_http_header('Access-Control-Allow-Headers', 'Content-Type,Authorization,X-CSRF-Token');
   drupal_add_http_header('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,HEAD,OPTIONS');


### PR DESCRIPTION
This was needed to give users (particularly self-hosted users) a means of configuring which third-party client sites can access the farmOS API. Prior to this we had farmos.app hardcoded in, but in the future, other clients may want to connect as well. It also alleviates a pain point in development of Field Kit, where we had to go into the module and modify the hardcoded value in order to connect via http:localhost:8080 instead of farmos.app.

This resolves #187 and https://www.drupal.org/project/farm/issues/3083205

Thanks @mstenta for all the help!