### PR TITLE
Display active plans on the dashboard

### DIFF
--- a/modules/farm/farm_plan/farm_plan.farm_dashboard.inc
+++ b/modules/farm/farm_plan/farm_plan.farm_dashboard.inc
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Farm dashboard hooks implemented by farm plan module.
+ */
+
+/**
+ * Implements hook_farm_dashboard_panes().
+ */
+function farm_plan_farm_dashboard_panes() {
+  return array(
+    'farm_plan_active_plans' => array(
+      'view' => 'farm_plan',
+      'view_display_id' => 'block_active_plans',
+      'group' => 'plans',
+    ),
+  );
+}

--- a/modules/farm/farm_plan/farm_plan.views_default.inc
+++ b/modules/farm/farm_plan/farm_plan.views_default.inc
@@ -163,8 +163,7 @@ function farm_plan_views_default_views() {
   $handler->display->display_options['defaults']['link_display'] = FALSE;
   $handler->display->display_options['link_display'] = 'page';
   $handler->display->display_options['defaults']['pager'] = FALSE;
-  $handler->display->display_options['pager']['type'] = 'some';
-  $handler->display->display_options['pager']['options']['items_per_page'] = '5';
+  $handler->display->display_options['pager']['type'] = 'none';
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['defaults']['fields'] = FALSE;
   /* Field: Farm plan: Farm plan ID */

--- a/modules/farm/farm_plan/farm_plan.views_default.inc
+++ b/modules/farm/farm_plan/farm_plan.views_default.inc
@@ -149,6 +149,54 @@ function farm_plan_views_default_views() {
   $handler->display->display_options['menu']['name'] = 'farm';
   $handler->display->display_options['menu']['context'] = 0;
   $handler->display->display_options['menu']['context_only_inline'] = 0;
+
+  /* Display: Block Active Plans */
+  $handler = $view->new_display('block', 'Block Active Plans', 'block_active_plans');
+  $handler->display->display_options['defaults']['title'] = FALSE;
+  $handler->display->display_options['title'] = 'Active Plans';
+  $handler->display->display_options['defaults']['use_more'] = FALSE;
+  $handler->display->display_options['use_more'] = TRUE;
+  $handler->display->display_options['defaults']['use_more_always'] = FALSE;
+  $handler->display->display_options['defaults']['use_more_always'] = FALSE;
+  $handler->display->display_options['use_more_always'] = FALSE;
+  $handler->display->display_options['defaults']['use_more_text'] = FALSE;
+  $handler->display->display_options['defaults']['link_display'] = FALSE;
+  $handler->display->display_options['link_display'] = 'page';
+  $handler->display->display_options['defaults']['pager'] = FALSE;
+  $handler->display->display_options['pager']['type'] = 'some';
+  $handler->display->display_options['pager']['options']['items_per_page'] = '5';
+  $handler->display->display_options['pager']['options']['offset'] = '0';
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Farm plan: Farm plan ID */
+  $handler->display->display_options['fields']['id']['id'] = 'id';
+  $handler->display->display_options['fields']['id']['table'] = 'farm_plan';
+  $handler->display->display_options['fields']['id']['field'] = 'id';
+  $handler->display->display_options['fields']['id']['label'] = 'Plan ID';
+  $handler->display->display_options['fields']['id']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['id']['separator'] = '';
+  /* Field: Farm plan: Name */
+  $handler->display->display_options['fields']['name']['id'] = 'name';
+  $handler->display->display_options['fields']['name']['table'] = 'farm_plan';
+  $handler->display->display_options['fields']['name']['field'] = 'name';
+  $handler->display->display_options['fields']['name']['alter']['make_link'] = TRUE;
+  $handler->display->display_options['fields']['name']['alter']['path'] = 'farm/plan/[id]';
+  /* Field: Farm plan: Farm plan type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'farm_plan';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  $handler->display->display_options['fields']['type']['label'] = 'Plan type';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Farm plan: Active */
+  $handler->display->display_options['filters']['active']['id'] = 'active';
+  $handler->display->display_options['filters']['active']['table'] = 'farm_plan';
+  $handler->display->display_options['filters']['active']['field'] = 'active';
+  $handler->display->display_options['filters']['active']['value'] = '1';
+  $handler->display->display_options['filters']['active']['group'] = 1;
+  $handler->display->display_options['filters']['active']['expose']['operator_id'] = '';
+  $handler->display->display_options['filters']['active']['expose']['label'] = 'Active';
+  $handler->display->display_options['filters']['active']['expose']['operator'] = 'active_op';
+  $handler->display->display_options['filters']['active']['expose']['identifier'] = 'active';
   $translatables['farm_plan'] = array(
     t('Master'),
     t('Plans'),
@@ -172,6 +220,8 @@ function farm_plan_views_default_views() {
     t('Plan type'),
     t('Active'),
     t('Page'),
+    t('Block Active Plans'),
+    t('Active Plans'),
   );
   $export['farm_plan'] = $view;
 

--- a/themes/farm_theme/template.php
+++ b/themes/farm_theme/template.php
@@ -513,6 +513,7 @@ function farm_theme_preprocess_page(&$vars) {
       // Move the map and metrics panes to the right column (and remove them
       // from the groups list).
       $right_panes = array(
+        'plans',
         'metrics',
       );
       foreach ($right_panes as $pane) {


### PR DESCRIPTION
This creates a simple view of the 5 most recent `active` farm plans.

I chose to only display the plan `name` and plan `type` fields in the table. I considered adding the `season` field, but not all plans have this. Also considered the `active` field but felt redundant?

The plans are sorted by the `changed` timestamp, idea being to display the most recently updated plan on top.