### PR TITLE
Fix location input in Planting Quick Form

### DIFF
--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -177,6 +177,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
         '#type' => 'textfield',
         '#title' => t( 'Location'),
         '#autocomplete_path' => 'taxonomy/autocomplete/field_farm_area',
+        '#maxlength' => NULL,
         '#ajax' => array(
           'callback' => 'farm_crop_planting_quick_form_name_ajax',
           'wrapper' => 'planting-name',

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -249,10 +249,13 @@ function farm_crop_planting_quick_form($form, &$form_state) {
   }
 
   // The planting will be named based on the season, location and crop.
+  // The location string may be trimmed to 253 char (accounting for spaces)
+  // to ensure that the asset name is less than 255 characters.
+  $crop_string = implode(',', $crop_tags);
   $planting_name_parts = array(
     $season,
-    $location,
-    implode(', ', $crop_tags),
+    substr($location, 0, (253 - strlen($season) - strlen($crop_string)) ),
+    $crop_string,
   );
   $planting_name = implode(' ', $planting_name_parts);
 

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -64,6 +64,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
     $form['planting']['crops'][$i] = array(
       '#type' => 'textfield',
       '#title' => t('Crop/variety') . ' ' . ($i+1),
+      '#description' => t('Enter the crop/variety that this is a planting of. As you type, you will have the option of selecting from crops/varieties that you\'ve entered in the past.'),
       '#autocomplete_path' => 'taxonomy/autocomplete/field_farm_crop',
       '#ajax' => array(
         'callback' => 'farm_crop_planting_quick_form_name_ajax',
@@ -176,6 +177,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
       'location' => array(
         '#type' => 'textfield',
         '#title' => t( 'Location'),
+        '#description' => t('Set the ' . $info['title'] . ' areas(s) for this asset. Separate multiple areas with commas.'),
         '#autocomplete_path' => 'taxonomy/autocomplete/field_farm_area',
         '#maxlength' => NULL,
         '#ajax' => array(

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -262,6 +262,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
   $form['planting']['name'] = array(
     '#type' => 'textfield',
     '#title' => t('Planting asset name'),
+    '#maxlength' => 255,
     '#description' => t('The planting asset name will default to "[Season] [Location] [Crop(s)]" but can be modified here. If both a seeding and a transplanting log are created, the transplanting location will be used.'),
     '#default_value' => $planting_name,
     '#prefix' => '<div id="planting-name">',

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -166,7 +166,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
         '#title' => t('Date'),
         '#date_format' => $date_format,
         '#date_label_position' => 'within',
-        '#date_year_range' => '-3:+10',
+        '#date_year_range' => '-10:+3',
         '#default_value' => REQUEST_TIME,
         '#required' => TRUE,
       ),


### PR DESCRIPTION
This fixes #211.

- Updated the `location` texfield to have unlimited length to allow inputting many locations (previously was limited to html/css default of 128 characters)
- Trim the `location` string to ensure the length of the planting asset `name` field is < 255 characters. This also takes into account the `season` and `crop tags` to make sure the TOTAL length (with spaces) is less than 255.
- Set the planting asset `name` field's `maxlength` property to 255 characters. Previous was 128 character default.
- Add description fields for Crops and Locations. Closes #210 
- Update the `date_year_range` to `-10:+3` for consistency with other date selectors. Closes #209 

@mstenta I saw your commit https://github.com/farmOS/farmOS/commit/94291e4b92cadae6cb6ebc40c9c4b35e1fc2f985 that added a `farm_movement_asset_location_validate` function to validate the length of each location name to < 255 characters. I thought about copy/pasting the same validator here, but was hesitant for a couple reasons: 
1. Is that code reusable? Not sure if I could simply link to `farm_movement_asset_location_validate` in this file. Also, I don't think the `form_state['values']` are structured the same way, so it would probably fail if I could. Can `farm_asset` provide a callback to validate an `asset_name` ?
2. I also omitted that for sake of simplicity. Kinda unlikely that location names > 255 characters will be input. It would be best if we had a reusable validation function so we aren't copy/pasting wherever we have `asset name` in a form.
