### PR TITLE
Wait only as long as necessary for Postgres and the farmOS file copying to be done

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,8 +25,10 @@ jobs:
         run: cp docker/docker-compose.testing.yml docker-compose.yml
       - name: Start containers
         run: docker-compose up -d
-      - name: Wait 15 seconds
-        run: sleep 15
+      - name: Wait until test-runner container is ready
+      # The test-runner-container-fs-ready file is only created once we expect the containers to be online
+      # so waiting for that lets us know it is safe to start the tests
+        run: until [ -f ./www/test-runner-container-fs-ready ]; do sleep 0.1; done
       - name: Run PHPUnit tests
         run: docker-compose exec -u www-data -T test-runner phpunit --verbose --debug --group farm
       - name: Run PHP CodeSniffer

--- a/docker/docker-compose.testing.yml
+++ b/docker/docker-compose.testing.yml
@@ -17,12 +17,27 @@ services:
     image: farmos/farmos:2.x-dev
     volumes:
       - './www:/opt/drupal'
+    environment:
+      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/www-container-fs-ready
 
   test-runner:
     depends_on:
       - www
     image: farmos/farmos:2.x
-    entrypoint: /bin/sh
-    command: -c 'sleep 10 && exec docker-entrypoint.sh apache2-foreground'
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        set -e
+        # Wait until the dev farmOS container has finished copying its files
+        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
+        # Wait until Postgres is online listening to its socket
+        while { ! exec 3<>/dev/tcp/db/5432; } > /dev/null 2>&1; do sleep 0.1; done
+        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
+        # file created, allowing the Github action to also wait for the above conditions on the basis
+        # of that file's creation.
+        exec docker-entrypoint.sh apache2-foreground
     volumes:
       - './www:/opt/drupal'
+    environment:
+      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/test-runner-container-fs-ready

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -19,6 +19,10 @@ if [ -d /opt/drupal/web/sites ] && ! [ "$(ls -A /opt/drupal/web/sites/)" ]; then
   cp -rp /var/farmOS/web/sites/. /opt/drupal/web/sites
 fi
 
+if [ -n "$FARMOS_FS_READY_SENTINEL_FILENAME" ]; then
+  echo "ready" > "$FARMOS_FS_READY_SENTINEL_FILENAME"
+fi
+
 # Execute the arguments passed into this script.
 echo "Attempting: $@"
 exec "$@"


### PR DESCRIPTION
Cuts about 15s of unnecessary waiting out of the build because it turns out the test-runner and Postgres containers were usually already done starting up before that `sleep 15` step of `run-tests.yml`.

This is tested via [this Github action run](https://github.com/symbioquine/farmOS/runs/1460645605?check_suite_focus=true) which includes;

* https://github.com/paul121/farmOS/commit/61c129fd4c594d6311d79780168a60ce0718f3df

The branch of this PR won't pass because it doesn't include that commit.