### PR TITLE
Issue collecting bundle field definitions

### DIFF
--- a/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
@@ -92,26 +92,36 @@ class FarmEntityFieldTest extends KernelTestBase {
    */
   public function testHookFarmEntityBundleFieldInfo() {
 
-    // Test log field storage definitions.
-    $fields = $this->entityFieldManager->getFieldStorageDefinitions('log');
-    $this->assertArrayHasKey('test_hook_base_field', $fields);
-    $this->assertArrayHasKey('test_hook_bundle_field', $fields);
-    $this->assertArrayHasKey('test_hook_bundle_test_specific_field', $fields);
-    $this->assertArrayHasKey('test_hook_bundle_test_override_specific_field', $fields);
+    // Get the log field storage definitions.
+    $log_storage_definitions = $this->entityFieldManager->getFieldStorageDefinitions('log');
 
-    // Test log field definitions for test logs.
+    // Test that 'test_hook_bundle_field' has a storage definition.
+    $this->assertArrayHasKey('test_hook_bundle_field', $log_storage_definitions);
+
+    // Test fields definitions for the 'test' log type.
     $fields = $this->entityFieldManager->getFieldDefinitions('log', 'test');
-    $this->assertArrayHasKey('test_hook_base_field', $fields);
     $this->assertArrayHasKey('test_hook_bundle_field', $fields);
-    $this->assertArrayHasKey('test_hook_bundle_test_specific_field', $fields);
-    $this->assertArrayNotHasKey('test_hook_bundle_test_override_specific_field', $fields);
 
-    // Test log field definitions for test_override logs.
+    // Test fields definitions for the 'test_override' log type.
     $fields = $this->entityFieldManager->getFieldDefinitions('log', 'test_override');
-    $this->assertArrayHasKey('test_hook_base_field', $fields);
     $this->assertArrayHasKey('test_hook_bundle_field', $fields);
-    $this->assertArrayHasKey('test_hook_bundle_test_override_specific_field', $fields);
-    $this->assertArrayNotHasKey('test_hook_bundle_test_specific_field', $fields);
+
+    // Get all log bundles.
+    /** @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info */
+    $entity_type_bundle_info = $this->container->get('entity_type.bundle.info');
+    $bundles = $entity_type_bundle_info->getBundleInfo('log');
+
+    // Test that all log types have a bundle specific field.
+    foreach (array_keys($bundles) as $bundle) {
+      $fields = $this->entityFieldManager->getFieldDefinitions('log', $bundle);
+      $field_name = 'test_hook_bundle_' . $bundle . '_specific_field';
+
+      // Assert field storage definition exists.
+      $this->assertArrayHasKey($field_name, $log_storage_definitions);
+
+      // Assert field definition for the bundle.
+      $this->assertArrayHasKey($field_name, $fields);
+    }
   }
 
   /**


### PR DESCRIPTION
Just a little bug with the operator that collects all the bundle field definitions from `hook_farm_entity_bundle_field_info()`. Right now only the *last* bundle's fields are being included. I don't think we've noticed this issue because we don't implement this hook in farmOS core (yet??). I added a failing test case that demonstrates this: https://github.com/paul121/farmOS/actions/runs/441518917

The current tests create the *same* fields for both the `test` and `test_override` log bundles which means this bug doesn't cause any problems. It's a bit complicated to replicate in the tests since it requires that we create fields that are only included in some bundles. To simplify this a little, I added a field called `{bundle_name}_specific_field` to each log type, where the field name is unique to the bundle name.

One other change: I expanded `testFarmFields()` to test that `hook_farm_entity_bundle_field_info()` can provide `FieldDefinitions` as well as `FieldStorageDefinitions`. A little confusing, but the hook is invoked in both the `getFieldStorageDefinitions()` and `getFieldDefinitions($bundle)` methods of `FarmEntityBundlePluginHandler`, so this should be possible. This part tripped me up when writing the tests... note that this bug is only affecting the `FieldStorageDefinitions` for logs since the `getFieldDefinitions` method requires the `$bundle` name as an argument, and means the hook is only invoked one time.