### PR TITLE
Fix quick form development/module link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,7 +23,7 @@ nav:
       - Changes: development/api/changes.md
     - Module:
       - Getting started: development/module/index.md
-      - Quick forms: development/modules/quick.md
+      - Quick forms: development/module/quick.md
       - Entities: development/module/entities.md
       - Fields: development/module/fields.md
       - OAuth: development/module/oauth.md


### PR DESCRIPTION
Just a little typo. The current menu link is broken: https://docs.farmos.org/development/modules/quick.md