### PR TITLE
Fix bugs after *_field_allowed_values changes

### DIFF
--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -163,7 +163,7 @@ class EntityFlagActionForm extends ConfirmFormBase {
     // disallowed flags cannot be assigned.
     $allowed_values = [];
     $field_storage_definitions = $this->entityFieldManager->getFieldStorageDefinitions($entity_type_id);
-    if (!empty($base_field_definitions['flag'])) {
+    if (!empty($field_storage_definitions['flag'])) {
       foreach ($this->entities as $entity) {
         $entity_allowed_values = farm_flag_field_allowed_values($field_storage_definitions['flag'], $entity);
         if (empty($allowed_values)) {


### PR DESCRIPTION
After updating our farm_land_type_field_allowed_values function we forgot to update this usage in the KML importer. I've checked for other usages of these *_field_allowed_values functions but did not see any others that we haven't already updated. Hopefully there aren't too many in 2.x contrib land.

Also, I forgot to update this variable name in the EntityFlagActionForm.