### PR TITLE
Fix caching of the farm_people view.

### DIFF
--- a/modules/ui/views/config/install/views.view.farm_people.yml
+++ b/modules/ui/views/config/install/views.view.farm_people.yml
@@ -22,7 +22,7 @@ display:
         options:
           perm: 'access user profiles'
       cache:
-        type: tag
+        type: none
         options: {  }
       query:
         type: views_query

--- a/modules/ui/views/config/install/views.view.farm_people.yml
+++ b/modules/ui/views/config/install/views.view.farm_people.yml
@@ -22,7 +22,7 @@ display:
         options:
           perm: 'access user profiles'
       cache:
-        type: none
+        type: tag
         options: {  }
       query:
         type: views_query
@@ -377,8 +377,8 @@ display:
           label: 'Last access'
           exclude: false
           alter:
-            alter_text: true
-            text: '{{ access__value == 0 ? access__value : access }}'
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -411,16 +411,16 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: Never
+          empty: ''
           hide_empty: false
-          empty_zero: true
+          empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: timestamp
+          type: timestamp_ago
           settings:
-            date_format: html_date
-            custom_date_format: ''
-            timezone: ''
+            future_format: '@interval hence'
+            past_format: '@interval ago'
+            granularity: 2
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/modules/ui/views/config/install/views.view.farm_people.yml
+++ b/modules/ui/views/config/install/views.view.farm_people.yml
@@ -377,8 +377,8 @@ display:
           label: 'Last access'
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ access__value == 0 ? access__value : access }}'
             make_link: false
             path: ''
             absolute: false
@@ -411,9 +411,9 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: Never
           hide_empty: false
-          empty_zero: false
+          empty_zero: true
           hide_alter_empty: true
           click_sort_column: value
           type: timestamp


### PR DESCRIPTION
Currently the farm_people page can be cached and display an incorrect `last_access` value for users. Also, if a user has never logged in the `last_access` value is rendered as 1970.

The first two commits of this PR modify the `last_access` field to rewrite the result as `Never` or the up-to-date HTML date.

The last commit changes the `last_access` value using the `timestamp_ago` formatter. This is the approach the core `user_admin_people` view uses. Due to the nature of "timestamp ago" formatting, it sets the cache max age accordingly (1s, 1m, 1 day, etc depending on the granularity the date is rendered) so that the value is always up to date. This also renders "never" when the user has never logged in. BUT this does not render the actual date of last access.

I see value in both the standard Date as well as "ago" formatting. I think we could accomplish both by rewriting the field to display "{HTML Date format} ({time ago format})". Thoughts?