### PR TITLE
Remove test-runner and Disable XDebug with XDEBUG_MODE: off

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -59,15 +59,15 @@ jobs:
           docker-compose -f docker-compose.testing.common.yml -f docker-compose.testing.${{ matrix.dbms }}.yml config > docker-compose.yml
       - name: Start containers
         run: docker-compose up -d
-      - name: Wait until test-runner container is ready
-      # The test-runner-container-fs-ready file is only created once we expect the containers to be online
+      - name: Wait until www container is ready
+      # The www-container-fs-ready file is only created once we expect the containers to be online
       # so waiting for that lets us know it is safe to start the tests
-        run: until [ -f ./www/test-runner-container-fs-ready ]; do sleep 0.1; done
+        run: until [ -f ./www/www-container-fs-ready ]; do sleep 0.1; done
       - name: Run PHP CodeSniffer
         run: docker-compose exec -u www-data -T www phpcs /opt/drupal/web/profiles/farm
       - name: Run PHPUnit tests
       # The overridden result printer is needed until Drupal 9.2 when the updated version of HtmlOutputPrinter will be available
       # https://github.com/drupal/drupal/blob/74fbb0aabdee3e1a5da7b8e489a725afdc5824fd/core/tests/Drupal/Tests/Listeners/HtmlOutputPrinter.php
-        run: docker-compose exec -u www-data -T test-runner paratest --passthru='--printer=PHPUnit\\TextUI\\DefaultResultPrinter' --verbose=1 /opt/drupal/web/profiles/farm
+        run: docker-compose exec -u www-data -T www paratest --passthru='--printer=PHPUnit\\TextUI\\DefaultResultPrinter' --verbose=1 /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules
         run: docker-compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'

--- a/docker/docker-compose.testing.common.yml
+++ b/docker/docker-compose.testing.common.yml
@@ -6,10 +6,13 @@ services:
       - './www:/opt/drupal'
     environment:
       FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/www-container-fs-ready
+      XDEBUG_MODE: 'off'
 
   chrome:
     image: selenium/standalone-chrome:latest
 
+  # We use a separate test-runner container running the 2.x image so that tests
+  # run without dev dependencies like XDebug, which slow things down.
   test-runner:
     depends_on:
       - www
@@ -31,3 +34,4 @@ services:
     environment:
       FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/test-runner-container-fs-ready
       SIMPLETEST_DB: $DB_URL
+      XDEBUG_MODE: 'off'

--- a/docker/docker-compose.testing.common.yml
+++ b/docker/docker-compose.testing.common.yml
@@ -6,6 +6,7 @@ services:
       - './www:/opt/drupal'
     environment:
       FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/www-container-fs-ready
+      SIMPLETEST_DB: $DB_URL
       XDEBUG_MODE: 'off'
 
   chrome:

--- a/docker/docker-compose.testing.common.yml
+++ b/docker/docker-compose.testing.common.yml
@@ -11,28 +11,3 @@ services:
 
   chrome:
     image: selenium/standalone-chrome:latest
-
-  # We use a separate test-runner container running the 2.x image so that tests
-  # run without dev dependencies like XDebug, which slow things down.
-  test-runner:
-    depends_on:
-      - www
-      - chrome
-    image: farmos/farmos:2.x
-    entrypoint: /bin/bash
-    command:
-      - -c
-      - |
-        set -e
-        # Wait until the dev farmOS container has finished copying its files
-        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
-        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
-        # file created, allowing the Github action to also wait for the above conditions on the basis
-        # of that file's creation.
-        exec docker-entrypoint.sh apache2-foreground
-    volumes:
-      - './www:/opt/drupal'
-    environment:
-      FARMOS_FS_READY_SENTINEL_FILENAME: /opt/drupal/test-runner-container-fs-ready
-      SIMPLETEST_DB: $DB_URL
-      XDEBUG_MODE: 'off'

--- a/docker/docker-compose.testing.mariadb.yml
+++ b/docker/docker-compose.testing.mariadb.yml
@@ -16,17 +16,3 @@ services:
   www:
     depends_on:
       - db
-
-  test-runner:
-    command:
-      - -c
-      - |
-        set -e
-        # Wait until the dev farmOS container has finished copying its files
-        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
-        # Wait until mariadb is online listening to its socket
-        while { ! exec 3<>/dev/tcp/db/3306; } > /dev/null 2>&1; do sleep 0.1; done
-        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
-        # file created, allowing the Github action to also wait for the above conditions on the basis
-        # of that file's creation.
-        exec docker-entrypoint.sh apache2-foreground

--- a/docker/docker-compose.testing.pgsql.yml
+++ b/docker/docker-compose.testing.pgsql.yml
@@ -15,17 +15,3 @@ services:
   www:
     depends_on:
       - db
-
-  test-runner:
-    command:
-      - -c
-      - |
-        set -e
-        # Wait until the dev farmOS container has finished copying its files
-        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
-        # Wait until Postgres is online listening to its socket
-        while { ! exec 3<>/dev/tcp/db/5432; } > /dev/null 2>&1; do sleep 0.1; done
-        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
-        # file created, allowing the Github action to also wait for the above conditions on the basis
-        # of that file's creation.
-        exec docker-entrypoint.sh apache2-foreground

--- a/docker/docker-compose.testing.sqlite.yml
+++ b/docker/docker-compose.testing.sqlite.yml
@@ -1,14 +1,3 @@
 # Inherits from docker-compose.testing.common.yml
 version: '3'
-services:
-  test-runner:
-    command:
-      - -c
-      - |
-        set -e
-        # Wait until the dev farmOS container has finished copying its files
-        until [ -f /opt/drupal/www-container-fs-ready ]; do sleep 0.1; done
-        # Run normal entrypoint and apache - only at this point is the test-runner-container-fs-ready
-        # file created, allowing the Github action to also wait for the above conditions on the basis
-        # of that file's creation.
-        exec docker-entrypoint.sh apache2-foreground
+services: {  }


### PR DESCRIPTION
Back in November of last year, we took a "clever" approach to running tests without XDebug, by spinning up both a `farmos/farmos:2.x-dev` service (to build a bind-mounted codebase in a directory with dev dependencies included) and a `farmos/farmos:2.x` service (for running `phpunit` without XDebug present).

See:

- https://www.drupal.org/project/farm/issues/3183687
- #377 

This worked great!

Then, in December 2020, we upgraded to XDebug 3: https://github.com/farmOS/farmOS/commit/9bb7d4f8557f1be29e3664831c236d5cdf6eeba8

XDebug 3 adds the `XDEBUG_MODE` environment variable, which we set to `debug` in our development environments, but can also be set to `off` to disable XDebug.

XDebug's docs state:

> `off`
> Nothing is enabled. Xdebug does no work besides checking whether functionality is enabled. Use this setting if you want close to 0 overhead.

https://xdebug.org/docs/all_settings#mode

This pull request uses the `XDEBUG_MODE` environment variable to disable XDebug in our testing environment. This removes the need for a separate `test-runner` service, so it also removes that.