### PR TITLE
Issue #3241653: Split SQLite3 tests out to a separate workflow.

### DIFF
--- a/.github/workflows/run-tests-sqlite.yml
+++ b/.github/workflows/run-tests-sqlite.yml
@@ -1,4 +1,7 @@
-name: Run 2.x PHPUnit tests
+# This has been separated from run-tests.yml because SQLite3 fails frequently
+# when tests are run in parallel via paratest. This is a temporary workaround.
+# @todo https://www.drupal.org/project/farm/issues/3241653
+name: Run 2.x PHPUnit tests (for SQlite3)
 on:
   schedule:
     - cron: '0 8 * * *' # Run at 8AM UTC.
@@ -17,13 +20,10 @@ jobs:
     strategy:
       matrix:
         dbms:
-         - pgsql
-         - mariadb
+         - sqlite
         include:
-          - dbms: pgsql
-            DB_URL: pgsql://farm:farm@db/farm
-          - dbms: mariadb
-            DB_URL: mysql://farm:farm@db/farm
+          - dbms: sqlite
+            DB_URL: sqlite://localhost/sites/default/files/db.sqlite
     steps:
       - name: Print test matrix variables
         run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Add allow-plugins config #467](https://github.com/farmOS/farmOS/pull/467)
+- Split SQLite3 automated tests out to a separate GitHub Actions workflow (temporary workaround for
+  [Issue #3241653: Occasional test failures with SQLite: SQLSTATE[HY000]: General error: 5 database is locked](https://www.drupal.org/project/farm/issues/3241653))
 
 ### Fixed
 


### PR DESCRIPTION
This is a temporary workaround for SQLite3 test failures.
@todo https://www.drupal.org/project/farm/issues/3241653