### PR TITLE
Add helper functions for loading Crop and Crop Family terms.

### DIFF
--- a/modules/farm/farm_crop/farm_crop.module
+++ b/modules/farm/farm_crop/farm_crop.module
@@ -217,3 +217,61 @@ function farm_crop_families() {
   // Load all terms in the farm_crop_families vocabulary.
   return taxonomy_get_tree($vocabulary->vid);
 }
+
+/**
+ * Load Farm Crop terms. Can optionally limit crops by Crop Family.
+ *
+ * @param array|int|bool $crop_family_tids
+ *   The Crop Family term ID(s) to include in the query or FALSE to load all
+ *   crop terms. Can be an array of terms, a single term, or FALSE. Defaults to
+ *   FALSE to load all crops.
+ *
+ * @return array
+ *   Array of Crop/Variety terms that are in the specified Crop Families.
+ */
+function farm_crop_family_crops($crop_family_tids = FALSE) {
+
+  // Start empty array.
+  $crops = array();
+
+  // Check if crop_family_tids are provided.
+  if ($crop_family_tids != FALSE) {
+
+    // If crop_family_tids is not an array, wrap it.
+    if (!is_array($crop_family_tids)) {
+      $crop_family_tids = array($crop_family_tids);
+    }
+  }
+
+  // Load the farm_crops vocabulary.
+  $farm_crops = taxonomy_vocabulary_machine_name_load('farm_crops');
+
+  // Return empty array if vocabulary is not found.
+  if (empty($farm_crops) || !isset($farm_crops->vid)) {
+    return $crops;
+  }
+
+  // Build an EntityFieldQuery to load terms referencing the crop family term.
+  // Order terms by the crop_family tid to improve display.
+  $query = new EntityFieldQuery();
+  $query
+    ->entityCondition('entity_type', 'taxonomy_term')
+    ->propertyCondition('vid', $farm_crops->vid)
+    ->fieldOrderBy('field_farm_crop_family', 'tid');
+
+  // Limit crops by crop_family_tids if provided.
+  if (is_array($crop_family_tids)) {
+    $query->fieldCondition('field_farm_crop_family', 'tid', $crop_family_tids, 'IN');
+  }
+
+  // Execute query.
+  $results = $query->execute();
+
+  // Load taxonomy terms from returned tids.
+  if (!empty($results['taxonomy_term'])) {
+    $term_ids = array_keys($results['taxonomy_term']);
+    $crops = taxonomy_term_load_multiple($term_ids);
+  }
+
+  return $crops;
+}

--- a/modules/farm/farm_crop/farm_crop.module
+++ b/modules/farm/farm_crop/farm_crop.module
@@ -197,3 +197,23 @@ function farm_crop_feeds_tamper_default_alter(&$feeds_tampers) {
   $feeds_tamper = farm_import_feeds_tamper_plugin('farm_asset', 'planting', 'Crop/variety', 'trim');
   $feeds_tampers[$feeds_tamper->id] = $feeds_tamper;
 }
+
+/**
+ * Load Crop Family terms.
+ */
+function farm_crop_families() {
+
+  // Start empty array.
+  $families = array();
+
+  // Load the vocabulary.
+  $vocabulary = taxonomy_vocabulary_machine_name_load('farm_crop_families');
+
+  // Return empty array if vocabulary is not found.
+  if (empty($vocabulary) || !isset($vocabulary->vid)) {
+    return $families;
+  }
+
+  // Load all terms in the farm_crop_families vocabulary.
+  return taxonomy_get_tree($vocabulary->vid);
+}


### PR DESCRIPTION
Adds two functions (not sure on the names - could they be better?)
- `farm_crop_families()`: Simple function to help load `farm_crop_families` terms.
- `farm_crop_families_crops()`: Load `farm_crop` terms that are apart of specific Crop Families. No parameter loads all Crop Terms.
  - Went with the `entity->load()` style where `ids = FALSE` specifies that all should be loaded. This requires a bit more logic, but seems cleaner than adding another parameter or needing a separate function to load all crop terms IMO. But open to alternatives!

Helps for building forms that use Crops + Varieties (named however you like haha :smile:):
![crop_varieties](https://user-images.githubusercontent.com/3116995/93390461-93c59f00-f822-11ea-9146-9f9094815448.png)
