### PR TITLE
Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,9 +66,6 @@
                 "Issue #3174572: Passing a third argument to headers->get() is deprecated": "https://www.drupal.org/files/issues/2020-10-02/3174572-2.patch",
                 "Issue #3186301: Make $modules variable protected in tests": "https://www.drupal.org/files/issues/2020-12-03/3186301-2.patch"
             },
-            "drupal/views_geojson": {
-                "Issue #3177013: Missing configuration schema.": "https://www.drupal.org/files/issues/2020-10-15/views_geojson-missing-config-schema-3177013.patch"
-            },
             "phayes/geophp": {
                 "Use BCMath (where available) for all float arithmetic #115": "https://patch-diff.githubusercontent.com/raw/phayes/geoPHP/pull/115.patch"
             }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/config_update": "^1.7",
         "drupal/csv_serialization": "^2.0",
         "drupal/date_popup": "^1.1",
-        "drupal/entity_browser": "^2.5",
+        "drupal/entity_browser": "^2.6",
         "drupal/entity_reference_integrity": "^1.0",
         "drupal/entity_reference_revisions": "^1.8",
         "drupal/entity_reference_validators": "^1.0@alpha",
@@ -56,9 +56,6 @@
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2021-05-18/3206703-7.patch"
-            },
-            "drupal/entity_browser": {
-                "Issue #3160482: Error with UntrustedCallbackException": "https://www.drupal.org/files/issues/2021-03-02/error-with-untrustedcallbackexception-3160482-5.patch"
             },
             "drupal/gin": {
                 "Issue #3213378: Settings cannot be saved when Gin is set as default theme and no specific admin theme is chosen": "https://git.drupalcode.org/project/gin/-/merge_requests/33.diff"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "drupal/exif_orientation": "^1.1",
         "drupal/fraction": "2.x-dev",
         "drupal/geofield": "^1.32",
-        "drupal/gin": "3.0-alpha34",
+        "drupal/gin": "3.0-alpha35",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",
         "drupal/jsonapi_extras": "^3.15",
@@ -56,9 +56,6 @@
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2021-05-18/3206703-7.patch"
-            },
-            "drupal/gin": {
-                "Issue #3213378: Settings cannot be saved when Gin is set as default theme and no specific admin theme is chosen": "https://git.drupalcode.org/project/gin/-/merge_requests/33.diff"
             },
             "drupal/simple_oauth": {
                 "Issue #3173947: Cannot authorize non-confidential clients": "https://www.drupal.org/files/issues/2020-09-29/3173947-2.patch",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/entity_reference_validators": "^1.0@alpha",
         "drupal/exif_orientation": "^1.1",
         "drupal/fraction": "2.x-dev",
-        "drupal/geofield": "^1.22",
+        "drupal/geofield": "^1.32",
         "drupal/gin": "3.0-alpha34",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",


### PR DESCRIPTION
`drupal/entity_browser` just made a new release and our patch no longer applies!

Also updated the `drupal/geofield` minimum version to match what we depend on.

The `drupal/views_geojson` patch file was actually incorrect and was creating new files in a `b` directory - this explains why this wasn't conflicting with the correct fix which was included with the 1.1 release we currently depend on.

I also bumped our `drupal/gin` dependency to the latest `alpha35` release. The most significant change here is that menu items are more condensed to take up a bit less space. I think it is a welcome change.