### PR TITLE
Minor fixes after converting config fields to bundle fields.

### DIFF
--- a/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
@@ -61,7 +61,7 @@ class Animal extends FarmAssetType {
       ],
     ];
     foreach ($field_info as $name => $info) {
-      $fields[$name] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($info);
+      $fields[$name] = $this->farmFieldFactory->bundleFieldDefinition($info);
     }
     return $fields;
   }

--- a/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
@@ -54,14 +54,8 @@ class Animal extends FarmAssetType {
         'type' => 'list_string',
         'label' => $this->t('Sex'),
         'allowed_values' => [
-          [
-            'value' => 'F',
-            'label' => 'Female',
-          ],
-          [
-            'value' => 'M',
-            'label' => 'Male',
-          ],
+          'F' => $this->t('Female'),
+          'M' => $this->t('Male'),
         ],
         'weight' => [
           'form' => 20,

--- a/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\farm_animal\Plugin\Asset\AssetType;
 
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
@@ -14,8 +13,6 @@ use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
  * )
  */
 class Animal extends FarmAssetType {
-
-  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
+++ b/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
@@ -3,7 +3,6 @@
 namespace Drupal\farm_equipment\Plugin\Asset\AssetType;
 
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Provides the equipment asset type.
@@ -14,8 +13,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  * )
  */
 class Equipment extends FarmAssetType {
-
-  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
+++ b/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
@@ -46,7 +46,7 @@ class Equipment extends FarmAssetType {
       ],
     ];
     foreach ($field_info as $name => $info) {
-      $fields[$name] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($info);
+      $fields[$name] = $this->farmFieldFactory->bundleFieldDefinition($info);
     }
     return $fields;
   }

--- a/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
+++ b/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
@@ -3,7 +3,6 @@
 namespace Drupal\farm_plant\Plugin\Asset\AssetType;
 
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Provides the plant asset type.
@@ -14,8 +13,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  * )
  */
 class Plant extends FarmAssetType {
-
-  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}

--- a/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
+++ b/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
@@ -35,7 +35,7 @@ class Plant extends FarmAssetType {
       ],
     ];
     foreach ($field_info as $name => $info) {
-      $fields[$name] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($info);
+      $fields[$name] = $this->farmFieldFactory->bundleFieldDefinition($info);
     }
     return $fields;
   }

--- a/modules/core/entity/src/FarmEntityTypeBase.php
+++ b/modules/core/entity/src/FarmEntityTypeBase.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\farm_entity;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\farm_field\FarmFieldFactoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a FarmEntityTypeBase for plugins to extends.
+ */
+abstract class FarmEntityTypeBase extends PluginBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The farm_field.factory service.
+   *
+   * @var \Drupal\farm_field\FarmFieldFactoryInterface
+   */
+  protected $farmFieldFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, FarmFieldFactoryInterface $farm_field_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->farmFieldFactory = $farm_field_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('farm_field.factory')
+    );
+  }
+
+}

--- a/modules/core/entity/src/Plugin/Asset/AssetType/AssetTypeBase.php
+++ b/modules/core/entity/src/Plugin/Asset/AssetType/AssetTypeBase.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\farm_entity\Plugin\Asset\AssetType;
 
-use Drupal\Core\Plugin\PluginBase;
+use Drupal\farm_entity\FarmEntityTypeBase;
 
 /**
  * Provides the base asset type class.
  */
