### PR TITLE
Correct the kml importer valid extensions

### DIFF
--- a/modules/core/import/modules/kml/src/Form/KmlImporter.php
+++ b/modules/core/import/modules/kml/src/Form/KmlImporter.php
@@ -104,7 +104,7 @@ class KmlImporter extends FormBase {
       '#description' => $this->t('Upload your KML file here and click "Parse".'),
       '#upload_location' => 'private://kml',
       '#upload_validators' => [
-        'file_validate_extensions' => 'kml kmz',
+        'file_validate_extensions' => ['kml kmz'],
       ],
       '#required' => TRUE,
     ];


### PR DESCRIPTION
Currently any file can be uploaded in the KML import form. This is because we have a slight error with the `file_validate_extensions` value - instead of just a string, it should be an array with a single string value

This is only an issue when the `managed_file` element is used directly. I also tested our file field definitions in `FarmFieldFactory` that specify `file_extensions` (like `log.file` and `log.image`) and confirmed they are working correctly.

I know, this is weird... but in the `managed_file` element only the 0 index is checked and passed client side as drupal settings for validation: https://git.drupalcode.org/project/drupal/-/blob/9.3.x/core/modules/file/src/Element/ManagedFile.php#L366

