### PR TITLE
Update Drupal core to 9.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "patches": {
             "drupal/core": {
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
-                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-09-24/2339235-9.2-72.patch",
+                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-12-09/2339235-9.3.x-76.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch"
             },
             "drupal/entity": {

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "patches": {
             "drupal/core": {
                 "Issue #3134470: Switch to entity owner in EntityContentBase during validation": "https://www.drupal.org/files/issues/2021-07-12/3134470-78.patch",
-                "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-10-22/2429699-429_0.patch",
+                "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-11-09/2429699-446.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-09-24/2339235-9.2-72.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         },
         "patches": {
             "drupal/core": {
-                "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-11-09/2429699-446.patch",
+                "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-09-24/2339235-9.2-72.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch"
             },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^2.4",
-        "drupal/core": "9.2.9",
+        "drupal/core": "9.2.10",
         "drupal/config_update": "^1.7",
         "drupal/csv_serialization": "^2.0",
         "drupal/date_popup": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         },
         "patches": {
             "drupal/core": {
-                "Issue #3134470: Switch to entity owner in EntityContentBase during validation": "https://www.drupal.org/files/issues/2021-07-12/3134470-78.patch",
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-11-09/2429699-446.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-09-24/2339235-9.2-72.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^2.4",
-        "drupal/core": "9.2.10",
+        "drupal/core": "9.3.0",
         "drupal/config_update": "^1.7",
         "drupal/csv_serialization": "^2.0",
         "drupal/date_popup": "^1.1",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,11 +1,11 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "~9.2.0"
+        "drupal/core-composer-scaffold": "~9.3.0"
     },
     "require-dev": {
         "brianium/paratest": "^4",
-        "drupal/core-dev": "~9.2.0",
+        "drupal/core-dev": "~9.3.0",
         "phpspec/prophecy-phpunit": "^2",
         "symfony/finder": "^4.0"
     },


### PR DESCRIPTION
The following `drupal/core` patches have been merged upstream and will be included with Drupal 9.3.0:

-  https://www.drupal.org/project/drupal/issues/3134470

This is a draft pull request. It cannot be merged until Drupal 9.3.0 is released, which is scheduled for December 8th 2021 (https://www.drupal.org/about/core/policies/core-release-cycles/schedule).

Note that this PR includes the commits from https://github.com/farmOS/farmOS/pull/454, which will be merged before it.