-abstract class AssetTypeBase extends PluginBase implements AssetTypeInterface {
+abstract class AssetTypeBase extends FarmEntityTypeBase implements AssetTypeInterface {
 
   /**
    * {@inheritdoc}

--- a/modules/core/entity/src/Plugin/Asset/AssetType/FarmAssetType.php
+++ b/modules/core/entity/src/Plugin/Asset/AssetType/FarmAssetType.php
@@ -2,9 +2,13 @@
 
 namespace Drupal\farm_entity\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
 /**
  * Provides a farmOS asset type base class.
  */
 class FarmAssetType extends AssetTypeBase {
+
+  use StringTranslationTrait;
 
 }

--- a/modules/core/entity/src/Plugin/Log/LogType/LogTypeBase.php
+++ b/modules/core/entity/src/Plugin/Log/LogType/LogTypeBase.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\farm_entity\Plugin\Log\LogType;
 
-use Drupal\Core\Plugin\PluginBase;
+use Drupal\farm_entity\FarmEntityTypeBase;
 
 /**
  * Provides the base log type class.
  */
-abstract class LogTypeBase extends PluginBase implements LogTypeInterface {
+abstract class LogTypeBase extends FarmEntityTypeBase implements LogTypeInterface {
 
   /**
    * {@inheritdoc}

--- a/modules/core/entity/src/Plugin/Plan/PlanType/PlanTypeBase.php
+++ b/modules/core/entity/src/Plugin/Plan/PlanType/PlanTypeBase.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\farm_entity\Plugin\Plan\PlanType;
 
-use Drupal\Core\Plugin\PluginBase;
+use Drupal\farm_entity\FarmEntityTypeBase;
 
 /**
  * Provides the base plan type class.
  */
-abstract class PlanTypeBase extends PluginBase implements PlanTypeInterface {
+abstract class PlanTypeBase extends FarmEntityTypeBase implements PlanTypeInterface {
 
   /**
    * {@inheritdoc}

--- a/modules/log/harvest/src/Plugin/Log/LogType/Harvest.php
+++ b/modules/log/harvest/src/Plugin/Log/LogType/Harvest.php
@@ -23,8 +23,8 @@ class Harvest extends FarmLogType {
     // Lot number.
     $options = [
       'type' => 'string',
-      'label' => 'Lot number',
-      'description' => 'If this harvest is part of a batch or lot, enter the lot number here.',
+      'label' => $this->t('Lot number'),
+      'description' => $this->t('If this harvest is part of a batch or lot, enter the lot number here.'),
       'weight' => [
         'form' => 20,
         'view' => 20,

--- a/modules/log/harvest/src/Plugin/Log/LogType/Harvest.php
+++ b/modules/log/harvest/src/Plugin/Log/LogType/Harvest.php
@@ -30,7 +30,7 @@ class Harvest extends FarmLogType {
         'view' => 20,
       ],
     ];
-    $fields['lot_number'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['lot_number'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/input/src/Plugin/Log/LogType/Input.php
+++ b/modules/log/input/src/Plugin/Log/LogType/Input.php
@@ -23,8 +23,8 @@ class Input extends FarmLogType {
     // Lot number.
     $options = [
       'type' => 'string',
-      'label' => 'Lot number',
-      'description' => 'If this harvest is part of a batch or lot, enter the lot number here.',
+      'label' => $this->t('Lot number'),
+      'description' => $this->t('If this harvest is part of a batch or lot, enter the lot number here.'),
       'weight' => [
         'form' => -45,
         'view' => -45,
@@ -35,8 +35,8 @@ class Input extends FarmLogType {
     // Material.
     $options = [
       'type' => 'entity_reference',
-      'label' => 'Material',
-      'description' => 'What materials are being applied?',
+      'label' => $this->t('Material'),
+      'description' => $this->t('What materials are being applied?'),
       'target_type' => 'taxonomy_term',
       'target_bundle' => 'material',
       'multiple' => TRUE,
@@ -50,8 +50,8 @@ class Input extends FarmLogType {
     // Method.
     $options = [
       'type' => 'string',
-      'label' => 'Method',
-      'description' => 'How was this input applied?',
+      'label' => $this->t('Method'),
+      'description' => $this->t('How was this input applied?'),
       'weight' => [
         'form' => -30,
         'view' => -30,
@@ -62,8 +62,8 @@ class Input extends FarmLogType {
     // Purchase date.
     $options = [
       'type' => 'timestamp',
-      'label' => 'Purchase date',
-      'description' => 'When was this input purchased (if applicable)?',
+      'label' => $this->t('Purchase date'),
+      'description' => $this->t('When was this input purchased (if applicable)?'),
       'weight' => [
         'form' => -35,
         'view' => -35,
@@ -74,8 +74,8 @@ class Input extends FarmLogType {
     // Source.
     $options = [
       'type' => 'string',
-      'label' => 'Source',
-      'description' => 'Where was this input obtained? Who manufactured it?',
+      'label' => $this->t('Source'),
+      'description' => $this->t('Where was this input obtained? Who manufactured it?'),
       'weight' => [
         'form' => -40,
         'view' => -40,

--- a/modules/log/input/src/Plugin/Log/LogType/Input.php
+++ b/modules/log/input/src/Plugin/Log/LogType/Input.php
@@ -30,7 +30,7 @@ class Input extends FarmLogType {
         'view' => -45,
       ],
     ];
-    $fields['lot_number'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['lot_number'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Material.
     $options = [
@@ -45,7 +45,7 @@ class Input extends FarmLogType {
         'view' => -50,
       ],
     ];
-    $fields['material'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['material'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Method.
     $options = [
@@ -57,7 +57,7 @@ class Input extends FarmLogType {
         'view' => -30,
       ],
     ];
-    $fields['method'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['method'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Purchase date.
     $options = [
@@ -69,7 +69,7 @@ class Input extends FarmLogType {
         'view' => -35,
       ],
     ];
-    $fields['purchase_date'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['purchase_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Source.
     $options = [
@@ -81,7 +81,7 @@ class Input extends FarmLogType {
         'view' => -40,
       ],
     ];
-    $fields['source'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['source'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -23,8 +23,8 @@ class LabTest extends FarmLogType {
     // Lab.
     $options = [
       'type' => 'string',
-      'label' => 'Laboratory',
-      'description' => 'What laboratory performed this test?',
+      'label' => $this->t('Laboratory'),
+      'description' => $this->t('What laboratory performed this test?'),
       'weight' => [
         'form' => -40,
         'view' => -40,
@@ -35,7 +35,7 @@ class LabTest extends FarmLogType {
     // Lab test type.
     $options = [
       'type' => 'list_string',
-      'label' => 'Test type',
+      'label' => $this->t('Test type'),
       'allowed_values_function' => 'farm_lab_test_type_field_allowed_values',
       'weight' => [
         'form' => -50,

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -30,7 +30,7 @@ class LabTest extends FarmLogType {
         'view' => -40,
       ],
     ];
-    $fields['lab'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['lab'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Lab test type.
     $options = [
@@ -42,7 +42,7 @@ class LabTest extends FarmLogType {
         'view' => -50,
       ],
     ];
-    $fields['lab_test_type'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['lab_test_type'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/medical/src/Plugin/Log/LogType/Medical.php
+++ b/modules/log/medical/src/Plugin/Log/LogType/Medical.php
@@ -23,8 +23,8 @@ class Medical extends FarmLogType {
     // Veterinarian.
     $options = [
       'type' => 'string',
-      'label' => 'Veterinarian',
-      'description' => 'If a veterinarian was involved, enter their name here.',
+      'label' => $this->t('Veterinarian'),
+      'description' => $this->t('If a veterinarian was involved, enter their name here.'),
       'weight' => [
         'form' => -40,
         'view' => -40,

--- a/modules/log/medical/src/Plugin/Log/LogType/Medical.php
+++ b/modules/log/medical/src/Plugin/Log/LogType/Medical.php
@@ -30,7 +30,7 @@ class Medical extends FarmLogType {
         'view' => -40,
       ],
     ];
-    $fields['vet'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['vet'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/purchase/src/Plugin/Log/LogType/Purchase.php
+++ b/modules/log/purchase/src/Plugin/Log/LogType/Purchase.php
@@ -23,7 +23,7 @@ class Purchase extends FarmLogType {
     // Invoice number.
     $options = [
       'type' => 'string',
-      'label' => 'Invoice number',
+      'label' => $this->t('Invoice number'),
       'weight' => [
         'form' => 20,
         'view' => 20,
@@ -34,7 +34,7 @@ class Purchase extends FarmLogType {
     // Seller.
     $options = [
       'type' => 'string',
-      'label' => 'Seller',
+      'label' => $this->t('Seller'),
       'weight' => [
         'form' => 20,
         'view' => 20,

--- a/modules/log/purchase/src/Plugin/Log/LogType/Purchase.php
+++ b/modules/log/purchase/src/Plugin/Log/LogType/Purchase.php
@@ -29,7 +29,7 @@ class Purchase extends FarmLogType {
         'view' => 20,
       ],
     ];
-    $fields['invoice_number'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['invoice_number'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Seller.
     $options = [
@@ -40,7 +40,7 @@ class Purchase extends FarmLogType {
         'view' => 20,
       ],
     ];
-    $fields['seller'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['seller'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/sale/src/Plugin/Log/LogType/Sale.php
+++ b/modules/log/sale/src/Plugin/Log/LogType/Sale.php
@@ -29,7 +29,7 @@ class Sale extends FarmLogType {
         'view' => 20,
       ],
     ];
-    $fields['customer'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['customer'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Invoice number.
     $options = [
@@ -40,7 +40,7 @@ class Sale extends FarmLogType {
         'view' => 20,
       ],
     ];
-    $fields['invoice_number'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['invoice_number'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/sale/src/Plugin/Log/LogType/Sale.php
+++ b/modules/log/sale/src/Plugin/Log/LogType/Sale.php
@@ -23,7 +23,7 @@ class Sale extends FarmLogType {
     // Customer.
     $options = [
       'type' => 'string',
-      'label' => 'Customer',
+      'label' => $this->t('Customer'),
       'weight' => [
         'form' => 20,
         'view' => 20,
@@ -34,7 +34,7 @@ class Sale extends FarmLogType {
     // Invoice number.
     $options = [
       'type' => 'string',
-      'label' => 'Invoice number',
+      'label' => $this->t('Invoice number'),
       'weight' => [
         'form' => 20,
         'view' => 20,

--- a/modules/log/seeding/src/Plugin/Log/LogType/Seeding.php
+++ b/modules/log/seeding/src/Plugin/Log/LogType/Seeding.php
@@ -23,8 +23,8 @@ class Seeding extends FarmLogType {
     // Lot number.
     $options = [
       'type' => 'string',
-      'label' => 'Lot number',
-      'description' => 'If this harvest is part of a batch or lot, enter the lot number here.',
+      'label' => $this->t('Lot number'),
+      'description' => $this->t('If this harvest is part of a batch or lot, enter the lot number here.'),
       'weight' => [
         'form' => 20,
         'view' => 20,
@@ -35,8 +35,8 @@ class Seeding extends FarmLogType {
     // Purchase date.
     $options = [
       'type' => 'timestamp',
-      'label' => 'Purchase date',
-      'description' => 'When was this input purchased (if applicable)?',
+      'label' => $this->t('Purchase date'),
+      'description' => $this->t('When was this input purchased (if applicable)?'),
       'weight' => [
         'form' => -35,
         'view' => -35,
@@ -47,8 +47,8 @@ class Seeding extends FarmLogType {
     // Source.
     $options = [
       'type' => 'string',
-      'label' => 'Source',
-      'description' => 'Where was this input obtained? Who manufactured it?',
+      'label' => $this->t('Source'),
+      'description' => $this->t('Where was this input obtained? Who manufactured it?'),
       'weight' => [
         'form' => -40,
         'view' => -40,

--- a/modules/log/seeding/src/Plugin/Log/LogType/Seeding.php
+++ b/modules/log/seeding/src/Plugin/Log/LogType/Seeding.php
@@ -30,7 +30,7 @@ class Seeding extends FarmLogType {
         'view' => 20,
       ],
     ];
-    $fields['lot_number'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['lot_number'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Purchase date.
     $options = [
@@ -42,7 +42,7 @@ class Seeding extends FarmLogType {
         'view' => -35,
       ],
     ];
-    $fields['purchase_date'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['purchase_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     // Source.
     $options = [
@@ -54,7 +54,7 @@ class Seeding extends FarmLogType {
         'view' => -40,
       ],
     ];
-    $fields['source'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['source'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }


### PR DESCRIPTION
Just a few small fixes/improvements after https://www.drupal.org/project/farm/issues/3183372 was merged.

Biggest issue is that the animal sex values are displaying as `M` and `Male`:
![animal_sex_values](https://user-images.githubusercontent.com/3116995/102151243-4cea4400-3e27-11eb-81da-28ba2c0e6a87.png)

I translated some other string labels & descriptions that were missing from various log field definitions. Thought I'd test out the localization and see how things are looking - after enabling Spanish, I'm surprised that not very much is being translated... even "Male" and "Female". Is this because we haven't released a version of farmOS 2.x yet? So technically no translations have been built on Drupal.org for this release of the project?
