### PR TITLE
Fix entity count query and metrics caching.

### DIFF
--- a/modules/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -138,7 +138,10 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
 
     // Count records by type.
     foreach ($bundles as $bundle => $bundle_info) {
-      $count = $this->entityTypeManager->getStorage($entity_type)->getAggregateQuery()->count()->execute();
+      $count = $this->entityTypeManager->getStorage($entity_type)->getAggregateQuery()
+        ->condition('type', $bundle)
+        ->count()
+        ->execute();
       $route_name = "view.farm_$entity_type.page_type";
       $metrics[] = Link::createFromRoute($bundle_info['label'] . ': ' . $count, $route_name, ['arg_0' => $bundle], ['attributes' => ['class' => ['metric', 'button']]])->toString();
     }

--- a/modules/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -92,6 +92,7 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
       $output['asset']['metrics']['empty']['#markup'] = '<p>' . $this->t('No assets found.') . '</p>';
     }
     $output['#cache']['tags'][] = 'asset_list';
+    $output['#cache']['tags'][] = 'config:asset_type_list';
 
     // Create a section for log metrics.
     $output['log'] = [
@@ -113,6 +114,7 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
       $output['log']['metrics']['empty']['#markup'] = '<p>' . $this->t('No logs found.') . '</p>';
     }
     $output['#cache']['tags'][] = 'log_list';
+    $output['#cache']['tags'][] = 'config:log_type_list';
 
     // Attach CSS.
     $output['#attached']['library'][] = 'farm_ui_metrics/metrics_block';

--- a/modules/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
+++ b/modules/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
@@ -63,14 +63,13 @@ class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
 
     // Run a count query to see if there are any assets that reference this
     // asset as a parent.
-    $result = $this->assetStorage->getAggregateQuery()
+    $count = $this->assetStorage->getAggregateQuery()
       ->condition('parent.entity.id', $asset_id)
-      ->aggregate('id', 'COUNT')
+      ->count()
       ->execute();
 
     // Determine access based on the child count.
-    $child_count = (int) $result[0]['id_count'] ?? 0;
-    $access = AccessResult::allowedIf($child_count > 0);
+    $access = AccessResult::allowedIf($count > 0);
 
     // Invalidate the access result when assets are changed.
     $access->addCacheTags(["asset_list"]);

--- a/modules/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
+++ b/modules/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
@@ -52,7 +52,7 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
     // Build a count query for logs of this type.
     $query = $this->logStorage->getAggregateQuery()
       ->condition('type', $log_type)
-      ->aggregate('id', 'COUNT');
+      ->count();
 
     // Only include logs that reference the asset.
     $reference_condition = $query->orConditionGroup()
@@ -61,9 +61,8 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
     $query->condition($reference_condition);
 
     // Determine access based on the log count.
-    $result = $query->execute();
-    $log_count = (int) $result[0]['id_count'] ?? 0;
-    $access = AccessResult::allowedIf($log_count > 0);
+    $count = $query->execute();
+    $access = AccessResult::allowedIf($count > 0);
 
     // Invalidate the access result when logs of this bundle are changed.
     $access->addCacheTags(["log_list:$log_type"]);


### PR DESCRIPTION
A follow up from #429 and #430 

- Fixes the entity bundle count problem I mentioned here: https://github.com/farmOS/farmOS/pull/430#issuecomment-862970395

- And updates the dashboard metrics when bundles are added/removed:

 > In this process I noticed that the dashboard metric block is not updated when new bundles of logs or assets are installed... I was hoping there might be a log_type_list cache tag, but doesn't look like it's that easy.

There actually is a `config:log_type_list` cache tag, so problem solved!!