### PR TITLE
Open the Gin toolbar by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Open the Gin toolbar by default #470](https://github.com/farmOS/farmOS/pull/470)
 - [Enforce that the changelog is updated with every pull request #469](https://github.com/farmOS/farmOS/pull/469)
 
 ### Fixed

--- a/modules/core/ui/theme/farm_ui_theme.libraries.yml
+++ b/modules/core/ui/theme/farm_ui_theme.libraries.yml
@@ -30,3 +30,5 @@ toolbar:
   css:
     theme:
       css/toolbar.css: { }
+  js:
+    js/toolbar.js: { weight: -50 }

--- a/modules/core/ui/theme/js/toolbar.js
+++ b/modules/core/ui/theme/js/toolbar.js
@@ -1,0 +1,8 @@
+(function () {
+
+  // Open the Gin toolbar by default.
+  itemName = 'GinSidebarOpen';
+  if (localStorage.getItem(itemName) === null) {
+    localStorage.setItem(itemName, 'true');
+  }
+}());

--- a/modules/core/ui/theme/js/toolbar.js
+++ b/modules/core/ui/theme/js/toolbar.js
@@ -1,6 +1,12 @@
 (function () {
 
   // Open the Gin toolbar by default.
+  var itemName = 'Drupal.gin.toolbarExpanded';
+  if (localStorage.getItem(itemName) === null) {
+    localStorage.setItem(itemName, 'true');
+  }
+  // @todo Remove this when new Gin version is released.
+  // Gin changed the name after 8.x-3.0-alpha37.
   itemName = 'GinSidebarOpen';
   if (localStorage.getItem(itemName) === null) {
     localStorage.setItem(itemName, 'true');


### PR DESCRIPTION
Currently the Gin toolbar appears collapsed by default. When you hover over *some* of the items, it opens a drawer with a title in the top to let you know what it is. But others (like the "Locations" item at the top) do not. It's not apparent what those items are without clicking on them. And it's not obvious that you can expand the toolbar by clicking the little > button at the bottom.

I propose we open the Gin toolbar by default, so that users can make the choice to close it if they want. This can be accomplished by simply setting the `GinSidebarOpen` local storage item to `true` if it  `=== null` on page load. This gets picked up by Gin's `gin_toolbar.js` behavior, which will then open the toolbar. Thus, this JavaScript needs to be loaded *before* the Gin JS (hence the `weight: -50` in this change).