### PR TITLE
Add support for drush site:install profile arguments

### DIFF
--- a/farm.install
+++ b/farm.install
@@ -68,7 +68,7 @@ function farm_install_modules(array &$install_state) {
 
   // Assemble the batch operation for installing modules.
   $operations = [];
-  foreach ($modules as $module => $weight) {
+  foreach ($modules as $module) {
     $operations[] = [
       '_farm_install_module_batch',
       [

--- a/farm.install
+++ b/farm.install
@@ -5,6 +5,8 @@
  * Install, update and uninstall functions for the farmOS installation profile.
  */
 
+use Drupal\Component\Serialization\Json;
+
 /**
  * Implements hook_install_tasks().
  */
@@ -51,9 +53,17 @@ function farm_install_tasks_alter(&$tasks, $install_state) {
  */
 function farm_install_modules(array &$install_state) {
 
-  // Load the list of modules that should be installed. This state is set by
-  // the \Drupal\farm\Form\FarmModulesForm submit method.
-  $modules = \Drupal::state()->get('farm.install_modules') ?: [];
+  // Load the list of modules that should be installed.
+  // If provided, use the modules defined in farm_install_modules.module
+  // profile arguments.
+  if (!empty($install_state['forms']['farm_install_modules']['modules'])) {
+    $modules = Json::decode($install_state['forms']['farm_install_modules']['modules']);
+  }
+
+  // Use the state set by the \Drupal\farm\Form\FarmModulesForm submit method.
+  else {
+    $modules = \Drupal::state()->get('farm.install_modules') ?: [];
+  }
 
   // If this is running in the context of a functional test, do not install any
   // additional modules. This is a temporary hack.

--- a/src/Form/FarmModulesForm.php
+++ b/src/Form/FarmModulesForm.php
@@ -115,7 +115,8 @@ class FarmModulesForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $modules = array_filter($form_state->getValue('modules'));
+    // Build array of module names to install.
+    $modules = array_values(array_filter($form_state->getValue('modules')));
     $this->state->set('farm.install_modules', $modules);
   }
 


### PR DESCRIPTION
Currently all of the default modules are installed when using `drush site:install farm`. This would allow specifying only certain modules to be installed with a `farm_install_modules.modules` profile argument ([drush docs](https://drushcommands.com/drush-9x/site/site:install/))

Example usage:

```bash
drush site:install farm farm_install_modules.modules='["farm_observation", "farm_land", "farm_ui"]'
```

Since Drush only supports strings, numeric and NULL values to be supplied in this way, the `modules` variable is expected to be a JSON array of module names encoded as a string.

I didn't add any error handling here... an invalid string, JSON structure, or invalid module name might cause errors. But since Drupal has already been installed, I'm not sure if we can fail gracefully anyways. If this value is somehow being provided by users, extra care should be taken to ensure it is OK before being used.