### PR TITLE
Expose sensor_type and sensor_settings fields to sensor assets REST API

### DIFF
--- a/drupal-org.make
+++ b/drupal-org.make
@@ -118,6 +118,8 @@ projects[restws][patch][] = "http://www.drupal.org/files/issues/2019-06-17/restw
 projects[restws][patch][] = "http://www.drupal.org/files/issues/2020-03-29/restws-auth-check-2490416-12.patch"
 ; Fix Issue #2301237: Allow creating nodes with multi-value fields
 projects[restws][patch][] = "https://www.drupal.org/files/issues/2020-05-31/2301237-34.patch"
+; Fix Issue #3161113: Support fields with unknown data type.
+projects[restws][patch][] = "http://www.drupal.org/files/issues/2020-07-23/3161113-6.patch"
 
 projects[restws_field_collection][subdir] = "contrib"
 projects[restws_field_collection][version] = "1.1"

--- a/modules/farm/farm_sensor/farm_sensor.module
+++ b/modules/farm/farm_sensor/farm_sensor.module
@@ -34,6 +34,28 @@ function farm_sensor_farm_ui_entity_view_groups() {
 }
 
 /**
+ * Implements hook_entity_property_info_alter().
+ */
+function farm_sensor_entity_property_info_alter(&$info) {
+
+  // Add a sensor type property to sensor assets.
+  $info['farm_asset']['bundles']['sensor']['properties']['sensor_type'] = array(
+    'type' => 'text',
+    'label' => t('Sensor Type'),
+    'description' => t('The type of sensor.'),
+    'setter callback' => 'entity_property_verbatim_set',
+  );
+
+  // Add a sensor settings property to sensor assets.
+  $info['farm_asset']['bundles']['sensor']['properties']['sensor_settings'] = array(
+    'type' => 'unknown',
+    'label' => t('Sensor Settings'),
+    'description' => t('Settings for this sensor.'),
+    'setter callback' => 'entity_property_verbatim_set',
+  );
+}
+
+/**
  * Implements hook_entity_load().
  */
 function farm_sensor_entity_load($entities, $type) {


### PR DESCRIPTION
Exposes both the `sensor_type` and `sensor_settings` fields to `sensor` assets over the API. These fields are returned via the API, but they can also be created and updated.

This adds support for a few major use cases:
- Any "custom" values saved in `sensor_settings` for any Sensor type can be accessed via the API.
- The `public_key` and `private_key` saved in the `sensor_settings` of `listener` sensors can be accessed via the API.
- Any sensor asset can be created _and be configured with custom settings_ via the API