### PR TITLE
Fixes for livestock quick movement form

### DIFF
--- a/modules/farm/farm_livestock/farm_livestock.farm_quick.move.inc
+++ b/modules/farm/farm_livestock/farm_livestock.farm_quick.move.inc
@@ -167,6 +167,9 @@ function farm_livestock_move_form($form, &$form_state) {
     '#date_label_position' => 'within',
     '#date_year_range' => '-10:+3',
     '#default_value' => $defaults['date'],
+    '#ajax' => array(
+      'callback' => 'farm_livestock_move_form_date_ajax',
+    ),
     '#required' => TRUE,
   );
 
@@ -449,6 +452,18 @@ function farm_livestock_move_form_validate($form, &$form_state) {
 
   // Save the asset to the form state.
   $form_state['storage']['assets'] = $assets;
+}
+
+/**
+ * Ajax callback for farm_livestock_move_form().
+ */
+function farm_livestock_move_form_date_ajax($form, $form_state) {
+
+  // Load the current location commands.
+  $commands = farm_livestock_move_form_current_location_commands($form, $form_state);
+
+  // Return ajax commands.
+  return array('#type' => 'ajax', '#commands' => $commands);
 }
 
 /**

--- a/modules/farm/farm_livestock/farm_livestock.farm_quick.move.inc
+++ b/modules/farm/farm_livestock/farm_livestock.farm_quick.move.inc
@@ -222,7 +222,8 @@ function farm_livestock_move_form($form, &$form_state) {
     // Load current location geometry of all assets.
     $geoms = array();
     foreach ($assets as $asset) {
-      $geoms[] = farm_movement_asset_geometry($asset);
+      $timestamp = strtotime($form_state['values']['move']['date'] ?: $defaults['date']);
+      $geoms[] = farm_movement_asset_geometry($asset, $timestamp);
     }
 
     // Combine geometries.
@@ -628,7 +629,7 @@ function farm_livestock_move_form_submit($form, &$form_state) {
       // Load current locations of all assets.
       $previous_areas = array();
       foreach ($assets as $asset) {
-        $previous_areas = array_merge($previous_areas, farm_movement_asset_location($asset));
+        $previous_areas = array_merge($previous_areas, farm_movement_asset_location($asset, $timestamp));
       }
 
       // Remove any duplicate areas.
@@ -646,7 +647,7 @@ function farm_livestock_move_form_submit($form, &$form_state) {
       // Load current location geometry of all assets.
       $geoms = array();
       foreach ($assets as $asset) {
-        $geoms[] = farm_movement_asset_geometry($asset);
+        $geoms[] = farm_movement_asset_geometry($asset, $timestamp);
       }
 
       // Combine geometries.

--- a/modules/farm/farm_livestock/farm_livestock.farm_quick.move.inc
+++ b/modules/farm/farm_livestock/farm_livestock.farm_quick.move.inc
@@ -631,6 +631,9 @@ function farm_livestock_move_form_submit($form, &$form_state) {
         $previous_areas = array_merge($previous_areas, farm_movement_asset_location($asset));
       }
 
+      // Remove any duplicate areas.
+      $previous_areas = array_unique($previous_areas, SORT_REGULAR);
+
       // Link post grazing logs to the area(s) animals are moving from.
       if (!empty($previous_areas)) {
 

--- a/modules/farm/farm_livestock/farm_livestock.install
+++ b/modules/farm/farm_livestock/farm_livestock.install
@@ -508,3 +508,54 @@ function farm_livestock_update_7007(&$sandbox) {
     module_enable(array($module));
   }
 }
+
+/**
+ * Remove duplicate area references from movement quickform logs.
+ */
+function farm_livestock_update_7008(&$sandbox) {
+
+  // Setup. Find observation logs associated with the farm_livestock_move_form
+  // that need to be updated.
+  if (!isset($sandbox['progress'])) {
+    $sandbox['progress'] = 0;
+
+    // Query observation logs linked to this quick form.
+    $query = db_select('farm_quick_entity', 'fqe');
+    $query->addField('fqe', 'entity_id');
+    $query->condition('fqe.entity_type', 'log');
+    $query->condition('fqe.quick_form_id', 'farm_livestock_move_form');
+    $log_alias = $query->join('log', 'l', 'fqe.entity_id = l.id');
+    $query->condition($log_alias . '.type', 'farm_observation');
+    $log_ids = $query->execute()->fetchCol();
+
+    // Finish the update if there are no logs to update.
+    if (empty($log_ids)) {
+      $sandbox['#finished'] = 1;
+      return;
+    }
+
+    $sandbox['log_ids'] = $log_ids;
+    $sandbox['total'] = count($log_ids);
+  }
+
+  // Load the Nth log we need to process.
+  $log = log_load($sandbox['log_ids'][$sandbox['progress']]);
+
+  // Load areas that each log references.
+  $log_wrapper = entity_metadata_wrapper('log', $log);
+  $areas = $log_wrapper->field_farm_area->value();
+
+  // Only update areas if some exist.
+  if (!empty($areas)) {
+
+    // Get the unique areas.
+    $new_areas = array_unique($areas, SORT_REGULAR);
+
+    // Update the log.
+    $log_wrapper->field_farm_area->set($new_areas);
+    $log_wrapper->save();
+  }
+
+  $sandbox['progress']++;
+  $sandbox['#finished'] = $sandbox['progress'] / $sandbox['total'];
+}

--- a/modules/farm/farm_livestock/farm_livestock.install
+++ b/modules/farm/farm_livestock/farm_livestock.install
@@ -545,15 +545,17 @@ function farm_livestock_update_7008(&$sandbox) {
   $log_wrapper = entity_metadata_wrapper('log', $log);
   $areas = $log_wrapper->field_farm_area->value();
 
-  // Only update areas if some exist.
-  if (!empty($areas)) {
+  // Only update areas if more than 1 exists.
+  if (!empty($areas) && count($areas) > 1) {
 
     // Get the unique areas.
     $new_areas = array_unique($areas, SORT_REGULAR);
 
     // Update the log.
-    $log_wrapper->field_farm_area->set($new_areas);
-    $log_wrapper->save();
+    if (count($areas) > count($new_areas)) {
+      $log_wrapper->field_farm_area->set($new_areas);
+      $log_wrapper->save();
+    }
   }
 
   $sandbox['progress']++;


### PR DESCRIPTION
- Fix bug where post-grazing observation logs might reference the same area multiple times if different assets were located in the same area before being moved.
- Fix any previous post-grazing observation logs via a batch `hook_update_n` in `farm_livestock`
- Get the asset's current location relative to the movement time specified in the form. This allows for "past" movements to be recorded using the quick form.
- Add ajax to update the current location geometry when changing the date

@mstenta everything seems to be working well, there just seems to be a UI bug with the AJAX on the "Movement Date" field. Once one of the date input fields is changed it becomes full width. This wasn't happening before I added the AJAX callback.

Looking closer, it seems like the AJAX adds a new element within the input select `<span class="input-group-addon"></span>` -  which doesn't exist before modifying the field. This confuses me, because the AJAX command I'm returning explicitly updates the `#current_location` wrapper, not the date.

Any ideas? Having AJAX on the date input is nice because when you change the date, the current location geometry updates quite fluidly!

After changing the "month" and "day" input:
![quick_move_bug](https://user-images.githubusercontent.com/3116995/97372267-7992ce00-1870-11eb-9bca-b59aa0379495.png)

Span element that is added:
![quick_move_html](https://user-images.githubusercontent.com/3116995/97372264-78fa3780-1870-11eb-8a09-3f6bc23a9214.png)


