### PR TITLE
Improvements to GH action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,15 +15,23 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set FARMOS_VERSION environment variable
-        run: echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for push event.
+        if: ${{ !github.event.pull_request }}
+        run: |
+          echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+          echo "FARMOS_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for pull request event.
+        if: ${{ github.event.pull_request }}
+        run: |
+          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
       - name: Build farmOS 2.x Docker image
-        run: docker build --build-arg FARMOS_REPO=https://github.com/${GITHUB_REPOSITORY} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x docker
+        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x docker
       # This builds the dev Docker image using the specified FARMOS_VERSION,
       # but notably it does NOT override the default PROJECT_VERSION, so the
       # farmOS Composer project 2.x branch is always used.
       - name: Build farmOS 2.x-dev Docker image
-        run: docker build --build-arg FARMOS_REPO=https://github.com/${GITHUB_REPOSITORY} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --build-arg WWW_DATA_ID=33 -t farmos/farmos:2.x-dev docker/dev
+        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --build-arg WWW_DATA_ID=33 -t farmos/farmos:2.x-dev docker/dev
       - name: Create docker-compose.yml
         run: cp docker/docker-compose.testing.yml docker-compose.yml
       - name: Start containers

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,12 +18,12 @@ jobs:
       - name: Set FARMOS_VERSION for push event.
         if: ${{ !github.event.pull_request }}
         run: |
-          echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+          echo "FARMOS_VERSION=${GITHUB_REF:11}#${GITHUB_SHA}" >> $GITHUB_ENV
           echo "FARMOS_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
       - name: Set FARMOS_VERSION for pull request event.
         if: ${{ github.event.pull_request }}
         run: |
-          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}#${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
       - name: Build farmOS 2.x Docker image
         run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x docker

--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -23,12 +23,12 @@ git reset --hard
 # Replace the farmOS repository and version in composer.json.
 # If FARMOS_VERSION is a valid semantic versioning string, we assume that it is
 # a tagged version, and replace the entire version string in composer.json.
-# Or, if FARMOS_VERSION is not "2.x", we assume that it is a branch, and
+# Or, if FARMOS_VERSION is "2.x-*", we assume that it is a branch, and
 # prepend it with "dev-". Otherwise (FARMOS_VERSION is "2.x"), do nothing.
 sed -i 's|"repositories": \[|"repositories": \[ {"type": "git", "url": "'"${FARMOS_REPO}"'"},|g' composer.json
 if [[ "${FARMOS_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
   sed -i 's|"farmos/farmos": "2.x-dev"|"farmos/farmos": "'"${FARMOS_VERSION}"'"|g' composer.json
-elif ! [ "${FARMOS_VERSION}" = "2.x" ]; then
+elif [[ "${FARMOS_VERSION}" = "2.x-"* ]]; then
   sed -i 's|"farmos/farmos": "2.x-dev"|"farmos/farmos": "dev-'"${FARMOS_VERSION}"'"|g' composer.json
 fi
 

--- a/tests/src/Functional/FarmTest.php
+++ b/tests/src/Functional/FarmTest.php
@@ -14,6 +14,9 @@ class FarmTest extends FarmBrowserTestBase {
    */
   public function testFarm() {
 
+    // Testing GH action. This should break.
+    $this->assertEquals(0, 1);
+
     // Test that the profile was installed.
     $this->assertSame($this->profile, $this->container->getParameter('install_profile'));
 


### PR DESCRIPTION
- Use the correct HEAD ref for pull requests. On pull requests `GITHUB_REF` = `refs/pull/{number}/`, which sets `FARMOS_VERSION` to an incorrect branch name.
- Specify the SHA that triggered the event so that the tests are run against that specific commit. Currently, tests checkout the HEAD of the target branch, which is problematic if multiple commits are pushed before the test has finished building the docker images. This is useful for pushing a commit that should result in a failing test, followed by a commit that fixes the test.

Some references just because this was a little confusing to figure out:
- Environment variables: https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables
- Contexts and expressions: https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#about-contexts-and-expressions