### PR TITLE
Run phpunit without XDebug to speed up tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,14 +20,14 @@ jobs:
       # but notably it does NOT override the default PROJECT_VERSION, so the
       # farmOS Composer project 2.x branch is always used.
       - name: Build farmOS 2.x-dev Docker image
-        run: docker build --build-arg FARMOS_REPO=https://github.com/${GITHUB_REPOSITORY} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x-dev docker/dev
+        run: docker build --build-arg FARMOS_REPO=https://github.com/${GITHUB_REPOSITORY} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --build-arg WWW_DATA_ID=33 -t farmos/farmos:2.x-dev docker/dev
       - name: Create docker-compose.yml
-        run: curl https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.development.yml -o docker-compose.yml
+        run: cp docker/docker-compose.testing.yml docker-compose.yml
       - name: Start containers
-        run: sudo docker-compose up -d
-      - name: Wait 10 seconds
-        run: sleep 10
+        run: docker-compose up -d
+      - name: Wait 15 seconds
+        run: sleep 15
       - name: Run PHPUnit tests
-        run: sudo docker exec -i -u www-data farmos_www_1 phpunit --verbose --debug --group farm
+        run: docker-compose exec -u www-data -T test-runner phpunit --verbose --debug --group farm
       - name: Run PHP CodeSniffer
-        run: sudo docker exec -i -u www-data farmos_www_1 phpcs /opt/drupal/web/profiles/farm
+        run: docker-compose exec -u www-data -T www phpcs /opt/drupal/web/profiles/farm

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - '2.x'
+      - '2.x-**'
 
 jobs:
   build:

--- a/docker/docker-compose.testing.yml
+++ b/docker/docker-compose.testing.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  db:
+    image: postgres:12
+    volumes:
+      - './db:/var/lib/postgresql/data'
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: farm
+      POSTGRES_PASSWORD: farm
+      POSTGRES_DB: farm
+
+  www:
+    depends_on:
+      - db
+    image: farmos/farmos:2.x-dev
+    volumes:
+      - './www:/opt/drupal'
+
+  test-runner:
+    depends_on:
+      - www
+    image: farmos/farmos:2.x
+    entrypoint: /bin/sh
+    command: -c 'sleep 10 && exec docker-entrypoint.sh apache2-foreground'
+    volumes:
+      - './www:/opt/drupal'


### PR DESCRIPTION
**Why:** Tests take about 8 - 9 minutes with XDebug, but closer to
3 minutes without it.

**How:** Implement strategy that mstenta@ described in https://www.drupal.org/project/farm/issues/3183687
using the dev docker image to build up the /opt/drupal directory,
but the prod image to actually run it since that image doesn't have
XDebug.