### PR TITLE
Standardize method and property visibility to be protected.

### DIFF
--- a/modules/core/api/tests/src/Functional/ConsumerConfigTest.php
+++ b/modules/core/api/tests/src/Functional/ConsumerConfigTest.php
@@ -211,7 +211,7 @@ class ConsumerConfigTest extends OauthTestBase {
    * @return mixed
    *   The JSON parsed response.
    */
-  private function getTokenInfo($access_token) {
+  protected function getTokenInfo($access_token) {
     $response = $this->get(
       $this->tokenDebugUrl,
       [
@@ -230,7 +230,7 @@ class ConsumerConfigTest extends OauthTestBase {
    * @return array
    *   Array of role IDs.
    */
-  private function getClientRoleIds() {
+  protected function getClientRoleIds() {
     return array_map(function ($role) {
       return $role['target_id'];
     }, $this->client->get('roles')->getValue());
@@ -244,7 +244,7 @@ class ConsumerConfigTest extends OauthTestBase {
    *
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
-  private function grantClientRoles(array $role_ids) {
+  protected function grantClientRoles(array $role_ids) {
     $roles = [];
     foreach ($role_ids as $id) {
       $roles[] = ['target_id' => $id];
@@ -262,7 +262,7 @@ class ConsumerConfigTest extends OauthTestBase {
    * @return string
    *   The access token.
    */
-  private function getAccessToken(array $scopes = []) {
+  protected function getAccessToken(array $scopes = []) {
     $valid_payload = [
       'grant_type' => 'password',
       'client_id' => $this->client->get('client_id')->value,

--- a/modules/core/location/src/EventSubscriber/LogPresaveEventSubscriber.php
+++ b/modules/core/location/src/EventSubscriber/LogPresaveEventSubscriber.php
@@ -29,14 +29,14 @@ class LogPresaveEventSubscriber implements EventSubscriberInterface {
    *
    * @var \Drupal\farm_location\AssetLocationInterface
    */
-  private AssetLocationInterface $assetLocation;
+  protected AssetLocationInterface $assetLocation;
 
   /**
    * Cache tag invalidator service.
    *
    * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
    */
-  private CacheTagsInvalidatorInterface $cacheTagsInvalidator;
+  protected CacheTagsInvalidatorInterface $cacheTagsInvalidator;
 
   /**
    * LogPresaveEventSubscriber Constructor.

--- a/modules/core/location/tests/src/Functional/LocationTest.php
+++ b/modules/core/location/tests/src/Functional/LocationTest.php
@@ -201,7 +201,7 @@ class LocationTest extends FarmBrowserTestBase {
    * @param string|null $geometry
    *   The expected geometry.
    */
-  private function assertApiAssetLocationEquals($location_uuid, $geometry) {
+  protected function assertApiAssetLocationEquals($location_uuid, $geometry) {
 
     // Fetch the asset from the API.
     $response = $this->requestApiEntity($this->asset);
@@ -245,7 +245,7 @@ class LocationTest extends FarmBrowserTestBase {
    * @return array
    *   The json-decoded response.
    */
-  private function requestApiEntity(EntityInterface $entity) {
+  protected function requestApiEntity(EntityInterface $entity) {
     $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
     $asset_uri = "base://api/{$entity->getEntityType()->id()}/{$entity->bundle()}/{$entity->uuid()}";
     $response = $this->request('GET', Url::fromUri($asset_uri), $request_options);

--- a/modules/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -25,7 +25,7 @@ class AddEntity extends LocalActionDefault {
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  private $entityTypeManager;
+  protected $entityTypeManager;
 
   /**
    * Constructs an AddEntity object.


### PR DESCRIPTION
Found myself double checking if I should be declaring a property as `private` or `protected` a couple times.. seems like something we can standardize in farmOS core. Overall, it seems like `protected` is the best bet for the sake of inheritance and general extendibility.

https://www.drupal.org/project/drupal/issues/2727011
https://www.php.net/manual/en/language.oop5.visibility.php