### PR TITLE
Add allow-plugins config.

### DIFF
--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -38,6 +38,18 @@ elif [[ ! "${FARMOS_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9
 fi
 composer require farmos/farmos ${FARMOS_COMPOSER_VERSION} --no-install
 
+# Add allow-plugins config.
+allowedPlugins=(
+  "composer/installers"
+  "cweagans/composer-patches"
+  "drupal/core-composer-scaffold"
+  "oomphinc/composer-installers-extender"
+  "wikimedia/composer-merge-plugin"
+)
+for plugin in ${allowedPlugins[@]}; do
+  composer config --no-plugins allow-plugins.$plugin true
+done
+
 # Run composer install with optional arguments passed into this script.
 if [ $# -eq 0 ]; then
   composer install


### PR DESCRIPTION
Rather than define this in our composer project, lets define it as a part of our build process. This way downstream users of the `farmos/composer-project` will have to allow the plugins themselves.

Follow up from https://github.com/farmOS/composer-project/pull/6