### PR TITLE
Update Entity Reference Integrity to 8.x-1.1 and remove patches that were merged upstream.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/csv_serialization": "^2.0",
         "drupal/date_popup": "^1.1",
         "drupal/entity_browser": "^2.6",
-        "drupal/entity_reference_integrity": "^1.0",
+        "drupal/entity_reference_integrity": "^1.1",
         "drupal/entity_reference_revisions": "^1.8",
         "drupal/entity_reference_validators": "^1.0@alpha",
         "drupal/exif_orientation": "^1.1",
@@ -57,10 +57,6 @@
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2021-05-18/3206703-7.patch"
-            },
-            "drupal/entity_reference_integrity": {
-                "Issue #2831365: Make action confirm_form_route_name forms that delete entities disabled when protected": "https://www.drupal.org/files/issues/2021-10-04/2831365-18.patch",
-                "Issue #3195039: 500 error when deleting referenced entities via JSONAPI": "https://www.drupal.org/files/issues/2021-10-04/3195039-6.patch"
             },
             "drupal/simple_oauth": {
                 "Issue #3173947: Cannot authorize non-confidential clients": "https://www.drupal.org/files/issues/2020-09-29/3173947-2.patch",


### PR DESCRIPTION
This reverts commit 4c30aca7c50fc57886b723b2e5863a3d76dc0c9f, reversing
changes made to e6b76a74469f00557be454e1963b65a84f8eecd0.

This cannot be merged until Entity Reference Revisions 8.x-1.1 is released.