### PR TITLE
Updated postgis image to version managed directly by postgis team; ad…

### DIFF
--- a/docker/docker-compose.override.postgis.yml
+++ b/docker/docker-compose.override.postgis.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   db:
-    image: mdillon/postgis:latest
+    image: postgis/postgis:latest
     volumes:
       - './db:/var/lib/postgresql/data'
     ports:
@@ -9,3 +9,4 @@ services:
     environment:
       POSTGRES_USER: farm
       POSTGRES_PASSWORD: farm
+    restart: unless-stopped


### PR DESCRIPTION
…ded restart: unless-stopped direction

As requested. Updated docker-compose override that uses the postgis container managed by the postgis team