### PR TITLE
Bump drupal/config_rewrite to v1.4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^2.4",
         "drupal/core": "~9.1.2",
-        "drupal/config_rewrite": "^1.3",
+        "drupal/config_rewrite": "^1.4",
         "drupal/csv_serialization": "^2.0@beta",
         "drupal/date_popup": "^1.1",
         "drupal/entity_reference_integrity": "^1.0@RC",
@@ -46,9 +46,6 @@
             "drupal/core": "-p2"
         },
         "patches": {
-            "drupal/config_rewrite": {
-                "Issue #3166694: Make config_rewrite/tests/modules compatible with Drupal 9": "https://www.drupal.org/files/issues/2020-08-22/3166694-2.patch"
-            },
             "drupal/core": {
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2020-10-12/2339235_60.patch"
             },


### PR DESCRIPTION
Our patch is not applying with the latest release of config_rewrite, breaking tests.

The release notes don't mention it, but `Issue #3166694: Make config_rewrite/tests/modules compatible with Drupal 9` was included in the 1.4 release as well!

https://www.drupal.org/project/config_rewrite/releases/8.x-1.4