### PR TITLE
2.x Create FarmMapPrototype element to support JS map creation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "drupal/token": "^1.7",
         "drupal/views_geojson": "^1.1",
         "drush/drush": "^10.3",
-        "npm-asset/farmos.org--farmos-map": "^1.4",
+        "npm-asset/farmos.org--farmos-map": "^2",
         "phayes/geophp": "^1.2"
     },
     "extra": {

--- a/modules/core/map/farm_map.libraries.yml
+++ b/modules/core/map/farm_map.libraries.yml
@@ -6,7 +6,13 @@ farmOS-map:
     gpl-compatible: true
   js:
     /libraries/farmOS-map/dist/farmOS-map.js:
+      # Skip aggregating farmOS-map.js with other JS since that
+      # breaks the lazy loading of behavior chunks.
+      preprocess: false
       minified: true
+  css:
+    theme:
+      /libraries/farmOS-map/dist/farmOS-map.css: { }
   dependencies:
     - core/drupalSettings
 

--- a/modules/core/map/js/farmOS.map.behaviors.geofield.js
+++ b/modules/core/map/js/farmOS.map.behaviors.geofield.js
@@ -1,9 +1,10 @@
 (function () {
   farmOS.map.behaviors.geofield = {
     attach: function (instance) {
-      instance.edit.wktOn('featurechange', function(wkt) {
-        console.log('here!');
-        document.querySelector('#' + instance.target).parentElement.querySelector('textarea').value = wkt;
+      instance.editAttached.then(() => {
+        instance.edit.wktOn('featurechange', function(wkt) {
+          document.querySelector('#' + instance.target).parentElement.querySelector('textarea').value = wkt;
+        });
       });
     },
 

--- a/modules/core/map/js/farmOS.map.behaviors.geofield.js
+++ b/modules/core/map/js/farmOS.map.behaviors.geofield.js
@@ -3,7 +3,7 @@
     attach: function (instance) {
       instance.editAttached.then(() => {
         instance.edit.wktOn('featurechange', function(wkt) {
-          document.querySelector('#' + instance.target).parentElement.querySelector('textarea').value = wkt;
+          instance.map.getTargetElement().parentElement.querySelector('textarea').value = wkt;
         });
       });
     },

--- a/modules/core/map/js/farmOS.map.behaviors.wkt.js
+++ b/modules/core/map/js/farmOS.map.behaviors.wkt.js
@@ -17,29 +17,35 @@
         var layer = instance.addLayer(type, opts);
       }
 
+      var focusLayerPromise = Promise.resolve(layer);
+
       // If edit is true, enable drawing controls.
       if (drupalSettings.farm_map[instance.target].behaviors.wkt.edit) {
         if (layer !== undefined) {
-          instance.addBehavior('edit', { layer: layer });
+          instance.editAttached = instance.addBehavior('edit', { layer: layer });
         } else {
-          instance.addBehavior('edit');
-          var layer = instance.edit.layer;
+          instance.editAttached = instance.addBehavior('edit');
+          // Focus on the edit layer if no layer was provided
+          focusLayerPromise = instance.editAttached
+            .then(() => instance.edit.layer);
         }
 
         // Add the snappingGrid behavior.
         instance.addBehavior('snappingGrid');
       }
 
-      // Enable the line/polygon measure behavior.
-      instance.addBehavior('measure', { layer: layer });
+      focusLayerPromise.then(focusLayer => {
+        // Enable the line/polygon measure behavior.
+        instance.addBehavior('measure', { layer: focusLayer });
 
-      // If the layer has features, zoom to them.
-      // Otherwise, zoom to all vectors.
-      if (layer !== undefined) {
-        instance.zoomToLayer(layer);
-      } else {
-        instance.zoomToVectors();
-      }
+        // If the layer has features, zoom to them.
+        // Otherwise, zoom to all vectors.
+        if (focusLayer !== undefined) {
+          instance.zoomToLayer(focusLayer);
+        } else {
+          instance.zoomToVectors();
+        }
+      });
     },
     weight: 100,
   };

--- a/modules/core/map/js/farmOS.map.behaviors.wkt.js
+++ b/modules/core/map/js/farmOS.map.behaviors.wkt.js
@@ -2,9 +2,11 @@
   farmOS.map.behaviors.wkt = {
     attach: function (instance) {
 
+      const settings = drupalSettings.farm_map[instance.drupalSettingsKey] || {};
+
       // If WKT was set, create a layer.
-      if (drupalSettings.farm_map[instance.target].wkt) {
-        var wkt = drupalSettings.farm_map[instance.target].wkt;
+      if (settings.wkt) {
+        var wkt = drupalSettings.farm_map[instance.drupalSettingsKey].wkt;
         var type = 'vector';
         var opts = {
           title: 'Geometry',
@@ -20,7 +22,7 @@
       var focusLayerPromise = Promise.resolve(layer);
 
       // If edit is true, enable drawing controls.
-      if (drupalSettings.farm_map[instance.target].behaviors.wkt.edit) {
+      if (settings.behaviors && settings.behaviors.wkt && settings.behaviors.wkt.edit) {
         if (layer !== undefined) {
           instance.editAttached = instance.addBehavior('edit', { layer: layer });
         } else {

--- a/modules/core/map/js/farm_map.js
+++ b/modules/core/map/js/farm_map.js
@@ -2,62 +2,17 @@
   Drupal.behaviors.farm_map = {
     attach: function (context, settings) {
 
-      // Get the units.
-      let units = 'metric';
-      if (!!drupalSettings.farm_map.units) {
-        units = drupalSettings.farm_map.units;
-      }
-
-      // Build default options.
-      const defaultOptions = {
-        units,
-        interactions: {
-          onFocusOnly: true
-        },
-      };
       context.querySelectorAll('.farm-map').forEach(function (element) {
 
-        // Only create a map once per element.
-        if (element.getAttribute('processed')) return;
-        element.setAttribute('processed', true);
+          // Only create a map once per element.
+          if (element.getAttribute('processed')) return;
+          element.setAttribute('processed', true);
 
-        element.setAttribute('tabIndex', 0);
-        const mapId = element.getAttribute('id');
-        const mapOptions = { ...defaultOptions, ...drupalSettings.farm_map[mapId].instance};
-        const instance = farmOS.map.create(mapId, mapOptions);
-        context.querySelectorAll('.ol-popup-closer').forEach(function (element) {
-          element.onClick = function (element) {
-            element.focus();
-          };
-        });
+          element.setAttribute('tabIndex', 0);
 
-        // If the map is rendered as part of a form field, update the map size
-        // when the field's visible state changes,
-        const formWrapper = element.closest('div.form-wrapper');
-        if (formWrapper != null) {
-          const formWrapperObserver = new MutationObserver((mutations) => {
-
-            // Only update the map size if the wrapper was previously hidden.
-            if (mutations.some((mutation) => { return mutation.oldValue.includes('display: none')})) {
-              instance.map.updateSize();
-            }
-          });
-
-          // Observe the style attribute.
-          formWrapperObserver.observe(formWrapper, {
-            attributeFilter: ["style"],
-            attributeOldValue: true
-          })
-        }
-
-        // If the map is inside a details element, update the map size when
-        // the details element is toggled.
-        const details = element.closest('details');
-        if (details != null) {
-          details.addEventListener('toggle', function() {
-            instance.map.updateSize();
-          });
-        }
+          const mapId = element.getAttribute('id');
+          const mapInstanceOptions = {};
+          Drupal.behaviors.farm_map.createMapInstance(context, element, mapId, mapInstanceOptions);
       });
 
       // Add an event listener to update the map size when the Gin toolbar is toggled.
@@ -79,6 +34,69 @@
           }
         });
       }
+
+    },
+
+    createMapInstance: function(context, element, drupalSettingsKey, mapInstanceOptions) {
+
+      // Get the units.
+      let units = 'metric';
+      if (!!drupalSettings.farm_map.units) {
+        units = drupalSettings.farm_map.units;
+      }
+
+      // Build default options.
+      const defaultOptions = {
+        units,
+        interactions: {
+          onFocusOnly: true
+        },
+      };
+
+      const mapOptions = {
+        ...defaultOptions,
+        ...drupalSettings.farm_map[drupalSettingsKey].instance,
+        ...mapInstanceOptions
+      };
+      const instance = farmOS.map.create(element, mapOptions);
+      instance.drupalSettingsKey = drupalSettingsKey;
+
+      context.querySelectorAll('.ol-popup-closer').forEach(function (element) {
+        element.onClick = function (element) {
+          element.focus();
+        };
+      });
+
+      // If the map is rendered as part of a form field, update the map size
+      // when the field's visible state changes,
+      const formWrapper = element.closest('div.form-wrapper');
+      if (formWrapper != null) {
+        const formWrapperObserver = new MutationObserver((mutations) => {
+
+          // Only update the map size if the wrapper was previously hidden.
+          if (mutations.some((mutation) => { return mutation.oldValue.includes('display: none')})) {
+            instance.map.updateSize();
+          }
+        });
+
+        // Observe the style attribute.
+        formWrapperObserver.observe(formWrapper, {
+          attributeFilter: ["style"],
+          attributeOldValue: true
+        })
+      }
+
+      // If the map is inside a details element, update the map size when
+      // the details element is toggled.
+      const details = element.closest('details');
+      if (details != null) {
+        details.addEventListener('toggle', function() {
+          instance.map.updateSize();
+        });
+      }
+
+      return instance;
     }
+
   };
 }(Drupal));

--- a/modules/core/map/src/Element/FarmMapPrototype.php
+++ b/modules/core/map/src/Element/FarmMapPrototype.php
@@ -6,11 +6,13 @@ use Drupal\Core\Render\Element\RenderElement;
 use Drupal\farm_map\Traits\PreRenderableMapTrait;
 
 /**
- * Provides a farm_map render element.
+ * Provides a farm_map_prototype render element - that is
+ * an element that will be used from Javascript as a prototype
+ * of the element upon which to instantiate map instances.
  *
- * @RenderElement("farm_map")
+ * @RenderElement("farm_map_prototype")
  */
-class FarmMap extends RenderElement {
+class FarmMapPrototype extends RenderElement {
 
   use PreRenderableMapTrait;
 
@@ -29,22 +31,22 @@ class FarmMap extends RenderElement {
   }
 
   /**
-   * Pre-render callback for the map render array.
+   * Pre-render callback for the map prototype render array.
    *
    * @param array $element
    *   A renderable array containing a #map_type property, which will be
    *   appended to 'farm-map-' as the map element ID.
    *
    * @return array
-   *   A renderable array representing the map.
+   *   A renderable array representing the map prototype.
    */
   public static function preRenderMap(array $element) {
 
     // Add the farm-map class.
-    $element['#attributes']['class'][] = 'farm-map';
+    $element['#attributes']['class'][] = 'farm-map-prototype';
 
     // Return the element.
-    return FarmMap::preRenderMapCommon($element);
+    return FarmMapPrototype::preRenderMapCommon($element);
   }
 
 }

--- a/modules/core/map/src/Traits/PreRenderableMapTrait.php
+++ b/modules/core/map/src/Traits/PreRenderableMapTrait.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Drupal\farm_map\Traits;
+
+use Drupal\Component\Utility\Html;
+use Drupal\farm_map\Event\MapRenderEvent;
+
+
+/**
+ * A trait for performing common map pre-render steps.
+ */
+trait PreRenderableMapTrait {
+
+  /**
+   * Helper function to perform common map pre-render steps for the map render array.
+   *
+   * @param array $element
+   *   A renderable array containing a #map_type property, which will be
+   *   appended to 'farm-map-' as the map element ID.
+   *
+   * @return array
+   *   A renderable array representing the map.
+   */
+  protected static function preRenderMapCommon(array $element) {
+
+      if (empty($element['#attributes']['id'])) {
+          // Set the id to the map name.
+          $map_id = Html::getUniqueId('farm-map-' . $element['#map_type']);
+          $element['#attributes']['id'] = $map_id;
+      } else {
+          $map_id = $element['#attributes']['id'];
+      }
+
+      // Get the map type.
+      /** @var \Drupal\farm_map\Entity\MapTypeInterface $map */
+      $map = \Drupal::entityTypeManager()->getStorage('map_type')->load($element['#map_type']);
+
+      // Attach the farmOS-map and farm_map libraries.
+      $element['#attached']['library'][] = 'farm_map/farmOS-map';
+      $element['#attached']['library'][] = 'farm_map/farm_map';
+
+      // Include map settings.
+      $map_settings = !empty($element['#map_settings']) ? $element['#map_settings'] : [];
+
+      // Include the map options.
+      $map_options = $map->getMapOptions();
+
+      // Add the instance settings under the map id key.
+      $instance_settings = array_merge_recursive($map_settings, $map_options);
+      $element['#attached']['drupalSettings']['farm_map'][$map_id] = $instance_settings;
+
+      // Create and dispatch a MapRenderEvent.
+      $event = new MapRenderEvent($map, $element);
+      \Drupal::service('event_dispatcher')->dispatch(MapRenderEvent::EVENT_NAME, $event);
+
+      // Return the element.
+      return $event->element;
+  }
+
+}

--- a/modules/ui/map/js/farmOS.map.behaviors.asset_type_layers.js
+++ b/modules/ui/map/js/farmOS.map.behaviors.asset_type_layers.js
@@ -3,10 +3,10 @@
     attach: function (instance) {
 
       // Check if there are asset type layers to add.
-      if (drupalSettings.farm_map[instance.target].asset_type_layers !== undefined) {
+      if (drupalSettings.farm_map[instance.drupalSettingsKey].asset_type_layers !== undefined) {
 
         // Add layers for each area type.
-        var layers = drupalSettings.farm_map[instance.target].asset_type_layers;
+        var layers = drupalSettings.farm_map[instance.drupalSettingsKey].asset_type_layers;
         Object.values(layers).reverse().forEach( layer => {
 
           // Determine if the layer should display full geometry or centroids.


### PR DESCRIPTION
**Note:** This is intended to be merged to the `2.x` branch after https://github.com/farmOS/farmOS/pull/425. Unfortunately, the diff includes the changes from that PRs since [stacked pull requests](http://bentrengrove.com/blog/2020/7/8/how-to-stack-prs-in-github) don't work [across forks](https://github.com/google/ground-android/issues/93) on Github.

**Why?** Currently the extension system for `FarmMap` couples the code that determines which behaviors should be loaded
with the code that instantiates a specific instance of farmOS-map.

With these changes, I've refactored out the map-type/settings/event logic into a common trait which is used both by the existing `FarmMap` `RenderElement` and a new `FarmMapPrototype` element.

This new `FarmMapPrototype` element does all the same steps, except it doesn't include the `farm-map` class which is used by the JS to find the maps to instantiate.

Further, I've refactored the code from the `farm_map.js` Drupal behavior such that a factory method is exposed which other JS can leverage to create maps using all the same boiler-plate that is needed to wire map settings exposed from Drupal into new map instances.

I also had to decouple the mechanism by which settings are accessed in JS given a map instance. Prior to these changes, that assumed the id of the map element was always that same as the key by which those settings
are accessed.

All that together allows for map creation like this;

```js
const mapPrototypeElement = document.getElementById('my-tool-map-prototype');

const mapElement = mapPrototypeElement.cloneNode();
mapElement.removeAttribute('id');

myParentContainer.appendChild(mapElement);

const mapInstance = Drupal.behaviors.farm_map.createMapInstance(mapElement, mapElement, 'my-tool-map-prototype', {});
```