### PR TITLE
Fix google maps api version parameter.

### DIFF
--- a/modules/farm/farm_map/farm_map_google/farm_map_google.farm_map.inc
+++ b/modules/farm/farm_map/farm_map_google/farm_map_google.farm_map.inc
@@ -25,7 +25,8 @@ function farm_map_google_farm_map_view($name, $element) {
   if (!empty($google_api_key)) {
 
     // Add remote Google Maps JavaScript library, with the API key.
-    $url = 'https://maps.googleapis.com/maps/api/js?v=3&key=' . $google_api_key;
+    // See https://developers.google.com/maps/documentation/javascript/versions
+    $url = 'https://maps.googleapis.com/maps/api/js?v=weekly&key=' . $google_api_key;
     drupal_add_js($url, array('type' => 'external', 'weight' => -100));
 
     // Add a farmOS map behavior that will enable Google Maps.


### PR DESCRIPTION
Based on these [docs](https://developers.google.com/maps/documentation/javascript/versions), I think we should be using the `weekly` version of the Google Maps API.

> For most applications, we recommend the weekly channel. This is the most current and up-to-date version and contains the latest bug fixes and performance improvements.

Version 3 was [deleted](https://developers.google.com/maps/documentation/javascript/versions#documentation-for-the-api-versions), so I believe we have been using the `weekly` version anyways.

> If you do not explicitly specify a channel or version, you will receive the weekly channel by default. 