### PR TITLE
Create a new /var/farmOS directory in two steps.

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -26,7 +26,10 @@ RUN yes | pecl install xdebug \
 	&& echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
 
 # Create a fresh /var/farmOS directory owned by www-data.
-RUN rm -r /var/farmOS && mkdir /var/farmOS && chown www-data:www-data /var/farmOS
+# We do this in two steps because of a known issue with Moby.
+# @see https://github.com/farmOS/farmOS/pull/440
+RUN rm -r /var/farmOS
+RUN mkdir /var/farmOS && chown www-data:www-data /var/farmOS
 
 # Change to the www-data user.
 USER www-data


### PR DESCRIPTION
I ran into a bug when trying to build the farmOS development docker image in a Gitpod workspace. I need to build the image since the default `gitpod` user has the id `33333`, not `1000`.

When building the dev image I get an error, `Failed to build docker image: Exit code 1` when executing this step: https://github.com/farmOS/farmOS/blob/9e9734c3f511a9a82af806e68081cf954d33c0ee/docker/dev/Dockerfile#L35

I added an `echo "$(ls -A /var/farmOS/)"` in this first `IF` statement of `build-farmOS.sh`, and sure enough the directory wasn't empty: https://github.com/farmOS/farmOS/blob/9e9734c3f511a9a82af806e68081cf954d33c0ee/docker/build-farmOS.sh#L10

Weird.

**So TLDR I don't really know what is going on, but I found a simple fix that worked in the Gitpod environment:**

Change:

```
RUN rm -r /var/farmOS && mkdir /var/farmOS && chown www-data:www-data /var/farmOS
```

Into two steps:

```
RUN rm -r /var/farmOS
RUN mkdir /var/farmOS && chown www-data:www-data /var/farmOS
```

I know this isn't great because it creates another intermediary docker image. But this is the only solution I could get to work :-/

### Why

Turns out there is a [known issue](https://docs.docker.com/engine/reference/builder/#known-issues-run) for the Dockerfile `RUN` when trying to `rm` files. https://github.com/moby/moby/issues/783 It's an old issue, but still not solved.

It also seems that something similar can happen with the `overlay` storage driver: https://stackoverflow.com/a/42534076

But my gitpod workspace gives me the following `docker info`, which should be OK according to that issue:
```
 Storage Driver: overlay2
  Backing Filesystem: xfs
  Supports d_type: true
  Native Overlay Diff: false
```
`overlay2` is the currently recommended storage driver, but supposedly going to the deprecated `devicemapper` storage driver is a "fix"...

