### PR TITLE
Use a test matrix to run tests and site-install against MariaDB/SQLite/Postgres in parallel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,6 +12,19 @@ jobs:
   build:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dbms:
+         - pgsql
+         - mariadb
+         - sqlite
+        include:
+          - node: pgsql
+            DB_URL: pgsql://farm:farm@db/farm
+          - node: mariadb
+            DB_URL: mysql://farm:farm@db/farm
+          - node: sqlite
+            DB_URL: sqlite://localhost/sites/default/files/db.sqlite
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
@@ -25,8 +38,10 @@ jobs:
       - name: Build farmOS 2.x-dev Docker image
         run: docker build --build-arg FARMOS_REPO=https://github.com/${GITHUB_REPOSITORY} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --build-arg WWW_DATA_ID=33 -t farmos/farmos:2.x-dev docker/dev
       - name: Create docker-compose.yml
-        run: cp docker/docker-compose.testing.yml docker-compose.yml
+        run: cp docker/docker-compose.testing.${{ matrix.dbms }}.yml docker-compose.yml
       - name: Start containers
+        env:
+          DB_URL: ${{ matrix.DB_URL }}
         run: docker-compose up -d
       - name: Wait until test-runner container is ready
       # The test-runner-container-fs-ready file is only created once we expect the containers to be online
@@ -37,4 +52,4 @@ jobs:
       - name: Run PHP CodeSniffer
         run: docker-compose exec -u www-data -T www phpcs /opt/drupal/web/profiles/farm
       - name: Test Drush site install
-        run: docker-compose exec -u www-data -T www drush site-install --db-url=pgsql://farm:farm@db/farm
+        run: docker-compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }}

--- a/docker/docker-compose.testing.mariadb.yml
+++ b/docker/docker-compose.testing.mariadb.yml
@@ -1,0 +1,45 @@
+version: '3'
+services:
+  db:
+    image: mariadb:latest
+    volumes:
+      - './db:/var/lib/mysql'
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: farm
+      MYSQL_DATABASE: farm
+      MYSQL_USER: farm
+      MYSQL_PASSWORD: farm
+
+  www:
+    depends_on:
+      - db
+    image: farmos/farmos:2.x-dev
+    volumes:
+      - './www:/opt/drupal'
+    environment:
+      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/www-container-fs-ready
+
+  test-runner:
+    depends_on:
+      - www
+    image: farmos/farmos:2.x
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        set -e
+        # Wait until the dev farmOS container has finished copying its files
+        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
+        # Wait until Postgres is online listening to its socket
+        while { ! exec 3<>/dev/tcp/db/3306; } > /dev/null 2>&1; do sleep 0.1; done
+        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
+        # file created, allowing the Github action to also wait for the above conditions on the basis
+        # of that file's creation.
+        exec docker-entrypoint.sh apache2-foreground
+    volumes:
+      - './www:/opt/drupal'
+    environment:
+      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/test-runner-container-fs-ready
+      SIMPLETEST_DB: $DB_URL

--- a/docker/docker-compose.testing.pgsql.yml
+++ b/docker/docker-compose.testing.pgsql.yml
@@ -1,0 +1,44 @@
+version: '3'
+services:
+  db:
+    image: postgres:12
+    volumes:
+      - './db:/var/lib/postgresql/data'
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: farm
+      POSTGRES_PASSWORD: farm
+      POSTGRES_DB: farm
+
+  www:
+    depends_on:
+      - db
+    image: farmos/farmos:2.x-dev
+    volumes:
+      - './www:/opt/drupal'
+    environment:
+      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/www-container-fs-ready
+
+  test-runner:
+    depends_on:
+      - www
+    image: farmos/farmos:2.x
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - |
+        set -e
+        # Wait until the dev farmOS container has finished copying its files
+        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
+        # Wait until Postgres is online listening to its socket
+        while { ! exec 3<>/dev/tcp/db/5432; } > /dev/null 2>&1; do sleep 0.1; done
+        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
+        # file created, allowing the Github action to also wait for the above conditions on the basis
+        # of that file's creation.
+        exec docker-entrypoint.sh apache2-foreground
+    volumes:
+      - './www:/opt/drupal'
+    environment:
+      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/test-runner-container-fs-ready
+      SIMPLETEST_DB: $DB_URL

--- a/docker/docker-compose.testing.sqlite.yml
+++ b/docker/docker-compose.testing.sqlite.yml
@@ -1,19 +1,6 @@
 version: '3'
 services:
-  db:
-    image: postgres:12
-    volumes:
-      - './db:/var/lib/postgresql/data'
-    ports:
-      - '5432:5432'
-    environment:
-      POSTGRES_USER: farm
-      POSTGRES_PASSWORD: farm
-      POSTGRES_DB: farm
-
   www:
-    depends_on:
-      - db
     image: farmos/farmos:2.x-dev
     volumes:
       - './www:/opt/drupal'
@@ -31,8 +18,6 @@ services:
         set -e
         # Wait until the dev farmOS container has finished copying its files
         until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
-        # Wait until Postgres is online listening to its socket
-        while { ! exec 3<>/dev/tcp/db/5432; } > /dev/null 2>&1; do sleep 0.1; done
         # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
         # file created, allowing the Github action to also wait for the above conditions on the basis
         # of that file's creation.
@@ -41,3 +26,4 @@ services:
       - './www:/opt/drupal'
     environment:
       FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/test-runner-container-fs-ready
+      SIMPLETEST_DB: $DB_URL

--- a/docs/development/environment/tests.md
+++ b/docs/development/environment/tests.md
@@ -24,7 +24,9 @@ for [debugging](/development/environment/debug), but is also slower. One way to 
 XDebug is to run the tests via the prod farmOS image.
 
 The automated tests which run upon Github check-in follow this strategy which is
-orchestrated via [run-tests.yml] and [docker-compose.testing.yml].
+orchestrated via [run-tests.yml] and a docker-compose file like
+[docker-compose.testing.pgsql.yml] - corresponding files also exist for [MariaDB] and
+[SQLite].
 
 Something similar can be accomplished locally by adding an additional container to one's
 dev environment using the `farmos/farmos:2.x` image and mounting the same volume from the
@@ -59,6 +61,8 @@ mounted to `/opt/drupal` such that user id 33 can access them
 * Rebuild the dev docker image to also use 33 as the user id of the `www-data` user
 
 [run-tests.yml]: https://raw.githubusercontent.com/farmOS/farmOS/2.x/.github/workflows/run-tests.yml
-[docker-compose.testing.yml]: https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.testing.yml
+[docker-compose.testing.pgsql.yml]: https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.testing.pgsql.yml
+[MariaDB]: https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.testing.mariadb.yml
+[SQLite]: https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.testing.sqlite.yml
 [docker-compose.development.yml]: https://raw.githubusercontent.com/farmOS/farmOS/2.x/docker/docker-compose.development.yml
 


### PR DESCRIPTION
**Why?** Detect if things break on specific DBMS' and have ongoing proof
that the top DB options work with farmOS.