### PR TITLE
Make tests much faster with paratest to run tests in parallel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -33,7 +33,9 @@ jobs:
       # so waiting for that lets us know it is safe to start the tests
         run: until [ -f ./www/test-runner-container-fs-ready ]; do sleep 0.1; done
       - name: Run PHPUnit tests
-        run: docker-compose exec -u www-data -T test-runner phpunit --verbose --debug /opt/drupal/web/profiles/farm
+      # The overridden result printer is needed until Drupal 9.2 when the updated version of HtmlOutputPrinter will be available
+      # https://github.com/drupal/drupal/blob/74fbb0aabdee3e1a5da7b8e489a725afdc5824fd/core/tests/Drupal/Tests/Listeners/HtmlOutputPrinter.php
+        run: docker-compose exec -u www-data -T test-runner paratest --functional --passthru='--printer=PHPUnit\\TextUI\\DefaultResultPrinter' --verbose=1 /opt/drupal/web/profiles/farm
       - name: Run PHP CodeSniffer
         run: docker-compose exec -u www-data -T www phpcs /opt/drupal/web/profiles/farm
       - name: Test Drush site install


### PR DESCRIPTION
**Why?** Faster testing leads to faster iteration and faster
overall development.

**How?** Leverage paratest which is - mostly - a drop-in for the
invocation of phpunit.

**Note:** The tests for this PR won't pass until the prerequisite change in https://github.com/farmOS/composer-project/pull/2 is merged.

The most recent 10 builds for farmOS 2.x took an average of 307 seconds for the phpunit step;

```
311s
284s
314s
250s
329s
308s
272s
325s
333s
345s
```

The following two builds demonstrate that it will pass and is faster;

* `189s` https://github.com/symbioquine/farmOS/runs/1690088541?check_suite_focus=true
* `171s` https://github.com/symbioquine/farmOS/runs/1690400928?check_suite_focus=true

Some background on earlier versions of this PR can be found at https://github.com/farmOS/farmOS/pull/378