### PR TITLE
Include sensor type column in sensor asset view

### DIFF
--- a/modules/farm/farm_sensor/farm_sensor.views.inc
+++ b/modules/farm/farm_sensor/farm_sensor.views.inc
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @file
+ * Farm Sensor Views data.
+ */
+
+/**
+ * Implements hook_views_data().
+ */
+function farm_sensor_views_data() {
+
+  // Describe the {farm_sensor} table to Views.
+  $data['farm_sensor']['table']['group'] = t('Sensor');
+
+  // Create an implicit relationship to the farm_asset table, so that when the
+  // base table is farm_asset, sensor fields are automatically available.
+  $data['farm_sensor']['table']['join'] = array(
+    'farm_asset' => array(
+      'left_field' => 'id',
+      'field' => 'id',
+    ),
+  );
+
+  // Sensor reading name.
+  $data['farm_sensor']['type'] = array(
+    'title' => t('Sensor type'),
+    'help' => t('Type of sensor.'),
+    'field' => array(
+      'handler' => 'views_handler_field',
+      'click sortable' => TRUE,
+    ),
+    'sort' => array(
+      'handler' => 'views_handler_sort',
+    ),
+    'filter' => array(
+      'handler' => 'views_handler_filter_string',
+    ),
+    'argument' => array(
+      'handler' => 'views_handler_argument_string',
+    ),
+  );
+
+  return $data;
+}

