### PR TITLE
Fix deprecation warning for implode function

### DIFF
--- a/modules/farm/farm_log/farm_log.module
+++ b/modules/farm/farm_log/farm_log.module
@@ -884,7 +884,7 @@ function farm_log_entity_label_summary($entity_type, $entities, $cutoff = 3) {
   }
   $count = count($labels);
   if ($cutoff == 0 || count($labels) <= $cutoff) {
-    $output = implode($labels, ', ');
+    $output = implode(', ', $labels);
   }
   else {
     $output = $labels[0] . ' (+' . ($count - 1) . ' ' . t('more') . ')';


### PR DESCRIPTION
Parameters are passed in the incorrect order. Support for this is deprecated with PHP 7.4.0.

I did a quick search for other usages of `implode()` in farmOS core and they all look OK 👍 

From the docs:
> Note: implode() can, for historical reasons, accept its parameters in either order. For consistency with explode(), however, it is deprecated not to use the documented order of arguments.

I noticed the warning when grouping animal assets:
![Screenshot_2020-07-06 Animals farmos-dev](https://user-images.githubusercontent.com/3116995/86611355-69727e00-bf63-11ea-9143-c21128ba3346.png)
