### PR TITLE
Filter listener sensor graphs by value and date range.

### DIFF
--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -432,7 +432,10 @@ function farm_sensor_listener_data($id, $name = '', $start = NULL, $end = NULL, 
   $query->orderBy('fsd.timestamp', 'DESC');
 
   // Limit the results.
-  $query->range($offset, $limit);
+  // Don't apply a range if both offset and limit are NULL.
+  if (!empty($offset) && !empty($limit)) {
+    $query->range($offset, $limit);
+  }
 
   // Run the query.
   $result = $query->execute();

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -695,11 +695,24 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
   $graphs = array();
   foreach ($filters['values'] as $name) {
     $id = drupal_html_id('sensor-data-' . $name);
+
+    // Load data.
+    $data = farm_sensor_listener_data($asset->id, $name, strtotime($filters['start_date']), strtotime($filters['end_date']), NULL, NULL);
+
+    // Don't render a graph if there is no data to display.
+    if (empty($data)) {
+      $markup[] = '<div class="farm-sensor-graph alert alert-warning"><p>' . t('No data for "@value" in this date range.', array('@value' => $name)) . '</p></div>';
+      continue;
+    }
+
+    // Build graph markup.
     $markup[] = '<div id="' . $id . '" class="farm-sensor-graph"></div>';
+
+    // Build graph settings.
     $graph = array(
       'name' => $name,
       'id' => $id,
-      'data' => farm_sensor_listener_data($asset->id, $name, strtotime($filters['start_date']), strtotime($filters['end_date']), NULL, NULL),
+      'data' => $data,
     );
     $graphs[] = $graph;
   }

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -464,6 +464,49 @@ function farm_sensor_listener_data($id, $name = '', $start = NULL, $end = NULL, 
 }
 
 /**
+ * Fetch distinct info for sensor values from the database.
+ *
+ * @param $id
+ *  The sensor asset id.
+ *
+ * @return array
+ *  Returns an array of info for each distinct value keyed by value name.
+ *    'first': timestamp of data first recorded for this value on the sensor.
+ *    'last': timestamp of data last recorded for this value on the sensor.
+ */
+function farm_sensor_listener_values($id) {
+
+  // Build array of values.
+  $values = array();
+
+  // Query all the distinct value names this sensor has stored.
+  $query = db_select('farm_sensor_data')
+    ->fields('farm_sensor_data', array('name'))
+    ->condition('farm_sensor_data.id', $id)
+    ->groupBy('farm_sensor_data.name');
+
+  // Select the max timestamp for each value name.
+  $query->addExpression('MAX(farm_sensor_data.timestamp)', 'last');
+
+  // Select the min timestamp for each value name.
+  $query->addExpression('MIN(farm_sensor_data.timestamp)', 'first');
+
+  // Execute query.
+  $result = $query->execute();
+
+  // Add each value's info keyed by value name.
+  foreach ($result as $row) {
+    $values[$row->name] = array(
+      'first' => $row->first,
+      'last' => $row->last,
+    );
+  }
+
+  // Return values.
+  return $values;
+}
+
+/**
  * Implements hook_farm_sensor_type_info().
  */
 function farm_sensor_listener_farm_sensor_type_info() {
@@ -634,12 +677,11 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
     '#collapsed' => TRUE,
   );
 
-  // Query all the distinct value names this sensor has stored.
-  $names = array();
-  $result = db_query('SELECT name FROM {farm_sensor_data} WHERE id = :id GROUP BY name', array(':id' => $asset->id));
-  foreach ($result as $row) {
-    $names[] = $row->name;
-  }
+  // Load distinct sensor value info.
+  $values = farm_sensor_listener_values($asset->id);
+
+  // Load the distinct value names this sensor has stored.
+  $names = array_keys($values);
 
   // Sensor values to display.
   // Default to all distinct values the sensor has stored.

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -609,6 +609,129 @@ function farm_sensor_listener_settings_form($sensor, $settings = array()) {
 }
 
 /**
+ * Farm Sensor Listener Data Graphs Form.
+ */
+function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
+
+  // Bail if not a sensor asset.
+  if ($asset->type != 'sensor') {
+    return array();
+  }
+
+  // Fieldset to display sensor data.
+  $form['data'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Sensor Graphs'),
+    '#collapsible' => TRUE,
+    '#collapsed' => FALSE,
+  );
+
+  // Fieldset for query filters.
+  $form['data']['filters'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Filters'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  // Query all the distinct value names this sensor has stored.
+  $names = array();
+  $result = db_query('SELECT name FROM {farm_sensor_data} WHERE id = :id GROUP BY name', array(':id' => $asset->id));
+  foreach ($result as $row) {
+    $names[] = $row->name;
+  }
+
+  // Sensor values to display.
+  // Default to all distinct values the sensor has stored.
+  $form['data']['filters']['values'] = array(
+    '#type' => 'select',
+    '#title' => t('Sensor Values'),
+    '#options' => drupal_map_assoc($names),
+    '#multiple' => TRUE,
+    '#default_value' => $names,
+  );
+
+  // Provide a default date in the format YYYY-MM-DD.
+  $format = 'Y-m-d';
+  $current_date = date($format, REQUEST_TIME);
+
+  // Start date. Defaults to 1 week ago.
+  $past_week_date = date($format, strtotime('- 7 days', REQUEST_TIME));
+  $form['data']['filters']['start_date'] = array(
+    '#type' => 'date_select',
+    '#title' => t('Start date'),
+    '#default_value' => $past_week_date,
+    '#date_year_range' => '-10:+1',
+    '#date_format' => $format,
+    '#date_label_position' => 'within',
+  );
+
+  // End date. Defaults to current time.
+  $form['data']['filters']['end_date'] = array(
+    '#type' => 'date_select',
+    '#title' => t('End date'),
+    '#default_value' => $current_date,
+    '#date_year_range' => '-10:+1',
+    '#date_format' => $format,
+    '#date_label_position' => 'within',
+  );
+
+  // Submit button.
+  $form['data']['filters']['submit'] = array(
+    '#type' => 'submit',
+    '#value' => t('Submit'),
+  );
+
+  // Load filter values from form state or form field #default_value.
+  $filters = array(
+    'values' => isset($form_state['values']['values']) ? $form_state['values']['values'] : $form['data']['filters']['values']['#default_value'],
+    'start_date' => isset($form_state['values']['start_date']) ? $form_state['values']['start_date'] : $form['data']['filters']['start_date']['#default_value'],
+    'end_date' => isset($form_state['values']['end_date']) ? $form_state['values']['end_date'] : $form['data']['filters']['end_date']['#default_value'],
+  );
+
+  // Iterate through the names, load the data values for each,
+  // generate markup DIV ids, and store it all in JS settings.
+  $markup = array();
+  $graphs = array();
+  foreach ($filters['values'] as $name) {
+    $id = drupal_html_id('sensor-data-' . $name);
+    $markup[] = '<div id="' . $id . '" class="farm-sensor-graph"></div>';
+    $graph = array(
+      'name' => $name,
+      'id' => $id,
+      'data' => farm_sensor_listener_data($asset->id, $name, strtotime($filters['start_date']), strtotime($filters['end_date']), NULL, NULL),
+    );
+    $graphs[] = $graph;
+  }
+
+  // Add Javascript and CSS to build the graphs.
+  $settings = array(
+    'farm_sensor_listener' => array(
+      'graphs' => $graphs,
+    ),
+  );
+  drupal_add_js($settings, 'setting');
+  drupal_add_js(drupal_get_path('module', 'farm_sensor_listener') . '/farm_sensor_listener.js');
+  drupal_add_js('https://cdn.plot.ly/plotly-latest.min.js', 'external');
+  drupal_add_css(drupal_get_path('module', 'farm_sensor_listener') . '/farm_sensor_listener.css');
+
+  // Output graphs.
+  $form['data']['graphs'] = array(
+    '#markup' => '<div class="farm-sensor-graphs clearfix">' . implode('', $markup) . '</div>',
+  );
+
+  return $form;
+}
+
+/**
+ * Submit callback for farm_sensor_listener_data_form_submit.
+ */
+function farm_sensor_listener_data_graphs_form_submit($form, &$form_state) {
+  // Rebuild the form in order to keep filter values.
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
  * Helper function for loading a sensor asset from it's public/private key.
  *
  * @param $key
@@ -671,44 +794,8 @@ function farm_sensor_listener_farm_sensor_view($asset) {
     return array();
   }
 
-  // Query all the distinct value names this sensor has stored.
-  $names = array();
-  $result = db_query('SELECT name FROM {farm_sensor_data} WHERE id = :id GROUP BY name', array(':id' => $asset->id));
-  foreach ($result as $row) {
-    $names[] = $row->name;
-  }
-
-  // Iterate through the names, load the most recent 100 values for each,
-  // generate markup DIV ids, and store it all in JS settings.
-  $markup = array();
-  $graphs = array();
-  foreach ($names as $name) {
-    $id = drupal_html_id('sensor-data-' . $name);
-    $markup[] = '<div id="' . $id . '" class="farm-sensor-graph"></div>';
-    $graph = array(
-      'name' => $name,
-      'id' => $id,
-      'data' => farm_sensor_listener_data($asset->id, $name, NULL, NULL,100),
-    );
-    $graphs[] = $graph;
-  }
-
-  // Add Javascript and CSS to build the graphs.
-  $settings = array(
-    'farm_sensor_listener' => array(
-      'graphs' => $graphs,
-    ),
-  );
-  drupal_add_js($settings, 'setting');
-  drupal_add_js(drupal_get_path('module', 'farm_sensor_listener') . '/farm_sensor_listener.js');
-  drupal_add_js('https://cdn.plot.ly/plotly-latest.min.js', 'external');
-  drupal_add_css(drupal_get_path('module', 'farm_sensor_listener') . '/farm_sensor_listener.css');
-
-  // Output the markup.
-  $build['views']['graph'] = array(
-    '#markup' => '<div class="farm-sensor-graphs clearfix">' . implode('', $markup) . '</div>',
-    '#weight' => -1,
-  );
+  // Load the sensor data graph form.
+  $build['views']['data'] = drupal_get_form('farm_sensor_listener_data_graphs_form', $asset);
 
   // Return build array.
   return $build;

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -156,8 +156,10 @@ function farm_sensor_listener_page_callback($public_key) {
      */
     drupal_add_http_header('Access-Control-Allow-Origin', '*');
 
-    // If value summary info is requested, output it and return success.
-    if (!empty($params['summary'])) {
+    // If the path includes "/summary" after the public key, output value
+    // summary info and return success.
+    $args = func_get_args();
+    if (!empty($args[1]) && $args[1] == 'summary') {
       $data = farm_sensor_listener_values_info($sensor->id);
       drupal_json_output($data);
       return MENU_FOUND;

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -11,6 +11,16 @@ include_once 'farm_sensor_listener.features.inc';
  */
 function farm_sensor_listener_menu() {
   $items = array();
+
+  // Callback for returning a list of sensor value info.
+  $items['farm/sensor/listener/values/%'] = array(
+    'page callback' => 'farm_sensor_listener_values_page_callback',
+    'page arguments' => array(4),
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  // Callback for returning data.
   $items['farm/sensor/listener/%'] = array(
     'page callback' => 'farm_sensor_listener_page_callback',
     'page arguments' => array(3),
@@ -76,6 +86,63 @@ function farm_sensor_listener_mail($key, &$message, $params) {
     $entity_label = htmlspecialchars(entity_label('farm_asset', $params['sensor']));
     $message['body'][] = $entity_label . ': ' . url($uri['path'], array('absolute' => TRUE));
   }
+}
+
+/**
+ * Callback function for returning listener sensor value names via API requests.
+ *
+ * @param $public_key
+ *   The public key of the sensor that is pushing the data.
+ *
+ * The private key should be provided as a URL query string.
+ *
+ * Use HTTPS to encrypt data in transit.
+ *
+ * @return int
+ *   Returns MENU_FOUND or MENU_NOT_FOUND.
+ */
+function farm_sensor_listener_values_page_callback($public_key) {
+
+  // Load the private key from the URL query string.
+  $params = drupal_get_query_parameters();
+
+  // Look up the sensor by it's public key.
+  $sensor = farm_sensor_listener_load($public_key);
+
+  // If no asset was found, bail.
+  if (empty($sensor)) {
+    return MENU_NOT_FOUND;
+  }
+
+  // Bail if not a GET request.
+  if ($_SERVER['REQUEST_METHOD'] != 'GET') {
+    return MENU_ACCESS_DENIED;
+  }
+
+  // If the sensor allows public API read access, proceed.
+  // Otherwise check the private key.
+  if (empty($sensor->sensor_settings['public_api'])) {
+    if (empty($params['private_key']) || $params['private_key'] != $sensor->sensor_settings['private_key']) {
+      return MENU_ACCESS_DENIED;
+    }
+  }
+
+  // Add 'Access-Control-Allow-Origin' header to allow pulling this data into
+  // other domains.
+  /**
+   * @todo
+   * Move this to a more official place, or adopt the CORS module in farmOS.
+   */
+  drupal_add_http_header('Access-Control-Allow-Origin', '*');
+
+  // Get values from the sensor.
+  $data = farm_sensor_listener_values($sensor->id);
+
+  // Return the values as JSON.
+  drupal_json_output($data);
+
+  // Return success.
+  return MENU_FOUND;
 }
 
 /**

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -221,6 +221,13 @@ function farm_sensor_listener_page_callback($public_key) {
      */
     drupal_add_http_header('Access-Control-Allow-Origin', '*');
 
+    // If value summary info is requested, output it and return success.
+    if (!empty($params['summary'])) {
+      $data = farm_sensor_listener_values_info($sensor->id);
+      drupal_json_output($data);
+      return MENU_FOUND;
+    }
+
     // If the 'name' parameter is set, filter by name.
     $name = '';
     if (!empty($params['name'])) {

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -466,9 +466,10 @@ function farm_sensor_listener_process_notifications($sensor, $data_name, $value)
  * @param $end
  *   Filter data to timestamps less than or equal to this end timestamp.
  * @param $limit
- *   The number of results to return.
+ *   The number of results to return. Defaults to 1. If this is 0, no limit will
+ *   be applied.
  * @param $offset
- *   The value to start at.
+ *   The value to start at, used in combination with $limit.
  *
  * @return array
  *   Returns an array of data.
@@ -498,9 +499,8 @@ function farm_sensor_listener_data($id, $name = '', $start = NULL, $end = NULL, 
   // Order by timestamp descending.
   $query->orderBy('fsd.timestamp', 'DESC');
 
-  // Limit the results.
-  // Don't apply a range if both offset and limit are NULL.
-  if (!empty($offset) && !empty($limit)) {
+  // Limit the results, if $limit is not empty.
+  if (!empty($limit)) {
     $query->range($offset, $limit);
   }
 
@@ -816,7 +816,7 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
     $id = drupal_html_id('sensor-data-' . $name);
 
     // Load data.
-    $data = farm_sensor_listener_data($asset->id, $name, strtotime($filters['start_date']), strtotime($filters['end_date']), NULL, NULL);
+    $data = farm_sensor_listener_data($asset->id, $name, strtotime($filters['start_date']), strtotime($filters['end_date']), 0);
 
     // Don't render a graph if there is no data to display.
     if (empty($data)) {

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -753,7 +753,7 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
 
     // Don't render a graph if there is no data to display.
     if (empty($data)) {
-      $markup[] = '<div class="farm-sensor-graph alert alert-warning"><p>' . t('No data for "@value" in this date range.', array('@value' => $name)) . '</p></div>';
+      $markup[] = '<div class="farm-sensor-graph"><p>' . t('No data for "@value" in this date range.', array('@value' => $name)) . '</p></div>';
       continue;
     }
 

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -12,14 +12,6 @@ include_once 'farm_sensor_listener.features.inc';
 function farm_sensor_listener_menu() {
   $items = array();
 
-  // Callback for returning a list of sensor value info.
-  $items['farm/sensor/listener/values/%'] = array(
-    'page callback' => 'farm_sensor_listener_values_page_callback',
-    'page arguments' => array(4),
-    'access callback' => TRUE,
-    'type' => MENU_CALLBACK,
-  );
-
   // Callback for returning data.
   $items['farm/sensor/listener/%'] = array(
     'page callback' => 'farm_sensor_listener_page_callback',
@@ -86,63 +78,6 @@ function farm_sensor_listener_mail($key, &$message, $params) {
     $entity_label = htmlspecialchars(entity_label('farm_asset', $params['sensor']));
     $message['body'][] = $entity_label . ': ' . url($uri['path'], array('absolute' => TRUE));
   }
-}
-
-/**
- * Callback function for returning listener sensor value names via API requests.
- *
- * @param $public_key
- *   The public key of the sensor that is pushing the data.
- *
- * The private key should be provided as a URL query string.
- *
- * Use HTTPS to encrypt data in transit.
- *
- * @return int
- *   Returns MENU_FOUND or MENU_NOT_FOUND.
- */
-function farm_sensor_listener_values_page_callback($public_key) {
-
-  // Load the private key from the URL query string.
-  $params = drupal_get_query_parameters();
-
-  // Look up the sensor by it's public key.
-  $sensor = farm_sensor_listener_load($public_key);
-
-  // If no asset was found, bail.
-  if (empty($sensor)) {
-    return MENU_NOT_FOUND;
-  }
-
-  // Bail if not a GET request.
-  if ($_SERVER['REQUEST_METHOD'] != 'GET') {
-    return MENU_ACCESS_DENIED;
-  }
-
-  // If the sensor allows public API read access, proceed.
-  // Otherwise check the private key.
-  if (empty($sensor->sensor_settings['public_api'])) {
-    if (empty($params['private_key']) || $params['private_key'] != $sensor->sensor_settings['private_key']) {
-      return MENU_ACCESS_DENIED;
-    }
-  }
-
-  // Add 'Access-Control-Allow-Origin' header to allow pulling this data into
-  // other domains.
-  /**
-   * @todo
-   * Move this to a more official place, or adopt the CORS module in farmOS.
-   */
-  drupal_add_http_header('Access-Control-Allow-Origin', '*');
-
-  // Get values summary info from the sensor.
-  $data = farm_sensor_listener_values_info($sensor->id);
-
-  // Return the values as JSON.
-  drupal_json_output($data);
-
-  // Return success.
-  return MENU_FOUND;
 }
 
 /**

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -694,6 +694,11 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
   // Load distinct sensor value info.
   $values = farm_sensor_listener_values_info($asset->id);
 
+  // Don't display the graph fieldset if the sensor has no data.
+  if (empty($values)) {
+    return array();
+  }
+
   // Load the distinct value names this sensor has stored.
   $names = array_keys($values);
 

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -712,8 +712,8 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
     '#default_value' => $names,
   );
 
-  // Provide a default date in the format YYYY-MM-DD.
-  $format = 'Y-m-d';
+  // Provide a default date in the format YYYY-MM-DD HH-MM-SS.
+  $format = 'Y-m-d H:i:s';
 
   // Get the latest timestamp data from saved data
   // or default to current time.

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -159,7 +159,7 @@ function farm_sensor_listener_page_callback($public_key) {
     // If the path includes "/summary" after the public key, output value
     // summary info and return success.
     $args = func_get_args();
-    if (!empty($args[1]) && $args[1] == 'summary') {
+    if (isset($args[1]) && $args[1] == 'summary') {
       $data = farm_sensor_listener_values_info($sensor->id);
       drupal_json_output($data);
       return MENU_FOUND;
@@ -167,31 +167,31 @@ function farm_sensor_listener_page_callback($public_key) {
 
     // If the 'name' parameter is set, filter by name.
     $name = '';
-    if (!empty($params['name'])) {
+    if (isset($params['name'])) {
       $name = $params['name'];
     }
 
     // If the 'start' parameter is set, limit results to timestamps after it.
     $start = NULL;
-    if (!empty($params['start'])) {
+    if (isset($params['start'])) {
       $start = $params['start'];
     }
 
     // If the 'end' parameter is set, limit to results before it.
     $end = NULL;
-    if (!empty($params['end'])) {
+    if (isset($params['end'])) {
       $end = $params['end'];
     }
 
     // If the 'limit' parameter is set, limit the number of results.
     $limit = 1;
-    if (!is_null($params['limit'])) {
+    if (isset($params['limit'])) {
       $limit = $params['limit'];
     }
 
     // If the 'offset' parameter is set, offset the results.
     $offset = 0;
-    if (!empty($params['offset'])) {
+    if (isset($params['offset'])) {
       $offset = $params['offset'];
     }
 

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -135,8 +135,8 @@ function farm_sensor_listener_values_page_callback($public_key) {
    */
   drupal_add_http_header('Access-Control-Allow-Origin', '*');
 
-  // Get values from the sensor.
-  $data = farm_sensor_listener_values($sensor->id);
+  // Get values summary info from the sensor.
+  $data = farm_sensor_listener_values_info($sensor->id);
 
   // Return the values as JSON.
   drupal_json_output($data);
@@ -534,7 +534,7 @@ function farm_sensor_listener_data($id, $name = '', $start = NULL, $end = NULL, 
 }
 
 /**
- * Fetch distinct info for sensor values from the database.
+ * Fetch summary info about sensor values from the database.
  *
  * @param $id
  *  The sensor asset id.
@@ -544,7 +544,7 @@ function farm_sensor_listener_data($id, $name = '', $start = NULL, $end = NULL, 
  *    'first': timestamp of data first recorded for this value on the sensor.
  *    'last': timestamp of data last recorded for this value on the sensor.
  */
-function farm_sensor_listener_values($id) {
+function farm_sensor_listener_values_info($id) {
 
   // Build array of values.
   $values = array();
@@ -748,7 +748,7 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
   );
 
   // Load distinct sensor value info.
-  $values = farm_sensor_listener_values($asset->id);
+  $values = farm_sensor_listener_values_info($asset->id);
 
   // Load the distinct value names this sensor has stored.
   $names = array_keys($values);

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -512,6 +512,9 @@ function farm_sensor_listener_values_info($id) {
     ->condition('farm_sensor_data.id', $id)
     ->groupBy('farm_sensor_data.name');
 
+  // Select the total record count for each value name.
+  $query->addExpression('COUNT(farm_sensor_data.timestamp)', 'count');
+
   // Select the max timestamp for each value name.
   $query->addExpression('MAX(farm_sensor_data.timestamp)', 'last');
 
@@ -524,6 +527,7 @@ function farm_sensor_listener_values_info($id) {
   // Add each value's info keyed by value name.
   foreach ($result as $row) {
     $values[$row->name] = array(
+      'count' => $row->count,
       'first' => $row->first,
       'last' => $row->last,
     );

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -187,6 +187,19 @@ function farm_sensor_listener_page_callback($public_key) {
     $limit = 1;
     if (isset($params['limit'])) {
       $limit = $params['limit'];
+
+      // On second thought... only allow 100k max data points. Otherwise, it's
+      // possible to exhaust PHP's memory, which is a potential DDoS vector.
+      // If the requested limit is 0, set it to the max automatically.
+      // If more than the max is specified, return a 422 error code.
+      $max = 100000;
+      if ($limit == 0) {
+        $limit = $max;
+      }
+      elseif ($limit > $max) {
+        drupal_add_http_header('Status', '422 Unprocessable Entity: exceeds max limit of ' . $max);
+        return MENU_FOUND;
+      }
     }
 
     // If the 'offset' parameter is set, offset the results.

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -695,10 +695,20 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
 
   // Provide a default date in the format YYYY-MM-DD.
   $format = 'Y-m-d';
-  $current_date = date($format, REQUEST_TIME);
 
-  // Start date. Defaults to 1 week ago.
-  $past_week_date = date($format, strtotime('- 7 days', REQUEST_TIME));
+  // Get the latest timestamp data from saved data
+  // or default to current time.
+  $latest = REQUEST_TIME;
+  if (!empty($values)) {
+    $latest = max(array_column($values, 'last'));
+  }
+
+  // Build latest date.
+  $latest_date = date($format, $latest);
+
+  // Start date. Defaults to 1 week before latest date..
+  $past_week_date = date($format, strtotime('- 7 days', $latest));
+
   $form['data']['filters']['start_date'] = array(
     '#type' => 'date_select',
     '#title' => t('Start date'),
@@ -712,7 +722,7 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
   $form['data']['filters']['end_date'] = array(
     '#type' => 'date_select',
     '#title' => t('End date'),
-    '#default_value' => $current_date,
+    '#default_value' => $latest_date,
     '#date_year_range' => '-10:+1',
     '#date_format' => $format,
     '#date_label_position' => 'within',

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -185,7 +185,7 @@ function farm_sensor_listener_page_callback($public_key) {
 
     // If the 'limit' parameter is set, limit the number of results.
     $limit = 1;
-    if (!empty($params['limit'])) {
+    if (!is_null($params['limit'])) {
       $limit = $params['limit'];
     }
 

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -172,7 +172,7 @@ function farm_sensor_listener_values_page_callback($public_key) {
  *   the database, for accurate precision.
  *
  * @return int
- *   Returns MENU_FOUND or MENU_NOT_FOUND.
+ *   Returns MENU_FOUND, MENU_ACCESS_DENIED, or MENU_NOT_FOUND.
  */
 function farm_sensor_listener_page_callback($public_key) {
 
@@ -256,6 +256,9 @@ function farm_sensor_listener_page_callback($public_key) {
 
     // Return the latest readings as JSON.
     drupal_json_output($data);
+
+    // Return success.
+    return MENU_FOUND;
   }
 
   // Return success and do nothing on all other request types.

--- a/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
+++ b/modules/farm/farm_sensor/farm_sensor_listener/farm_sensor_listener.module
@@ -664,7 +664,7 @@ function farm_sensor_listener_data_graphs_form($form, &$form_state, $asset) {
   // Fieldset to display sensor data.
   $form['data'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Sensor Graphs'),
+    '#title' => t('Sensor graphs'),
     '#collapsible' => TRUE,
     '#collapsed' => FALSE,
   );


### PR DESCRIPTION
This adds a `farm_sensor_listener_data_graphs_form` which renders graphs of sensor data with a fieldset of filters for value and date range. This is only a minor step towards a solution for #227, but seems likely that this is the most we will accomplish in farmOS 1.x. While there is greater support for graphing data with views in D8, it would be quite a bit of work to get it working in D7.

I chose to make the graphs load a default date range (the past 7 days) rather than a default `limit` of 100 data points. Overall this seems more intuitive for users. The downside is that sensors which have not posted data within the past week, but have older values, will not display graphs of data by default. Open to ideas on this! Perhaps we could add a fallback condition to display the past X data points if the date range fails? Also, because this is a form, I believe that those loading the form could pre-load the form state with default filter values too.

To make the date range work I had to make a change to the `farm_sensor_listener_data` helper function to allow disabling the `limit` (see notes on this commit: https://github.com/farmOS/farmOS/commit/1d95005f156557bd85034585b41b312bc26e62eb). This seems to be the best solution that doesn't require changing the function's default values which might affect other current uses (especially those returning data via API).

