### PR TITLE
Log the result after reverting config.

### DIFF
--- a/modules/core/update/farm_update.services.yml
+++ b/modules/core/update/farm_update.services.yml
@@ -1,4 +1,7 @@
 services:
+  logger.channel.farm_update:
+    parent: logger.channel_base
+    arguments: [ 'farm_update' ]
   farm.update:
     class: Drupal\farm_update\FarmUpdate
-    arguments: [ '@module_handler', '@entity_type.manager', '@config_update.config_diff', '@config_update.config_list', '@config_update.config_update' ]
+    arguments: [ '@logger.channel.farm_update', '@module_handler', '@entity_type.manager', '@config_update.config_diff', '@config_update.config_list', '@config_update.config_update' ]


### PR DESCRIPTION
Follow up to #444 

`\Drupal::logger()->notice(...)` will print messages to the console when drush is sufficiently bootstrapped. This works via `drush farm_update:rebuild`:

```sh
$ docker-compose exec -u www-data www drush farm_update:rebuild
 [notice] Reverted config: quantity.type.material
 [notice] Reverted config: views.view.farm_log
```

Unfortunately `drush cr` doesn't get bootstrapped enough to print these messages to the console, but they are saved in the database logs. More info here: https://github.com/drush-ops/drush/issues/3449#issuecomment-490031390

So it doesn't seem like there is any way to print logs during `drush cr` - ah well

