### PR TITLE
Fix multiple seasons bug in Planting Quick Form

### DIFF
--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -32,7 +32,7 @@ function farm_crop_planting_quick_form($form, &$form_state) {
   $form['planting']['season'] = array(
     '#type' => 'textfield',
     '#title' => t('Season'),
-    '#description' => t('What season will this planting be part of? This is used for organizing plantings for future reference, and can be something like "@year" or "@year Summer". This will be prepended to the planting asset name.', array('@year' => date('Y'))),
+    '#description' => t('What season(s) will this planting be part of? This is used for organizing plantings for future reference, and can be something like "@year" or "@year Summer". This will be prepended to the planting asset name.', array('@year' => date('Y'))),
     '#autocomplete_path' => 'taxonomy/autocomplete/field_farm_season',
     '#default_value' => $season,
     '#ajax' => array(
@@ -330,7 +330,7 @@ function farm_crop_planting_quick_form_submit($form, &$form_state) {
   variable_set('farm_crop_planting_season', $season);
 
   // Load/create the season term.
-  $season_term = farm_term($season, 'farm_season');
+  $seasons = farm_season_parse_names($season, TRUE);
 
   // Get the crop(s) and load/create terms for each.
   $crops = array();
@@ -350,8 +350,10 @@ function farm_crop_planting_quick_form_submit($form, &$form_state) {
   $planting_asset = entity_create('farm_asset', $values);
   $planting_wrapper = entity_metadata_wrapper('farm_asset', $planting_asset);
 
-  // Add the season.
-  $planting_wrapper->field_farm_season[] = $season_term;
+  // Add each season.
+  foreach ($seasons as $season) {
+    $planting_wrapper->field_farm_season[] = $season;
+  }
 
   // Add the crop(s).
   foreach ($crops as $crop) {

--- a/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
+++ b/modules/farm/farm_crop/farm_crop.farm_quick.planting.inc
@@ -351,7 +351,7 @@ function farm_crop_planting_quick_form_submit($form, &$form_state) {
   $planting_wrapper = entity_metadata_wrapper('farm_asset', $planting_asset);
 
   // Add the season.
-  $planting_wrapper->field_farm_season = $season_term;
+  $planting_wrapper->field_farm_season[] = $season_term;
 
   // Add the crop(s).
   foreach ($crops as $crop) {

--- a/modules/farm/farm_season/farm_season.module
+++ b/modules/farm/farm_season/farm_season.module
@@ -19,3 +19,44 @@ function farm_season_farm_ui_entities() {
     ),
   );
 }
+
+/**
+ * Parse a string of season names and return an array of loaded season entities. If
+ * season names do not exist, they can optionally be created.
+ *
+ * @param string $names
+ *   A comma-separated list of season names.
+ * @param bool $create
+ *   Whether or not to create seasons that don't exist. Defaults to FALSE.
+ *
+ * @return array
+ *   Returns an array of season objects. If the season names exist, they will be
+ *   loaded from the database. Otherwise, they will be created.
+ */
+function farm_season_parse_names($names, $create = FALSE) {
+
+  // Start with an empty array.
+  $seasons = array();
+
+  // Explode the value into an array and only take the first value.
+  // (Same behavior as taxonomy autocomplete widget.)
+  $values = drupal_explode_tags($names);
+
+  // If the value is empty, bail.
+  if (empty($values)) {
+    return $seasons;
+  }
+
+  // Iterate through the values and build an array of seasons.
+  foreach ($values as $value) {
+
+    // Create/load the season term.
+    $season = farm_term($value, 'farm_season', $create);
+
+    // Add to the array of seasons.
+    $seasons[] = $season;
+  }
+
+  // Return the array of seasons.
+  return $seasons;
+}


### PR DESCRIPTION
I believe allowing multiple seasons on Planting assets broke this functionality. Simple fix. I'll see if I can quickly allow multiple seasons to be added via the form too.