### PR TITLE
Alias oauth2/* endpoints to oauth/*

### DIFF
--- a/modules/farm/farm_access/farm_access.install
+++ b/modules/farm/farm_access/farm_access.install
@@ -46,3 +46,20 @@ function farm_access_update_7000(&$sandbox) {
     module_enable(array($module));
   }
 }
+
+/**
+ * Add aliases for OAuth2 endpoints.
+ *
+ * https://www.drupal.org/project/farm/issues/3172818
+ */
+function farm_access_update_7001(&$sandbox) {
+  $path_aliases = array(
+    'oauth2/authorize' => 'oauth/authorize',
+    'oauth2/revoke' => 'oauth/revoke',
+    'oauth2/token' => 'oauth/token',
+  );
+  foreach ($path_aliases as $source => $alias) {
+    $path = array('source' => $source, 'alias' => $alias);
+    path_save($path);
+  }
+}

--- a/modules/farm/farm_api/farm_api.module
+++ b/modules/farm/farm_api/farm_api.module
@@ -50,6 +50,25 @@ function farm_api_menu() {
   return $items;
 }
 
+/**
+ * Implements hook_menu_alter().
+ */
+function farm_api_menu_alter(&$items) {
+
+  // Make OAuth2 token endpoints available at both oauth2/* and oauth/*.
+  // See https://www.drupal.org/project/farm/issues/3172818
+  $oauth_aliases = array(
+    'oauth2/authorize' => 'oauth/authorize',
+    'oauth2/revoke' => 'oauth/revoke',
+    'oauth2/token' => 'oauth/token',
+  );
+  foreach ($oauth_aliases as $source => $alias) {
+    if (!empty($items[$source])) {
+      $items[$alias] = $items[$source];
+    }
+  }
+}
+
 /*
  * Implements hook_farm_api_oauth2_client()
  */


### PR DESCRIPTION
https://www.drupal.org/project/farm/issues/3172818

Adds aliases using `path_save()` via `farm_access_update()`. This seems better than adding them via `hook_menu` and redirecting. I'm afraid a redirect could break different oauth client libraries if they aren't expecting a redirect response.

I've tested the aliased endpoints in farmOS.py and all is working as expected :+1: 