### PR TITLE
Improve asset archive timestamp behavior

### DIFF
--- a/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
+++ b/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
@@ -126,6 +126,36 @@ class AssetCRUDTest extends AssetTestBase {
 
     $this->assertEquals($asset->get('status')->first()->getString(), 'active', 'Assets can be made active');
     $this->assertNull($asset->getArchivedTime(), 'Asset made active has a null timestamp');
+
+    $asset->get('status')->first()->applyTransitionById('archive');
+    $asset->setArchivedTime('2021-07-17T19:45:49+00:00');
+    $asset->save();
+
+    $this->assertEquals($asset->get('status')->first()->getString(), 'archived', 'Assets can be archived with explicit timestamp');
+    $this->assertEquals($asset->getArchivedTime(), '2021-07-17T19:45:49+00:00', 'Explicit archived timestamp is saved');
+  }
+
+  /**
+   * Asset archiving/unarchiving via timestamp.
+   */
+  public function testArchiveAssetViaTimestamp() {
+    $asset = $this->createAssetEntity();
+    $asset->save();
+
+    $this->assertEquals($asset->get('status')->first()->getString(), 'active', 'New assets are active by default');
+    $this->assertNull($asset->getArchivedTime(), 'Archived timestamp is null by default');
+
+    $asset->setArchivedTime('2021-07-17T19:45:49+00:00');
+    $asset->save();
+
+    $this->assertEquals($asset->get('status')->first()->getString(), 'archived', 'Assets can be archived');
+    $this->assertEquals($asset->getArchivedTime(), '2021-07-17T19:45:49+00:00', 'Archived timestamp is saved');
+
+    $asset->setArchivedTime(NULL);
+    $asset->save();
+
+    $this->assertEquals($asset->get('status')->first()->getString(), 'active', 'Assets can be made active');
+    $this->assertNull($asset->getArchivedTime(), 'Asset made active has a null timestamp');
   }
 
 }

--- a/modules/core/plan/src/PlanStorage.php
+++ b/modules/core/plan/src/PlanStorage.php
@@ -29,13 +29,30 @@ class PlanStorage extends SqlContentEntityStorage {
     $new_state = $entity->get('status')->first()->getString();
     $old_state = $entity->original->get('status')->first()->getString();
 
+    $state_unchanged = $new_state == $old_state;
+
+    // If the entity is not archived and this would otherwise not be a state
+    // transition but the archive timestamp is set, then transition to the
+    // archived state.
+    if ($state_unchanged && $old_state != 'archived' && $entity->getArchivedTime() != NULL) {
+      $entity->get('status')->first()->applyTransitionById('archive');
+    }
+
+    // If the entity is archived and this would otherwise not be a state
+    // transition but the archive timestemp is NULL, then transition to the
+    // active state.
+    if ($state_unchanged && $old_state == 'archived' && $entity->getArchivedTime() == NULL) {
+      $entity->get('status')->first()->applyTransitionById('to_active');
+    }
+
     // If the state has not changed, bail.
-    if ($new_state == $old_state) {
+    if ($state_unchanged) {
       return;
     }
 
-    // If the state has changed to archived, save the archived timestamp.
-    if ($new_state == 'archived') {
+    // If the state has changed to archived and no archived timestamp was
+    // specified, set it to the current time.
+    if ($new_state == 'archived' && $entity->getArchivedTime() == NULL) {
       $entity->setArchivedTime(\Drupal::time()->getRequestTime());
     }
 

--- a/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
+++ b/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
@@ -126,6 +126,36 @@ class PlanCRUDTest extends PlanTestBase {
 
     $this->assertEquals($plan->get('status')->first()->getString(), 'active', 'Plans can be made active');
     $this->assertNull($plan->getArchivedTime(), 'Plan made active has a null timestamp');
+
+    $plan->get('status')->first()->applyTransitionById('archive');
+    $plan->setArchivedTime('2021-07-17T19:45:49+00:00');
+    $plan->save();
+
+    $this->assertEquals($plan->get('status')->first()->getString(), 'archived', 'Plans can be archived with explicit timestamp');
+    $this->assertEquals($plan->getArchivedTime(), '2021-07-17T19:45:49+00:00', 'Explicit archived timestamp is saved');
+  }
+
+  /**
+   * Plan archiving/unarchiving via timestamp.
+   */
+  public function testArchivePlanViaTimestamp() {
+    $plan = $this->createPlanEntity();
+    $plan->save();
+
+    $this->assertEquals($plan->get('status')->first()->getString(), 'active', 'New plans are active by default');
+    $this->assertNull($plan->getArchivedTime(), 'Archived timestamp is null by default');
+
+    $plan->setArchivedTime('2021-07-17T19:45:49+00:00');
+    $plan->save();
+
+    $this->assertEquals($plan->get('status')->first()->getString(), 'archived', 'Plans can be archived');
+    $this->assertEquals($plan->getArchivedTime(), '2021-07-17T19:45:49+00:00', 'Archived timestamp is saved');
+
+    $plan->setArchivedTime(NULL);
+    $plan->save();
+
+    $this->assertEquals($plan->get('status')->first()->getString(), 'active', 'Plans can be made active');
+    $this->assertNull($plan->getArchivedTime(), 'Plan made active has a null timestamp');
   }
 
 }


### PR DESCRIPTION
**Why?** Fix some weird behavior and make sure
inconsistent states cannot occur;

* Allow setting the archived timestamp at the same
  time as moving an asset to the archived state.
* Ensure that the archived timestamp cannot be set
  without also transitioning into the archived state.
* Ensure that the arhived timestamp cannot be set to
  NULL without transitioning back to the active state.