### PR TITLE
Add helper function to calculate animal inventories over time

### DIFF
--- a/modules/farm/farm_livestock/farm_livestock.module
+++ b/modules/farm/farm_livestock/farm_livestock.module
@@ -488,3 +488,62 @@ function farm_livestock_birth_log_form_validate(array $form, array &$form_state)
     }
   }
 }
+
+/**
+ * Calculate the inventory for a given animal or group asset.
+ *
+ * This will recursively calculate the inventory of animal assets that are
+ * members of a group at the given timestamp.
+ *
+ * @param \FarmAsset $asset
+ *   The animal or group asset.
+ * @param int $time
+ *   Unix timestamp limiter. Only inventory and group membership logs before
+ *   this time will be included. Defaults to the current time. Set to 0 to load
+ *   the absolute last.
+ * @param bool $done
+ *   Whether or not to only show logs that are marked as "done". TRUE will limit
+ *   to logs that are done, and FALSE will limit to logs that are not done. If
+ *   this is set to NULL, no filtering will be applied. Defaults to TRUE.
+ * @param false $archived
+ *   Whether or not to include archived member assets. Defaults to FALSE.
+ *
+ * @return int
+ *   Returns the total inventory of animal assets, including group members.
+ */
+function farm_livestock_asset_inventory(FarmAsset $asset, $time = REQUEST_TIME, $done = TRUE, $archived = FALSE) {
+
+  // Start count at 0.
+  $count = 0;
+
+  // Calculate inventory of a single animal asset.
+  if ($asset->type == 'animal') {
+
+    // Get inventory at the specified time.
+    $inventory = farm_inventory($asset, $time, $done);
+
+    // Use the inventory if valid.
+    if (!empty($inventory) && is_numeric($inventory)) {
+      $count += $inventory;
+    }
+    // Else increment count by 1.
+    else {
+      $count++;
+    }
+  }
+
+  // Recursively calculate inventory of group assets.
+  if ($asset->type == 'group') {
+
+    // Get group members.
+    $members = farm_group_members($asset, $time, $done, $archived);
+
+    // Get inventory of each member.
+    foreach ($members as $member) {
+      $count += farm_livestock_asset_inventory($member, $time, $done, $archived);
+    }
+  }
+
+  // Return total inventory count.
+  return $count;
+}


### PR DESCRIPTION
Add a `farm_livestock_asset_inventory` function to calculate the inventory of a single `animal` asset, or recursively calculate the total inventory of all animal assets in a `group` asset. Group memberships, as well as asset inventories, are taken into account to only include those logs that existed at the specified timestamp.

The use case I'm working with: iterating over movement logs to calculate the total number of animals moving into an area. Consider that a movement log can specify any type of asset, and group can contain multiple types of assets. This function allows me to iterate over all the assets on a log, regardless of type, and get the total number of animals represented by the movement. Non-animal asset types are ignored. Example code:

```php
    // Create an entity metadata wrapper for the movement log.
    $log_wrapper = entity_metadata_wrapper('log', $movement_log);

    // Iterate through the assets on a movement log.
    $group_size = 0;
    foreach ($log_wrapper->field_farm_asset as $asset_wrapper) {

      // Save asset.
      $asset = $asset_wrapper->value();

      // The the asset doesn't have an ID, skip it.
      if (empty($asset->id)) {
        continue;
      }

      // Get total asset inventory at the time of the movement.
      $group_size += farm_livestock_asset_inventory($asset, $movement_log->timestamp);
    }
```

<hr>

I considered making this function more general-purpose so it could recursively calculate the inventory of all assets in a group, something like `farm_inventory_group_inventory`, but there would be the issue of limiting the calculated inventory by asset type (even though `animal` assets are currently the only ones with inventory!). Another argument could be added to limit the calculation to only certain asset types, but seems like unnecessary complexity for now.

The other thing I considered is how this general purpose method would migrate to 2x, mostly because inventories will have `units`, which means an asset could have "multiple" inventories. By implementing this logic in the `farm_livestock` module, we can migrate this function with the expectation that it will explicitly be calculating "animal count" inventories (some of this still TBD).

