### PR TITLE
Update mapbox layers to use new studio style format.

### DIFF
--- a/modules/farm/farm_map/farm_map_mapbox/js/farmOS.map.behaviors.mapbox.js
+++ b/modules/farm/farm_map/farm_map_mapbox/js/farmOS.map.behaviors.mapbox.js
@@ -2,8 +2,8 @@
   farmOS.map.behaviors.mapbox = {
     attach: function (instance) {
       var key = Drupal.settings.farm_map.behaviors.mapbox.api_key;
-      this.addMapboxLayer(instance, 'Mapbox Outdoors', 'mapbox.outdoors', key);
-      this.addMapboxLayer(instance, 'Mapbox Satellite', 'mapbox.satellite', key, true);
+      this.addMapboxLayer(instance, 'Mapbox Outdoors', 'mapbox/outdoors-v11', key);
+      this.addMapboxLayer(instance, 'Mapbox Satellite', 'mapbox/satellite-v9', key, true);
     },
     addMapboxLayer: function (instance, title, tileset, key, visible = false) {
 
@@ -17,7 +17,7 @@
       // Add the layer.
       var opts = {
         title: title,
-        url: 'https://api.mapbox.com/v4/' + tileset + '/{z}/{x}/{y}.png?access_token=' + key,
+        url: 'https://api.mapbox.com/styles/v1/' + tileset + '/tiles/256/{z}/{x}/{y}?access_token=' + key,
         attribution: attribution,
         group: 'Base layers',
         base: true,


### PR DESCRIPTION
See #317. It's a simple change to use the new style format. I kept the default 256x256 `tilesize` that mapbox studio classic was using. But it seems like 512x512 might be recommended? Thoughts? From the [Static Tiles API docs](https://docs.mapbox.com/api/maps/#static-tiles):

> Default is 512x512 pixels. (512x512 image tiles are offset by one zoom level compared to 256x256 tiles from Mapbox Studio Classic styles. For example, 512x512 tiles at zoom level 4 are equivalent to Mapbox Studio Classic styles tiles at zoom level 5.) 256x256 tiles from the endpoint are one quarter of the size of 512x512 tiles. Therefore, they require 4 times as many API requests and accumulate 4 times as many map views to render the same area.

An important note from the email I received:

> Note: the Static Tiles API can return 512x512 map tiles, which cover 4x the area of the 256x256 tiles associated with Classic styles. Be sure you include the tileSize: 512 and zoomOffset: -1 options so you don't incur 4x as many tile requests as necessary and so that your labels, icons, and other map features don't appear smaller than expected. 

Note this does change from using the Mapbox Raster Tiles API to using the Static Tiles API. As per the [pricing](https://www.mapbox.com/pricing/#maps) page, this Static Tiles API **costs twice as much and has a smaller free-usage tier**. This might be a significant change... but seems like the only way to continue using the `mapbox.outdoor` layer (see mapbox [docs for OL 3.x](https://docs.mapbox.com/help/tutorials/mapbox-with-openlayers/#openlayers-3x)) But, with the larger 512x512 tiles 4x less requests would be made??