### PR TITLE
Fix quantity queries in migration to avoid extraneous rows

### DIFF
--- a/modules/core/migrate/src/Plugin/migrate/source/d7/Quantity.php
+++ b/modules/core/migrate/src/Plugin/migrate/source/d7/Quantity.php
@@ -22,20 +22,24 @@ class Quantity extends FieldableEntity {
     $query->addField('fci', 'item_id', 'id');
 
     // Join in the measure value.
-    $query->leftJoin('field_data_field_farm_quantity_measure', 'fdffqm', 'fci.item_id = fdffqm.entity_id');
+    $query->leftJoin('field_data_field_farm_quantity_measure', 'fdffqm',
+      "fci.item_id = fdffqm.entity_id AND fdffqm.entity_type = 'field_collection_item' AND fdffqm.bundle = 'field_farm_quantity' AND fdffqm.deleted = '0'");
     $query->addField('fdffqm', 'field_farm_quantity_measure_value', 'measure');
 
     // Join in the numerator and denominator values.
-    $query->leftJoin('field_data_field_farm_quantity_value', 'fdffqv', 'fci.item_id = fdffqv.entity_id');
+    $query->leftJoin('field_data_field_farm_quantity_value', 'fdffqv',
+      "fci.item_id = fdffqv.entity_id AND fdffqv.entity_type = 'field_collection_item' AND fdffqv.bundle = 'field_farm_quantity' AND fdffqv.deleted = '0'");
     $query->addField('fdffqv', 'field_farm_quantity_value_numerator', 'value_numerator');
     $query->addField('fdffqv', 'field_farm_quantity_value_denominator', 'value_denominator');
 
     // Join in the units value.
-    $query->leftJoin('field_data_field_farm_quantity_units', 'fdffqu', 'fci.item_id = fdffqu.entity_id');
+    $query->leftJoin('field_data_field_farm_quantity_units', 'fdffqu',
+      "fci.item_id = fdffqu.entity_id AND fdffqu.entity_type = 'field_collection_item' AND fdffqu.bundle = 'field_farm_quantity' AND fdffqu.deleted = '0'");
     $query->addField('fdffqu', 'field_farm_quantity_units_tid', 'units');
 
     // Join in the label value.
-    $query->leftJoin('field_data_field_farm_quantity_label', 'fdffql', 'fci.item_id = fdffql.entity_id');
+    $query->leftJoin('field_data_field_farm_quantity_label', 'fdffql',
+      "fci.item_id = fdffql.entity_id AND fdffql.entity_type = 'field_collection_item' AND fdffql.bundle = 'field_farm_quantity' AND fdffql.deleted = '0'");
     $query->addField('fdffql', 'field_farm_quantity_label_value', 'label');
 
     // Join in the log table to get the uid.


### PR DESCRIPTION
**Why?** Drupal 7 allows field re-use which means there may
be extra unrelated rows in addition to the ones pertaining
to the core logs.

More context available at https://farmos.discourse.group/t/symbioquines-2-x-migration-testing-log/660/11?u=symbioquine