### PR TITLE
Enable the snapping grid controls when farmOS-map is used for editing

### DIFF
--- a/modules/farm/farm_map/js/farmOS.map.behaviors.wkt.js
+++ b/modules/farm/farm_map/js/farmOS.map.behaviors.wkt.js
@@ -25,6 +25,7 @@
           instance.addBehavior('edit');
           var layer = instance.edit.layer;
         }
+        instance.addBehavior('snappingGrid');
       }
 
       // Enable the line/polygon measure behavior.

--- a/modules/farm/farm_movement/js/farmOS.map.behaviors.move.js
+++ b/modules/farm/farm_movement/js/farmOS.map.behaviors.move.js
@@ -19,11 +19,7 @@
       };
       this.movementLayer = this.instance.addLayer('vector', opts);
 
-      // Make the layer editable.
-      this.instance.addBehavior('edit', { layer: this.movementLayer });
-
-      // Add measure behavior.
-      this.instance.addBehavior('measure', { layer: this.movementLayer});
+      this.addEditBehaviors();
     },
 
     // Update the assets current location map layer.
@@ -73,11 +69,7 @@
       };
       this.movementLayer = this.instance.addLayer('wkt', opts);
 
-      // Make the layer editable.
-      this.instance.addBehavior('edit', { layer: this.movementLayer });
-
-      // Add measure behavior.
-      this.instance.addBehavior('measure', { layer: this.movementLayer});
+      this.addEditBehaviors();
 
       // Zoom to all vector layers.
       this.instance.zoomToVectors();
@@ -92,6 +84,18 @@
       this.instance.edit.wktOn('featurechange', function(wkt) {
         $('#' + target).parent().find('textarea').val(wkt);
       });
+    },
+
+    // Adds behaviors for editing movements
+    addEditBehaviors() {
+      // Make the layer editable.
+      this.instance.addBehavior('edit', { layer: this.movementLayer });
+
+      // Add the snappingGrid behavior.
+      this.instance.addBehavior('snappingGrid');
+
+      // Add measure behavior.
+      this.instance.addBehavior('measure', { layer: this.movementLayer});
     },
 
     // Make sure this runs after farmOS.map.behaviors.wkt.


### PR DESCRIPTION
Prerequisite: This must be checked in after the farmOS-map version is
updated to include the SnappingGrid implementation.

Testing: Tested against the latest farmos/farmos:dev docker image
with these modified files and the latest build artifact from farmOS-map
as volumes;

```
version: '2'
services:

  ...

  www:
    depends_on:
      - db
    image: farmos/farmos:dev
    volumes:
      - './www:/var/www/html'
      - './farmOS-map.js:/var/www/html/profiles/farm/libraries/farmOS-map/farmOS-map.js'
      - './farmOS.map.behaviors.wkt.js:/var/www/html/profiles/farm/modules/farm/farm_map/js/farmOS.map.behaviors.wkt.js'
      - './farmOS.map.behaviors.move.js:/var/www/html/profiles/farm/modules/farm/farm_movement/js/farmOS.map.behaviors.move.js'
    expose:
      - '80'
```