### PR TITLE
Fix metrics block caching.

### DIFF
--- a/modules/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -88,7 +88,7 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
         '#markup' => $metric,
       ];
     }
-    $output['#cache']['tags'] = ['asset_list'];
+    $output['#cache']['tags'][] = 'asset_list';
 
     // Create a section for log metrics.
     $output['log'] = [
@@ -106,7 +106,7 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
         '#markup' => $metric,
       ];
     }
-    $output['#cache']['tags'] = ['log_list'];
+    $output['#cache']['tags'][] = 'log_list';
 
     // Attach CSS.
     $output['#attached']['library'][] = 'farm_ui_metrics/metrics_block';


### PR DESCRIPTION
I noticed that the asset counts in the metrics block were not updating when I created new assets. Just a little bug, simple change.