### PR TITLE
Allow creating measurements with a value of 0

### DIFF
--- a/modules/farm/farm_quantity/farm_quantity_log/farm_quantity_log.module
+++ b/modules/farm/farm_quantity/farm_quantity_log/farm_quantity_log.module
@@ -425,7 +425,7 @@ function farm_quantity_log_add_measurements($log, $measurements) {
     }
 
     // Set the quantity value, if available.
-    if (!empty($measurement['value'])) {
+    if (isset($measurement['value'])) {
       $value_fraction = fraction_from_decimal($measurement['value']);
       $quantity_wrapper->field_farm_quantity_value->numerator->set($value_fraction->getNumerator());
       $quantity_wrapper->field_farm_quantity_value->denominator->set($value_fraction->getDenominator());


### PR DESCRIPTION
When creating quantities via `farm_quantity_log_add_measurements` if the measurement value is `0`, the value is not included. Changing the check within that function from `!empty()` to `isset()` should fix this.