### PR TITLE
Allow all three database tests to run even when one fails.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,6 +27,12 @@ jobs:
             DB_URL: mysql://farm:farm@db/farm
           - dbms: sqlite
             DB_URL: sqlite://localhost/sites/default/files/db.sqlite
+      # Allow all three database tests to run even when one fails.
+      # This is a temporary workaround for Issue #3241653: Occasional test
+      # failures with SQLite: SQLSTATE[HY000]: General error: 5 database is
+      # locked
+      # @todo https://www.drupal.org/project/farm/issues/3241653
+      fail-fast: false
     steps:
       - name: Print test matrix variables
         run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Patch `jsonapi_schema` module to fix
   [Issue #3256795: Float fields have a null schema](https://www.drupal.org/project/jsonapi_schema/issues/3256795)
+- Allow all three database tests to run even when one fails (workaround
+  for [Issue #3241653](https://www.drupal.org/project/farm/issues/3241653)).
 
 ### Security
 


### PR DESCRIPTION
This is a temporary workaround for Issue #3241653: Occasional test
failures with SQLite: SQLSTATE[HY000]: General error: 5 database is locked

@todo https://www.drupal.org/project/farm/issues/3241653