### PR TITLE
Update to Drupal 9.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -66,8 +66,6 @@ jobs:
       - name: Run PHP CodeSniffer
         run: docker-compose exec -u www-data -T www phpcs /opt/drupal/web/profiles/farm
       - name: Run PHPUnit tests
-      # The overridden result printer is needed until Drupal 9.2 when the updated version of HtmlOutputPrinter will be available
-      # https://github.com/drupal/drupal/blob/74fbb0aabdee3e1a5da7b8e489a725afdc5824fd/core/tests/Drupal/Tests/Listeners/HtmlOutputPrinter.php
-        run: docker-compose exec -u www-data -T www paratest --passthru='--printer=PHPUnit\\TextUI\\DefaultResultPrinter' --verbose=1 /opt/drupal/web/profiles/farm
+        run: docker-compose exec -u www-data -T www paratest --verbose=1 /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules
         run: docker-compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^2.4",
-        "drupal/core": "~9.1.2",
+        "drupal/core": "~9.2.0",
         "drupal/config_update": "^1.7",
         "drupal/csv_serialization": "^2.0",
         "drupal/date_popup": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "patches": {
             "drupal/core": {
                 "Issue #3134470: Switch to entity owner in EntityContentBase during validation": "https://www.drupal.org/files/issues/2021-07-12/3134470-78.patch",
-                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2020-10-12/2339235_60.patch"
+                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-09-24/2339235-9.2-72.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2021-05-18/3206703-7.patch"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM drupal:9-php7.4-apache
 ARG FARMOS_REPO=https://github.com/farmOS/farmOS.git
 ARG FARMOS_VERSION=2.x
 ARG PROJECT_REPO=https://github.com/farmOS/composer-project.git
-ARG PROJECT_VERSION=2.x
+ARG PROJECT_VERSION=2.x-drupal-9.2
 
 # Set Apache ServerName directive globally to suppress AH00558 message.
 RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,7 +5,7 @@ FROM farmos/farmos:2.x
 ARG FARMOS_REPO=https://github.com/farmOS/farmOS.git
 ARG FARMOS_VERSION=2.x
 ARG PROJECT_REPO=https://github.com/farmOS/composer-project.git
-ARG PROJECT_VERSION=2.x
+ARG PROJECT_VERSION=2.x-drupal-9.2
 
 # Change the user/group IDs of www-data inside the image to match the ID of the
 # developer's user on the host machine. This allows Composer to create files


### PR DESCRIPTION
This branch is for testing the update from Drupal 9.1 to 9.2. I had to update one of our core patches to apply, but other than that tests are passing. I have not manually tested yet, but generally minor Drupal core version updates should be pretty stable.

See related `2.x-drupal-9.2` branch in https://github.com/farmOS/composer-project: https://github.com/farmOS/composer-project/compare/2.x-drupal-9.2 - this branch contains a temporary commit to point to that branch, which should not be committed. These should both be merged at the same time.

Moving forward, I wonder if there's a way we can manage these minor version updates without needing to update the `composer-project/composer.json` every time - because this means that anyone managing their farmOS deployments via Composer will need to manually update theirs accordingly.

Can we specify a more general version in the project `composer.json` (eg `^9`) and then constrain the `drupal/core-dev` and `drupal/core-composer-scaffold` versions in `farmOS/composer.json`?