### PR TITLE
Add missing data stream and quick form menu items.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,9 +23,11 @@ nav:
       - Changes: development/api/changes.md
     - Module:
       - Getting started: development/module/index.md
+      - Data streams: development/module/data_stream.md
       - Entities: development/module/entities.md
       - Fields: development/module/fields.md
       - OAuth: development/module/oauth.md
+      - Quick forms: development/module/quick.md
       - Roles: development/module/roles.md
       - Updates: development/module/updates.md
       - Services: development/module/services.md


### PR DESCRIPTION
Noticed that these are missing from the development/module menu

https://github.com/farmOS/farmOS/runs/4027448205?check_suite_focus=true#step:5:8