### PR TITLE
Add workflow to trigger farmOS.org Netlify builds when docs are updated

### DIFF
--- a/.github/workflows/netlify-build-docs.yml
+++ b/.github/workflows/netlify-build-docs.yml
@@ -1,0 +1,28 @@
+name: Trigger Netlify to build docs
+on:
+  push:
+    branches:
+      - '2.x-netlify-build-docs'
+  pull_request:
+    branches:
+      - '2.x-netlify-build-docs'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      TOKEN: ${{ secrets.NETLIFY_BUILD_HOOK }}
+    steps:
+      - name: Set trigger_title environment variable
+        run: |
+          echo "TRIGGER_TITLE=Triggered+by+farmOS+source+repo" >> $GITHUB_ENV
+      - name: Set trigger_branch env.var for preview build
+        run: |
+          echo "TRIGGER_BRANCH=preview-farmos" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+      - name: Set trigger_branch env.var for main production build
+        run: |
+          echo "TRIGGER_BRANCH=main" >> $GITHUB_ENV
+        if: github.event_name == 'pull_request'
+      - name: Trigger Netlify Build Hook
+        run: curl -s -X POST -d {} "https://api.netlify.com/build_hooks/${TOKEN}?trigger_branch${TRIGGER_BRANCH}&trigger_title=${TRIGGER_TITLE}"

--- a/.github/workflows/netlify-build-docs.yml
+++ b/.github/workflows/netlify-build-docs.yml
@@ -5,11 +5,6 @@ on:
       - '2.x'
     paths:
       - 'docs/**'
-  pull_request:
-    branches:
-      - '2.x'
-    paths:
-      - 'docs/**'
 
 jobs:
   build:
@@ -20,14 +15,9 @@ jobs:
       - name: Set trigger_title environment variable
         run: |
           echo "TRIGGER_TITLE=Triggered+by+farmOS+source+repo" >> $GITHUB_ENV
-      - name: Set trigger_branch env.var for preview build
-        run: |
-          echo "TRIGGER_BRANCH=preview-farmos" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
       - name: Set trigger_branch env.var for main production build
         run: |
           echo "TRIGGER_BRANCH=main" >> $GITHUB_ENV
-        if: github.event_name == 'push'
       - name: Trigger Netlify Build Hook
         run: curl -s -X POST -d {} "https://api.netlify.com/build_hooks/${TOKEN}?trigger_branch=${TRIGGER_BRANCH}&trigger_title=${TRIGGER_TITLE}"
         if: ${{ env.TOKEN != '' }}

--- a/.github/workflows/netlify-build-docs.yml
+++ b/.github/workflows/netlify-build-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set trigger_branch env.var for main production build
         run: |
           echo "TRIGGER_BRANCH=main" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'push'
       - name: Trigger Netlify Build Hook
-        run: curl -s -X POST -d {} "https://api.netlify.com/build_hooks/${TOKEN}?trigger_branch${TRIGGER_BRANCH}&trigger_title=${TRIGGER_TITLE}"
+        run: curl -s -X POST -d {} "https://api.netlify.com/build_hooks/${TOKEN}?trigger_branch=${TRIGGER_BRANCH}&trigger_title=${TRIGGER_TITLE}"
         if: ${{ env.TOKEN != '' }}

--- a/.github/workflows/netlify-build-docs.yml
+++ b/.github/workflows/netlify-build-docs.yml
@@ -3,9 +3,13 @@ on:
   push:
     branches:
       - '2.x-netlify-build-docs'
+    paths:
+      - 'docs/**'
   pull_request:
     branches:
       - '2.x-netlify-build-docs'
+    paths:
+      - 'docs/**'
 
 jobs:
   build:

--- a/.github/workflows/netlify-build-docs.yml
+++ b/.github/workflows/netlify-build-docs.yml
@@ -2,12 +2,12 @@ name: Trigger Netlify to build docs
 on:
   push:
     branches:
-      - '2.x-netlify-build-docs'
+      - '2.x'
     paths:
       - 'docs/**'
   pull_request:
     branches:
-      - '2.x-netlify-build-docs'
+      - '2.x'
     paths:
       - 'docs/**'
 

--- a/.github/workflows/netlify-build-docs.yml
+++ b/.github/workflows/netlify-build-docs.yml
@@ -30,3 +30,4 @@ jobs:
         if: github.event_name == 'pull_request'
       - name: Trigger Netlify Build Hook
         run: curl -s -X POST -d {} "https://api.netlify.com/build_hooks/${TOKEN}?trigger_branch${TRIGGER_BRANCH}&trigger_title=${TRIGGER_TITLE}"
+        if: ${{ env.TOKEN != '' }}


### PR DESCRIPTION
As I mentioned [on the forum](https://farmos.discourse.group/t/work-proposal-scaffold-a-new-gatsby-site-for-farmos-org-2-x-docs/699/12?u=jgaehring), I think it's time to see how we can incorporate this into farmOS 2.x to start triggering builds on the [test deployment](https://gracious-brattain-bdd606.netlify.app/farmos/docs/). This won't impact the current deployment at docs.farmos.org, nor any of the other workflows. And it's a super lightweight workflow as far as GH Actions go; all it does is fire off a `curl` request and exit the process, doesn't even wait for a response. 

Currently I guess it won't even do that, since I have it set to trigger on `push` and `pull_request` events on the `2.x-netlify-build-docs` branch, which doesn't exist in farmOS/farmOS, so we probably want to add another commit to this to change the target branch, either to `2.x` or some other branch if that's preferable.

The only other requirement is to add the Netlify token to GH secrets for this repo. Down the line, we'll want to set up a permanent Netlify deployment that can be controlled by the farmOS GitHub org. That will also make it easier to share the token across all farmOS projects.

One final note, I've also created a special branch in the Gatsby repo, [`preview-farmos`](https://github.com/jgaehring/farmos.org-2.x/tree/preview-farmos), which triggers a separate [branch deployment](https://preview-farmos--gracious-brattain-bdd606.netlify.app/) when there are pull requests. There's nothing there yet, because there hasn't been a PR to trigger the deploy, but should be nice to add similar branch deployments for other repos' docs.