### PR TITLE
Auto create taxonomy term references

### DIFF
--- a/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
@@ -26,6 +26,7 @@ class Animal extends FarmAssetType {
         'description' => $this->t("Enter this animal asset's species/breed."),
         'target_type' => 'taxonomy_term',
         'target_bundle' => 'animal_type',
+        'auto_create_bundle' => 'animal_type',
         'required' => TRUE,
         'weight' => [
           'form' => -90,

--- a/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
+++ b/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
@@ -26,7 +26,7 @@ class Plant extends FarmAssetType {
         'description' => "Enter this plant asset's crop/variety.",
         'target_type' => 'taxonomy_term',
         'target_bundle' => 'plant_type',
-        'auto_create' => TRUE,
+        'auto_create_bundle' => 'plant_type',
         'required' => TRUE,
         'multiple' => TRUE,
         'weight' => [
@@ -40,7 +40,7 @@ class Plant extends FarmAssetType {
         'description' => $this->t('Assign this to a season for easier searching later.'),
         'target_type' => 'taxonomy_term',
         'target_bundle' => 'season',
-        'auto_create' => TRUE,
+        'auto_create_bundle' => 'season',
         'multiple' => TRUE,
         'weight' => [
           'form' => -50,

--- a/modules/core/entity/farm_entity.base_fields.inc
+++ b/modules/core/entity/farm_entity.base_fields.inc
@@ -114,8 +114,11 @@ function farm_entity_log_base_fields() {
       'target_bundle' => 'log_category',
       'multiple' => TRUE,
       'weight' => [
-        'form' => 10,
         'view' => 80,
+      ],
+      'form_display_options' => [
+        'type' => 'options_select',
+        'weight' => 10,
       ],
     ],
     'data' => [

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -179,6 +179,14 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
     // Make the form and view displays configurable.
     $field->setDisplayConfigurable('form', TRUE);
     $field->setDisplayConfigurable('view', TRUE);
+
+    // Override form and view display options, if specified.
+    foreach (['form', 'view'] as $display_type) {
+      $key = $display_type . '_display_options';
+      if (isset($options[$key])) {
+        $field->setDisplayOptions($display_type, $options[$key]);
+      }
+    }
   }
 
   /**

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -320,6 +320,13 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
           'auto_create' => FALSE,
           'auto_create_bundle' => '',
         ];
+
+        // Auto create term reference if auto_create_bundle is provided.
+        if (!empty($options['auto_create_bundle'])) {
+          $handler_settings['auto_create'] = TRUE;
+          $handler_settings['auto_create_bundle'] = $options['auto_create_bundle'];
+        }
+
         $form_display_options = [
           'type' => 'entity_reference_autocomplete',
           'weight' => $options['weight']['form'] ?? 0,

--- a/modules/log/input/src/Plugin/Log/LogType/Input.php
+++ b/modules/log/input/src/Plugin/Log/LogType/Input.php
@@ -39,6 +39,7 @@ class Input extends FarmLogType {
       'description' => $this->t('What materials are being applied?'),
       'target_type' => 'taxonomy_term',
       'target_bundle' => 'material',
+      'auto_create_bundle' => 'material',
       'multiple' => TRUE,
       'weight' => [
         'form' => -50,


### PR DESCRIPTION
- Support the `auto_create` and `auto_create_bundle` fields via FarmFieldFactory
- Auto create animal asset animal_type terms
- Auto create plant asset plant_type terms
- Auto create input log material terms

I think these are the only taxonomy term references we want to auto create? Maybe include the plant_type.crop_family?

Log category was a `list_item` field in 1.x, but right now it is an auto complete field in 2.x. This is a little confusing, because it seems like you could auto create a lot category. Shall we change this?