### PR TITLE
Add missing default_measure key for material quantity.

### DIFF
--- a/modules/quantity/material/config/install/quantity.type.material.yml
+++ b/modules/quantity/material/config/install/quantity.type.material.yml
@@ -6,5 +6,6 @@ dependencies:
       - farm_quantity_material
 id: material
 label: Material
+default_measure: ''
 description: 'Material quantity type.'
 new_revision: true


### PR DESCRIPTION
Running `drush farm_update:rebuild` revealed that the `default_measure` key was missing from the material quantity config - the config was rebuilt every time I ran the above command.

I think this happened because we introduced this `default_measure` feature with c48e380295ca9713375e9c39be180ae3cf8d965c which was being worked on separate of 2170fd57c4ae17aaad43b6c45e94abacd22f314c

My original commit set `default_measure: 'value'` for price quantities, but I'm not sure that was every included in 2.x. https://github.com/paul121/farmOS/commit/deb82c816a709553a69fb22c56de3bc1f11ea304