### PR TITLE
Make plotly graphs responsive to page size.

### DIFF
--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.js
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.js
@@ -37,10 +37,13 @@
           xaxis: { title: 'date' },
           yaxis: { title: name }
         };
+        var config = {
+          responsive: true
+        };
 
         // Draw the graph to the element.
         element = document.getElementById(id);
-        Plotly.newPlot(element, graph_data, layout);
+        Plotly.newPlot(element, graph_data, layout, config);
       }
     }
   };


### PR DESCRIPTION
Simple change to make the plotly graphs provided by `farm_sensor_listener` responsive to the page size. Currently graphs will overlap in almost the entire range of the bootstrap "medium" window size. The graphs break into full width at the "small" window size.

I should note that graphs don't resize super fluidly while changing the window size, but I think this is OK. It also depends on the number of graphs & data points being graphed.

Plotly responsive example: https://plotly.com/javascript/responsive-fluid-layout/

See before and after photos below: