### PR TITLE
Add convenience env vars to devel docker entrypoint

### DIFF
--- a/docker/dev/docker-entrypoint.sh
+++ b/docker/dev/docker-entrypoint.sh
@@ -5,6 +5,22 @@ set -e
 if ! [ "$(ls -A /var/www/html/)" ]; then
   echo "farmOS webroot not detected. Copying from pre-built codebase in the Docker image."
   cp -rp /tmp/www/. /var/www/html
+
+  # If the FARMOS_INSTALL_CMD variable is defined run the expression it contains. This allows
+  # for a drush site-install command to be specified as part of a docker-compose.yml file.
+  if [ -n "$FARMOS_INSTALL_CMD" ]; then
+    echo "Running '$FARMOS_INSTALL_CMD'"
+    eval "$FARMOS_INSTALL_CMD"
+  fi
+fi
+
+# If the FARMOS_DEV_MODULES_DIRECTORY variable is defined, symlink and use drush to enable
+# each module contained therein. This allows modules to be bind-mounted for live development.
+if [ -n "$FARMOS_DEV_MODULES_DIRECTORY" ]; then
+  find "$FARMOS_DEV_MODULES_DIRECTORY" -maxdepth 1 -mindepth 1 -execdir sh -c '\
+      echo Symlinking and drush enabling $(basename {}) && \
+      ln -sTf "$FARMOS_DEV_MODULES_DIRECTORY"/$(basename {}) /var/www/html/sites/all/modules/$(basename {}) && \
+      drush --root=/var/www/html pm-enable --yes $(basename {})' \;
 fi
 
 # Execute the arguments passed into this script.


### PR DESCRIPTION
Adds;

* `FARMOS_INSTALL_CMD` - A command to be executed just after copying the
  farmOS source from /tmp/www
* `FARMOS_DEV_MODULES_DIRECTORY` - A directory containing modules under
  development. These will be symlinked into the Drupal modules directory
  and enabled using drush.

Together these allow for a docker-compose.yml configuration which
automatically sets up farmOS and installs contrib modules which are
under development - since these are bind-mounted they can be edited
live in the source tree on the host system.

```yaml
  www:
    depends_on:
      - db
    image: farmos/farmos:dev
    volumes:
      - './www:/var/www/html'
      - './php-custom.ini:/usr/local/etc/php/conf.d/php-custom.ini'
      - '../farmos_wfs:/farmos_dev_modules/farmos_wfs'
    ports:
      - '80:80'
    environment:
      XDEBUG_CONFIG: remote_host=172.17.0.1
      FARMOS_INSTALL_CMD: while { ! exec 3<>/dev/tcp/db/3306; } > /dev/null 2>&1; do sleep 0.1; done && drush site-install farm --debug --yes --locale=us --db-url=mysql://farm:farm@db/farm --site-name=Test0 --account-name=root --account-pass=test install_configure_form.update_status_module='array(FALSE,FALSE)'
      FARMOS_DEV_MODULES_DIRECTORY: /farmos_dev_modules
```

Though not integral to this pattern, the php-custom.ini file contains;

```ini
opcache.enable=0
```

Which ensures php includes are executed every page load - making
develpment testing easier.