### PR TITLE
Fix: Buttons not translateable

### DIFF
--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -4,11 +4,14 @@ namespace Drupal\farm_ui_action\Plugin\Derivative;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Component\Utility\Unicode;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Defines farmOS action links.
  */
 class FarmActions extends DeriverBase {
+
+  use StringTranslationTrait;
 
   /**
    * {@inheritdoc}
@@ -36,7 +39,7 @@ class FarmActions extends DeriverBase {
       // Generate a link to [entity-type]/add.
       $name = 'farm.add.' . $type;
       $this->derivatives[$name] = $base_plugin_definition;
-      $this->derivatives[$name]['title'] = 'Add ' . Unicode::ucfirst($type);
+      $this->derivatives[$name]['title'] = $this->t('Add :entity_type', [':entity_type' => Unicode::ucfirst($type)]);
       $this->derivatives[$name]['route_name'] = 'entity.' . $type . '.add_page';
 
       // Add it to entity Views, if the farm_ui_views module is enabled.

--- a/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -70,8 +70,8 @@ class AddEntity extends LocalActionDefault {
     // Get the entity type.
     $entity_type = $this->entityTypeManager->getDefinition($this->pluginDefinition['entity_type']);
 
-    // Get the entity type label (lowercase).
-    $entity_type_label = Unicode::lcfirst($entity_type->getLabel());
+    // Get the entity type label.
+    $entity_type_label = $entity_type->getLabel();
 
     // Get the bundle machine name.
     $route_match = RouteMatch::createFromRequest($request);


### PR DESCRIPTION
Pull request mentioned here:
https://github.com/farmOS/farmOS/issues/472#issuecomment-1006725357

I´m still not 100% happy with this. The Button on the Dashboard still uses ucfirst, but I thought it's fine there for now because there are just two words.
The other one should maybe be changed more. Right now I removed the lowercase because I think this is language-dependent and should be done in translation. I know while I was translating I came across the phrase "Animal assets" and all the other assets as well. Maybe something like this should be used.