### PR TITLE
Run tests daily.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,5 +1,7 @@
 name: Run 2.x PHPUnit tests
 on:
+  schedule:
+    - cron: '0 8 * * *' # Run at 8AM UTC.
   push:
     branches:
       - '2.x'


### PR DESCRIPTION
Simple change to run the 2.x tests every day at 8AM UTC.

The catch is that the `on.scheduled` configuration is only used for default branch in a repository. So this won't work for farmOS/farmOS until we make 2.x the default, but if I specify 2.x as the default branch in my paul121/farmOS fork the scheduled event still works there! This seems good enough for now.

My past workflows filtered by the "scheduled" event (I ran them hourly to test that it was working): https://github.com/paul121/farmOS/actions?query=event%3Aschedule

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events