### PR TITLE
Use hook_sensor_view to add graphs to listener sensor asset views

### DIFF
--- a/modules/farm/farm_sensor/farm_sensor.module
+++ b/modules/farm/farm_sensor/farm_sensor.module
@@ -186,7 +186,7 @@ function farm_sensor_entity_view_alter(&$build, $type) {
 
   // Merge the asset view content into the build array.
   if (!empty($module_content)) {
-    $build = array_merge($build, $module_content);
+    $build = array_merge_recursive($build, $module_content);
   }
 }
 

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -656,28 +656,16 @@ function farm_sensor_listener_farm_ui_entity_views($entity_type, $bundle, $entit
 }
 
 /**
- * Implements hook_entity_view_alter().
+ * Implements hook_farm_sensor_view.
  */
-function farm_sensor_listener_entity_view_alter(&$build, $type) {
+function farm_sensor_listener_farm_sensor_view($asset) {
 
-  /*
-   * Alter sensor asset page to display graph(s).
-   */
-
-  // If it's not a farm_asset, bail.
-  if ($type != 'farm_asset') {
-    return;
-  }
-
-  // If the entity information isn't available, bail.
-  if (empty($build['#entity'])) {
-    return;
-  }
-  $asset = $build['#entity'];
+  // Start build array.
+  $build = array();
 
   // If the sensor is not a listener, bail.
   if (empty($asset->sensor_type) || $asset->sensor_type != 'listener') {
-    return;
+    return array();
   }
 
   // Query all the distinct value names this sensor has stored.
@@ -718,4 +706,7 @@ function farm_sensor_listener_entity_view_alter(&$build, $type) {
     '#markup' => '<div class="farm-sensor-graphs clearfix">' . implode('', $markup) . '</div>',
     '#weight' => -1,
   );
+
+  // Return build array.
+  return $build;
 }


### PR DESCRIPTION
I noticed there was a `hook_sensor_view` provided by `farm_sensor`. A simple change to simplify how `farm_sensor_listener` adds graphs to sensor asset pages. This required doing a recursive merge on the build arrays returned from `hook_sensor_views`, but that shouldn't change any current implementations (if any?)