### PR TITLE
Allow specifying a units_id to skip loading an existing term

### DIFF
--- a/modules/core/quick/src/Traits/QuickQuantityTrait.php
+++ b/modules/core/quick/src/Traits/QuickQuantityTrait.php
@@ -40,7 +40,12 @@ trait QuickQuantityTrait {
     // If the units are a term name, create or load the unit taxonomy term.
     if (!empty($values['units'])) {
       $term = $this->createOrLoadTerm($values['units'], 'unit');
-      $values['units'] = $term;
+      $values['units'] = $term->id();
+    }
+    // Else check if a units term ID is provided and use that instead.
+    elseif (!empty($values['units_id'])) {
+      $values['units'] = $values['units_id'];
+      unset($values['units_id']);
     }
 
     // Start a new quantity entity with the provided values.


### PR DESCRIPTION
I think this would be a nice improvement for the `QuickQuantityTrait` to better support creating quantities in quick forms.

Currently the `QuickQuantityTrait::createQuantity` method always passes a non-empty `units` value to the `QuickTermTrait::createOrLoadTerm` method which creates or loads a term of the given term name. This is inconvenient when using the `entity_autocomplete` form element which returns the entity ID(s) in a `string` variable - without any additional processing, this helper method creates a new term with the label just being a numeric ID.

It would be convenient to only call `QuickTermTrait::createOrLoadTerm` when a true non-numeric term name is provided. This way the `entity_autocomplete` form element can be used without any additional form processing.

The downside to this change is that `QuickQuantityTrait` won't support creating a `unit` term that actually has a numeric label. But I think this is OK because I can't imagine why such a unit would be helpful...

For example, this change would support super simple quick form submission of multiple quantities:
```php

  /**
   * {@inheritdoc}
   */
  public function buildForm(array $form, FormStateInterface $form_state, string $id = NULL) {
    $form = parent::buildForm($form, $form_state);

    // ...... additional form fields that provide a "count" field w/ AJAX replacement.

    // Add fields for each quantity.
    $form['quantity']['quantities']['#tree'] = TRUE;
    $quantities = $form_state->getValue('count', 1);
    for ($i = 0; $i < $quantities; $i++) {

      // Fieldset for each quantity.
      $form['quantity']['quantities'][$i] = [
        '#type' => 'details',
        '#title' => $this->t('Quantity @number', ['@number' => $i + 1]),
        '#collapsible' => TRUE,
        '#open' => TRUE,
      ];

      // Quantity measure (weight or volume).
      $form['quantity']['quantities'][$i]['measure'] = [
        '#type' => 'select',
        '#title' => $this->t('Quantity measure'),
        '#options' => [
          'weight' => $this->t('Weight'),
          'volume' => $this->t('Volume'),
        ],
      ];

      // Quantity value.
      $form['quantity']['quantities'][$i]['value'] = [
        '#type' => 'number',
        '#title' => $this->t('Quantity value'),
      ];

      // Quantity units.
      $form['quantity']['quantities'][$i]['units'] = [
        '#type' => 'entity_autocomplete',
        '#target_type' => 'taxonomy_term',
        '#title' => $this->t('Quantity units'),
        '#selection_settings' => [
          'target_bundles' => ['unit'],
        ],
      ];

      // Quantity label.
      $form['quantity']['quantities'][$i]['label'] = [
        '#type' => 'textfield',
        '#title' => $this->t('Quantity label'),
      ];
    }

    return $form;
  }

  /**
   * {@inheritdoc}
   */
  public function submitForm(array &$form, FormStateInterface $form_state) {
    $log = [
      'name' => $this->t('Harvest log'),
      'type' => 'harvest',
      'quantity' => $form_state->getValue('quantities') ?? [],
    ];

    // Create the log.
    $this->createLog($log);
  }

```