### PR TITLE
Do not run paratest in functional mode.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,6 +64,6 @@ jobs:
       - name: Run PHPUnit tests
       # The overridden result printer is needed until Drupal 9.2 when the updated version of HtmlOutputPrinter will be available
       # https://github.com/drupal/drupal/blob/74fbb0aabdee3e1a5da7b8e489a725afdc5824fd/core/tests/Drupal/Tests/Listeners/HtmlOutputPrinter.php
-        run: docker-compose exec -u www-data -T test-runner paratest --functional --passthru='--printer=PHPUnit\\TextUI\\DefaultResultPrinter' --verbose=1 /opt/drupal/web/profiles/farm
+        run: docker-compose exec -u www-data -T test-runner paratest --passthru='--printer=PHPUnit\\TextUI\\DefaultResultPrinter' --verbose=1 /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules
         run: docker-compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'


### PR DESCRIPTION
I'm undecided if this is a performance improvement right now. The Github test runner doesn't seem to produce very consistent test times. Might depend on the time of the day and I'm not that invested in figuring it out at the moment. So if anything this is maybe a marginal improvement, and something to revisit in the future if we get more (maybe?) or (especially?) longer test cases.

From the paratest [docs](https://github.com/paratestphp/paratest#optimizing-speed): 

> Given you have few testcases (classes) with many long running methods, you should use the -f option to enable the functional mode and allow different methods of the same class to be executed in parallel. Keep in mind that the default is per-testcase-parallelization to address inter-testmethod dependencies. Note that in most projects, using -f is slower since each test method will need to be bootstrapped separately.

It seems that the performance gain depends on a balance between the number of test cases (classes) and test methods. Once we have significantly more test methods than we do test cases, removing the `--functional` flag might see significant improvements?

I'm not sure what all happens in the "bootstrapping" of a test though. If this includes the shared test `setUp()` (installing drupal, creating test entities, etc) then I think we would see major improvements, but it seems like that may be covered with `--runner WrapperRunner`, which fails with a seg fault, likely due to the [caveats of the WrapperRunner](https://github.com/paratestphp/paratest#caveats)