### PR TITLE
Cannot query quantity labels that have spaces

### DIFF
--- a/modules/farm/farm_quantity/farm_quantity_log/farm_quantity_log.module
+++ b/modules/farm/farm_quantity/farm_quantity_log/farm_quantity_log.module
@@ -317,7 +317,7 @@ function farm_quantity_log_query_add_filters(&$query, $measure = NULL, $label = 
     }
   }
   if (!is_null($label)) {
-    $label = db_escape_field($label);
+    $label = db_like($label);
   }
 
   // Add the log ID field.


### PR DESCRIPTION
I wasn't getting any data back when querying quantity logs with the `Pasture Height` label (trying to retrieve data created by the livestock movement quick form).

Looks like this is because the `farm_quantity_log_query_add_filters()` method escapes the `label` using `db_escape_field()`. This is to strict; using `db_like()` should allow the label to have spaces (and other characters) that are valid for a quantity label.