--- a/modules/farm/farm_sensor/farm_sensor.views_default.inc
+++ b/modules/farm/farm_sensor/farm_sensor.views_default.inc
@@ -42,6 +42,7 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['style_options']['columns'] = array(
     'views_bulk_operations' => 'views_bulk_operations',
     'id' => 'id',
+    'type' => 'type',
     'name' => 'name',
     'field_farm_description' => 'field_farm_description',
     'field_farm_flags' => 'field_farm_flags',
@@ -60,6 +61,13 @@ function farm_sensor_views_default_views() {
     'id' => array(
       'sortable' => 1,
       'default_sort_order' => 'desc',
+      'align' => '',
+      'separator' => '',
+      'empty_column' => 0,
+    ),
+    'type' => array(
+      'sortable' => 1,
+      'default_sort_order' => 'asc',
       'align' => '',
       'separator' => '',
       'empty_column' => 0,

--- a/modules/farm/farm_sensor/farm_sensor.views_default.inc
+++ b/modules/farm/farm_sensor/farm_sensor.views_default.inc
@@ -348,9 +348,6 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['filters']['type_1']['expose']['label'] = 'Sensor Type';
   $handler->display->display_options['filters']['type_1']['expose']['operator'] = 'type_1_op';
   $handler->display->display_options['filters']['type_1']['expose']['identifier'] = 'sensor_type';
-  $handler->display->display_options['filters']['type_1']['expose']['remember_roles'] = array(
-    2 => '2',
-  );
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');

--- a/modules/farm/farm_sensor/farm_sensor.views_default.inc
+++ b/modules/farm/farm_sensor/farm_sensor.views_default.inc
@@ -201,6 +201,11 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['fields']['id']['field'] = 'id';
   $handler->display->display_options['fields']['id']['label'] = 'Asset ID';
   $handler->display->display_options['fields']['id']['separator'] = '';
+  /* Field: Sensor: Sensor type */
+  $handler->display->display_options['fields']['type']['id'] = 'type';
+  $handler->display->display_options['fields']['type']['table'] = 'farm_sensor';
+  $handler->display->display_options['fields']['type']['field'] = 'type';
+  $handler->display->display_options['fields']['type']['label'] = 'Sensor Type';
   /* Field: Farm asset: Name */
   $handler->display->display_options['fields']['name']['id'] = 'name';
   $handler->display->display_options['fields']['name']['table'] = 'farm_asset';
@@ -325,6 +330,19 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['filters']['archived_boolean']['expose']['label'] = 'Archived';
   $handler->display->display_options['filters']['archived_boolean']['expose']['operator'] = 'archived_boolean_op';
   $handler->display->display_options['filters']['archived_boolean']['expose']['identifier'] = 'archived_boolean';
+  /* Filter criterion: Sensor: Sensor type */
+  $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
+  $handler->display->display_options['filters']['type_1']['table'] = 'farm_sensor';
+  $handler->display->display_options['filters']['type_1']['field'] = 'type';
+  $handler->display->display_options['filters']['type_1']['operator'] = 'contains';
+  $handler->display->display_options['filters']['type_1']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['type_1']['expose']['operator_id'] = 'type_1_op';
+  $handler->display->display_options['filters']['type_1']['expose']['label'] = 'Sensor Type';
+  $handler->display->display_options['filters']['type_1']['expose']['operator'] = 'type_1_op';
+  $handler->display->display_options['filters']['type_1']['expose']['identifier'] = 'sensor_type';
+  $handler->display->display_options['filters']['type_1']['expose']['remember_roles'] = array(
+    2 => '2',
+  );
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');
@@ -384,6 +402,7 @@ function farm_sensor_views_default_views() {
     t('Delete'),
     t('Asset ID'),
     t('.'),
+    t('Sensor Type'),
     t('Name'),
     t('Description'),
     t('Flags'),

--- a/modules/farm/farm_sensor/farm_sensor.views_default.inc
+++ b/modules/farm/farm_sensor/farm_sensor.views_default.inc
@@ -291,6 +291,17 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['filters']['name']['expose']['label'] = 'Name';
   $handler->display->display_options['filters']['name']['expose']['operator'] = 'name_op';
   $handler->display->display_options['filters']['name']['expose']['identifier'] = 'name';
+  /* Filter criterion: Sensor: Sensor type */
+  $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
+  $handler->display->display_options['filters']['type_1']['table'] = 'farm_sensor';
+  $handler->display->display_options['filters']['type_1']['field'] = 'type';
+  $handler->display->display_options['filters']['type_1']['operator'] = 'contains';
+  $handler->display->display_options['filters']['type_1']['group'] = 1;
+  $handler->display->display_options['filters']['type_1']['exposed'] = TRUE;
+  $handler->display->display_options['filters']['type_1']['expose']['operator_id'] = 'type_1_op';
+  $handler->display->display_options['filters']['type_1']['expose']['label'] = 'Sensor type';
+  $handler->display->display_options['filters']['type_1']['expose']['operator'] = 'type_1_op';
+  $handler->display->display_options['filters']['type_1']['expose']['identifier'] = 'sensor_type';
   /* Filter criterion: Field collection item: Movement to (field_farm_move_to) */
   $handler->display->display_options['filters']['field_farm_move_to_tid']['id'] = 'field_farm_move_to_tid';
   $handler->display->display_options['filters']['field_farm_move_to_tid']['table'] = 'field_data_field_farm_move_to';
@@ -338,16 +349,6 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['filters']['archived_boolean']['expose']['label'] = 'Archived';
   $handler->display->display_options['filters']['archived_boolean']['expose']['operator'] = 'archived_boolean_op';
   $handler->display->display_options['filters']['archived_boolean']['expose']['identifier'] = 'archived_boolean';
-  /* Filter criterion: Sensor: Sensor type */
-  $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
-  $handler->display->display_options['filters']['type_1']['table'] = 'farm_sensor';
-  $handler->display->display_options['filters']['type_1']['field'] = 'type';
-  $handler->display->display_options['filters']['type_1']['operator'] = 'contains';
-  $handler->display->display_options['filters']['type_1']['exposed'] = TRUE;
-  $handler->display->display_options['filters']['type_1']['expose']['operator_id'] = 'type_1_op';
-  $handler->display->display_options['filters']['type_1']['expose']['label'] = 'Sensor Type';
-  $handler->display->display_options['filters']['type_1']['expose']['operator'] = 'type_1_op';
-  $handler->display->display_options['filters']['type_1']['expose']['identifier'] = 'sensor_type';
 
   /* Display: Page */
   $handler = $view->new_display('page', 'Page', 'page');

--- a/modules/farm/farm_sensor/farm_sensor.views_default.inc
+++ b/modules/farm/farm_sensor/farm_sensor.views_default.inc
@@ -213,7 +213,6 @@ function farm_sensor_views_default_views() {
   $handler->display->display_options['fields']['type']['id'] = 'type';
   $handler->display->display_options['fields']['type']['table'] = 'farm_sensor';
   $handler->display->display_options['fields']['type']['field'] = 'type';
-  $handler->display->display_options['fields']['type']['label'] = 'Sensor Type';
   /* Field: Farm asset: Name */
   $handler->display->display_options['fields']['name']['id'] = 'name';
   $handler->display->display_options['fields']['name']['table'] = 'farm_asset';
@@ -408,7 +407,7 @@ function farm_sensor_views_default_views() {
     t('Delete'),
     t('Asset ID'),
     t('.'),
-    t('Sensor Type'),
+    t('Sensor type'),
     t('Name'),
     t('Description'),
     t('Flags'),


### PR DESCRIPTION
I will soon be adding many sensors to a farmOS instance and it would be useful to include a `sensor type` column. I believe I've done this correctly using `farm_sensor_views_data()`. Note I didn't include the `sensor_settings` column from the DB because I don't imagine that would be useful in Views. (Curious if views could handle a serialized array though?)

I also exposed a filter for `sensor type` but its just a simple string "contains" operator. To make the filter a selectable list I think we would need to implement our own [`views_handler_filter_in_operator`](https://api.drupal.org/api/views/handlers%21views_handler_filter_in_operator.inc/class/views_handler_filter_in_operator/7.x-3.x) ?? (related article: https://atendesigngroup.com/articles/drupal-7-views-drop-down-exposed-filter-text-field)