### PR TITLE
Enable the map side panel with layer switcher by default

### DIFF
--- a/composer.libraries.json
+++ b/composer.libraries.json
@@ -11,10 +11,10 @@
             "type": "package",
             "package": {
                 "name": "farmos/farmos-map",
-                "version": "2.0.1",
+                "version": "2.0.2",
                 "type": "drupal-library",
                 "dist": {
-                  "url": "https://github.com/farmOS/farmOS-map/releases/download/v2.0.1/v2.0.1-dist.zip",
+                  "url": "https://github.com/farmOS/farmOS-map/releases/download/v2.0.2/v2.0.2-dist.zip",
                   "type": "zip"
                 },
                 "extra": {

--- a/modules/core/map/config/install/farm_map.map_behavior.enable_side_panel.yml
+++ b/modules/core/map/config/install/farm_map.map_behavior.enable_side_panel.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_map
+id: enable_side_panel
+label: Enable Side Panel
+description: 'Enables the map side panel and moves the layer switcher into it.'
+library: 'farm_map/behavior_enable_side_panel'
+settings: {  }

--- a/modules/core/map/config/install/farm_map.settings.yml
+++ b/modules/core/map/config/install/farm_map.settings.yml
@@ -1,0 +1,1 @@
+enable_side_panel: true

--- a/modules/core/map/config/schema/farm_map.schema.yml
+++ b/modules/core/map/config/schema/farm_map.schema.yml
@@ -77,3 +77,11 @@ block.settings.map_block:
     map_type:
       type: string
       label: 'Map type'
+farm_map.settings:
+  type: config_object
+  label: 'Map Settings'
+  mapping:
+    enable_side_panel:
+      type: boolean
+      label: 'Enable Side Panel'
+      description: 'Enables the side panel in farmOS maps for displaying additional settings and information.'

--- a/modules/core/map/farm_map.libraries.yml
+++ b/modules/core/map/farm_map.libraries.yml
@@ -35,6 +35,11 @@ behavior_geofield:
     js/farmOS.map.behaviors.geofield.js: { }
   dependencies:
     - farm_map/farm_map
+behavior_enable_side_panel:
+  js:
+    js/farmOS.map.behaviors.enable_side_panel.js: { }
+  dependencies:
+    - farm_map/farm_map
 behavior_popup:
   js:
     js/farmOS.map.behaviors.popup.js: { }

--- a/modules/core/map/farm_map.services.yml
+++ b/modules/core/map/farm_map.services.yml
@@ -1,6 +1,8 @@
 services:
   farm_map.map_render_event_subscriber:
     class: Drupal\farm_map\EventSubscriber\MapRenderEventSubscriber
+    arguments:
+      - '@config.factory'
     tags:
       - { name: 'event_subscriber' }
   farm_map.layer_style_loader:

--- a/modules/core/map/js/farmOS.map.behaviors.enable_side_panel.js
+++ b/modules/core/map/js/farmOS.map.behaviors.enable_side_panel.js
@@ -1,0 +1,7 @@
+(function () {
+  // Make the built-in farmOS-map 'sidePanel' behavior attach on map instantiation
+  farmOS.map.behaviors.sidePanel = farmOS.map.namedBehaviors.sidePanel;
+
+  // Make the built-in farmOS-map 'layerSwitcherInSidePanel' behavior attach on map instantiation
+  farmOS.map.behaviors.layerSwitcherInSidePanel = farmOS.map.namedBehaviors.layerSwitcherInSidePanel;
+}());

--- a/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\farm_map\EventSubscriber;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\farm_map\Event\MapRenderEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -11,6 +12,23 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Adds default behaviors to maps.
  */
 class MapRenderEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  private $configFactory;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->configFactory = $config_factory;
+  }
 
   /**
    * {@inheritdoc}
@@ -47,6 +65,16 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
     if (in_array($event->getMapType()->id(), ['geofield_widget'])) {
       $event->addBehavior('wkt');
       $event->addBehavior('geofield');
+    }
+
+    // Get whether the side panel should be enabled.
+    $enable_side_panel = $this->configFactory->get('farm_map.settings')->get('enable_side_panel');
+
+    // Set a cache tag on the map settings to invalidate the cache on changes.
+    $event->addCacheTags(['config:farm_map.settings']);
+
+    if ($enable_side_panel) {
+      $event->addBehavior('enable_side_panel');
     }
   }
 

--- a/modules/core/map/src/Form/MapSettingsForm.php
+++ b/modules/core/map/src/Form/MapSettingsForm.php
@@ -3,11 +3,19 @@
 namespace Drupal\farm_map\Form;
 
 use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides a farm_map settings form.
  */
 class MapSettingsForm extends ConfigFormbase {
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'farm_map.settings';
 
   /**
    * {@inheritdoc}
@@ -20,7 +28,37 @@ class MapSettingsForm extends ConfigFormbase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
-    return [];
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateinterface $form_state) {
+    $config = $this->config(static::SETTINGS);
+
+    // Add the enable side panel option.
+    $form['enable_side_panel'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Side Panel'),
+      '#description' => $this->t('Enable the side panel in farmOS maps for displaying additional settings and information.'),
+      '#default_value' => $config->get('enable_side_panel'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->configFactory->getEditable(static::SETTINGS)
+      ->set('enable_side_panel', $form_state->getValue('enable_side_panel'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
   }
 
 }


### PR DESCRIPTION
**Why?** Provide a place for more settings and information
to be included on farmOS maps without introducing more and more
border clutter.

![image](https://user-images.githubusercontent.com/30754460/132996678-cac9eff2-f88b-4d99-83ad-b880c3b5b4db.png)

![image](https://user-images.githubusercontent.com/30754460/132997041-70229611-3b21-485f-8a49-10f6a8fb725d.png)

![image](https://user-images.githubusercontent.com/30754460/132996682-cbe43237-79b1-4a95-9319-69d98e0dae19.png)

***Related:** There's a race-condition bug in the farmOS-map `layersSwitcherInSidePanel` behavior which I'm fixing in https://github.com/farmOS/farmOS-map/pull/131. Without that fix, the layer switcher sometimes stays as a separate control - leaving the side panel effectively empty.*