### PR TITLE
Simplify adding farmOS repository to composer.json.

### DIFF
--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -20,12 +20,14 @@ rm -rf project
 git checkout ${PROJECT_VERSION}
 git reset --hard
 
+# Add the farmOS repository to composer.json.
+composer config repositories.farmos git ${FARMOS_REPO}
+
 # Replace the farmOS repository and version in composer.json.
 # If FARMOS_VERSION is a valid semantic versioning string, we assume that it is
 # a tagged version, and replace the entire version string in composer.json.
 # Or, if FARMOS_VERSION is not "2.x", we assume that it is a branch, and
 # prepend it with "dev-". Otherwise (FARMOS_VERSION is "2.x"), do nothing.
-sed -i 's|"repositories": \[|"repositories": \[ {"type": "git", "url": "'"${FARMOS_REPO}"'"},|g' composer.json
 if [[ "${FARMOS_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
   sed -i 's|"farmos/farmos": "2.x-dev"|"farmos/farmos": "'"${FARMOS_VERSION}"'"|g' composer.json
 elif ! [ "${FARMOS_VERSION}" = "2.x" ]; then


### PR DESCRIPTION
Just learned that composer has a command for updating the repositories in composer.json via the cli: https://getcomposer.org/doc/03-cli.md#modifying-repositories

The `repositories` section of `composer.json` can either be a simple array or an object with key/value pairs for each repository. Using this command changes the repositories to an object and adds a `farmos` key. Using keys makes it easier to modify the composer.json project file in scripts later on.

I was hoping we could modify the `requires: farmos/farmos {FARMOS_VERSION}` in a similar way, but the `composer config` command doesn't work here. We'd have to use `composer require` which ends up installing everything. Composer v2 has a `composer require --no-install` option that JUST builds the `composer.lock` file. That might work in the future.