### PR TITLE
Update link to api keys documentation.

### DIFF
--- a/modules/farm/farm_map/farm_map_google/farm_map_google.module
+++ b/modules/farm/farm_map/farm_map_google/farm_map_google.module
@@ -29,7 +29,7 @@ function farm_map_google_form_farm_map_settings_form_alter(&$form, &$form_state,
   $form['farm_map_google_api_key'] = array(
     '#type' => 'textfield',
     '#title' => t('Google Maps API Key'),
-    '#description' => t('Google Maps layers require that you obtain an API key. Refer to the <a href="@doc">Google Maps API Key</a> documentation on farmOS.org for instructions.', array('@doc' => 'https://farmos.org/hosting/googlemaps')),
+    '#description' => t('Google Maps layers require that you obtain an API key. Refer to the <a href="@doc">API Keys</a> documentation on farmOS.org for instructions.', array('@doc' => 'https://farmos.org/hosting/apikeys/')),
     '#default_value' => variable_get('farm_map_google_api_key', ''),
   );
 }


### PR DESCRIPTION
The https://farmos.org/hosting/googlemaps/ page was moved to https://farmos.org/hosting/apikeys/