### PR TITLE
Fix issue with broken links in asset map popup

### DIFF
--- a/modules/farm/farm_movement/farm_movement.views_default.inc
+++ b/modules/farm/farm_movement/farm_movement.views_default.inc
@@ -350,6 +350,7 @@ function farm_movement_views_default_views() {
   $handler->display->display_options['fields']['id']['table'] = 'farm_asset';
   $handler->display->display_options['fields']['id']['field'] = 'id';
   $handler->display->display_options['fields']['id']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['id']['separator'] = '';
   /* Field: Field: Geometry */
   $handler->display->display_options['fields']['field_farm_geofield']['id'] = 'field_farm_geofield';
   $handler->display->display_options['fields']['field_farm_geofield']['table'] = 'field_data_field_farm_geofield';


### PR DESCRIPTION
**Why?** When assets don't have a URL alias and have an id
greater than 1000, the link to those assets was getting rendered
with a comma in the map popup, which breaks the link - often leading
to the wrong asset like `/farm/asset/1` instead of `/farm/asset/1234`.