### PR TITLE
Upgrade to farmOS-map 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "drupal/token": "^1.7",
         "drupal/views_geojson": "^1.1",
         "drush/drush": "^10.3",
-        "npm-asset/farmos.org--farmos-map": "^1.4",
+        "npm-asset/farmos.org--farmos-map": ">2.0.0-alpha.0",
         "phayes/geophp": "^1.2"
     },
     "extra": {

--- a/modules/core/map/farm_map.libraries.yml
+++ b/modules/core/map/farm_map.libraries.yml
@@ -6,7 +6,13 @@ farmOS-map:
     gpl-compatible: true
   js:
     /libraries/farmOS-map/dist/farmOS-map.js:
+      # Skip aggregating farmOS-map.js with other JS since that
+      # breaks the lazy loading of behavior chunks.
+      preprocess: false
       minified: true
+  css:
+    theme:
+      /libraries/farmOS-map/dist/farmOS-map.css: { }
   dependencies:
     - core/drupalSettings
 

--- a/modules/core/map/js/farmOS.map.behaviors.geofield.js
+++ b/modules/core/map/js/farmOS.map.behaviors.geofield.js
@@ -1,9 +1,10 @@
 (function () {
   farmOS.map.behaviors.geofield = {
     attach: function (instance) {
-      instance.edit.wktOn('featurechange', function(wkt) {
-        console.log('here!');
-        document.querySelector('#' + instance.target).parentElement.querySelector('textarea').value = wkt;
+      instance.editAttached.then(() => {
+        instance.edit.wktOn('featurechange', function(wkt) {
+          document.querySelector('#' + instance.target).parentElement.querySelector('textarea').value = wkt;
+        });
       });
     },
 

--- a/modules/core/map/js/farmOS.map.behaviors.popup.js
+++ b/modules/core/map/js/farmOS.map.behaviors.popup.js
@@ -46,6 +46,7 @@
         }
         return content;
       });
-    }
+    },
+    weight: 100,
   };
 }());

--- a/modules/core/map/js/farmOS.map.behaviors.wkt.js
+++ b/modules/core/map/js/farmOS.map.behaviors.wkt.js
@@ -17,29 +17,38 @@
         var layer = instance.addLayer(type, opts);
       }
 
+      // Variable used to track the layer to add measurements to and to zoom in on.
+      // It is either immediately the layer created with passed-in WKT data or is later
+      // resolved to the edit layer once the edit behavior is fully attached.
+      var focusLayerPromise = Promise.resolve(layer);
+
       // If edit is true, enable drawing controls.
       if (drupalSettings.farm_map[instance.target].behaviors.wkt.edit) {
         if (layer !== undefined) {
-          instance.addBehavior('edit', { layer: layer });
+          instance.editAttached = instance.addBehavior('edit', { layer: layer });
         } else {
-          instance.addBehavior('edit');
-          var layer = instance.edit.layer;
+          instance.editAttached = instance.addBehavior('edit');
+          // Focus on the edit layer if no layer was provided
+          focusLayerPromise = instance.editAttached
+            .then(() => instance.edit.layer);
         }
 
         // Add the snappingGrid behavior.
         instance.addBehavior('snappingGrid');
       }
 
-      // Enable the line/polygon measure behavior.
-      instance.addBehavior('measure', { layer: layer });
+      focusLayerPromise.then(focusLayer => {
+        // Enable the line/polygon measure behavior.
+        instance.addBehavior('measure', { layer: focusLayer });
 
-      // If the layer has features, zoom to them.
-      // Otherwise, zoom to all vectors.
-      if (layer !== undefined) {
-        instance.zoomToLayer(layer);
-      } else {
-        instance.zoomToVectors();
-      }
+        // If the layer has features, zoom to them.
+        // Otherwise, zoom to all vectors.
+        if (focusLayer !== undefined) {
+          instance.zoomToLayer(focusLayer);
+        } else {
+          instance.zoomToVectors();
+        }
+      });
     },
     weight: 100,
   };

--- a/modules/ui/map/js/farmOS.map.behaviors.asset_type_layers.js
+++ b/modules/ui/map/js/farmOS.map.behaviors.asset_type_layers.js
@@ -104,6 +104,9 @@
             });
         }
       });
-    }
+    },
+
+    // Make sure this runs after farmOS.map.behaviors.popup.
+    weight: 101,
   };
 }());


### PR DESCRIPTION
**Note:** This change must be merged after we tag the first farmOS-map 2.x release, otherwise the built won't be able to find the right version in NPM.

**Why?** farmOS-map 2.x provides a slightly cleaner API and more modular/extensible behavior loading.