### PR TITLE
Fixes "Warning divion by Zero" : https://github.com/farmOS/farmOS/issues/396

### DIFF
--- a/modules/farm/farm_livestock/farm_livestock_weight/farm_livestock_weight.module
+++ b/modules/farm/farm_livestock/farm_livestock_weight/farm_livestock_weight.module
@@ -132,6 +132,11 @@ function farm_livestock_weight_dlwg($asset) {
       // Calculate time difference.
       $timediff = $latest_log->timestamp - $previous_log->timestamp;
       $timediff_days = round($timediff/86400,2);
+      
+      // When multiple inputs are entered on a single day, round $timediff_days up to 1.
+      if ($timediff_days == 0) {
+        $timediff_days = 1;
+      }
 
       // Calculate dlwg.
       $dlwg_value = round($weight_difference/$timediff_days,3);


### PR DESCRIPTION
If there are multiple inputs entered on a single day, $timediff_days will round down to 0. This causes a division-by-0 error when $dlwg_value is calculated. This change makes it so that a $timediff_days value of 0 is rounded up to 1 in order to avoid the previously mentioned issue.