### PR TITLE
farm_map_set_bcscale() prevents the bcscale from being set multiple times.

### DIFF
--- a/modules/farm/farm_map/farm_map.geo.inc
+++ b/modules/farm/farm_map/farm_map.geo.inc
@@ -46,6 +46,9 @@ function farm_map_set_bcscale($reset = FALSE) {
 
     // Otherwise, reset.
     bcscale($scale);
+    // Unset the $scale variable so that a new bcscale can later be set.
+    // Note that we can't use unset() because this is a static variable.
+    $scale = NULL;
     return;
   }
 


### PR DESCRIPTION
Trying to calculate the size of an area and convert it to `acres` units with a couple points of precision. The conversion works, but `farm_area_convert_area_units()` outputs an integer as a string without any precision.

I think this is due to the `bcscale()` logic in `farm_map_set_bcscale()`. The current logic allows a scale to be set once, and used for all later methods using bc math, but once the bcscale is "reset", any subsequent calls to `farm_map_set_bcscale()` will never be able to re-set the bcscale to a value higher than 0.

It seems like we don't see this issue elsewhere because there aren't any instances where the set & unset pattern is run TWICE in the same request, maybe?

```php
farm_map_set_bcscale();

// ... stuff happens

farm_map_reset_bcscale();
```

But my custom script calls two methods, `farm_area_calculate_area()` and `farm_area_convert_area_units()`,  which each perform the above pattern.

```php
  $area_size = NULL;
  $area_meters = farm_area_calculate_area($area->tid);
  if (!empty($area_meters)) {
    $area_acres = farm_area_convert_area_units($area_meters, 'acres');
    $area_size = round(floatval($area_acres), 1);
  }
```

Simply setting the `static $scale` variable to `NULL` after "resetting" the bcscale seems to fix this issue. I don't think this has any ill-consequences.. the dashboard area metrics load with precision & map geometries load as normal. It seems like this issue would have appeared elsewhere, but maybe not?