### PR TITLE
Add support for Pi

### DIFF
--- a/docker/docker-compose-development-pi.yml
+++ b/docker/docker-compose-development-pi.yml
@@ -1,0 +1,24 @@
+version: '2'
+services:
+  db:
+    image: jsurf/rpi-mariadb
+    volumes:
+      - './db:/var/lib/mysql'
+    ports:
+      - '3306:3306'
+    environment:
+      MYSQL_ROOT_PASSWORD: farm
+      MYSQL_DATABASE: farm
+      MYSQL_USER: farm
+      MYSQL_PASSWORD: farm
+
+  www:
+    depends_on:
+      - db
+    image: frakman1/farmos-dev-pi:latest
+    volumes:
+      - './www:/var/www/html'
+    ports:
+      - '80:80'
+    environment:
+      XDEBUG_CONFIG: remote_host=172.17.0.1


### PR DESCRIPTION
Used `buildx` option to `docker build` to support following architectures:

linux/amd64
linux/arm/v7
linux/arm64

Base Image can be found here:
https://hub.docker.com/r/frakman1/farmos-base-pi

Dev Image built based on Base Image above can be found here:
https://hub.docker.com/r/frakman1/farmos-dev-pi

Then used that in docker-compose-development-pi.yml