### PR TITLE
Log categories are not migrated to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [Log categories are not migrated to v2 #481](https://github.com/farmOS/farmOS/pull/481)
 - Make local action buttons translatable.
 - Fix permission for map settings form (/farm/settings/map).
 - Patch `jsonapi_schema` module to fix

--- a/modules/core/migrate/config/install/migrate_plus.migration_group.farm_migrate_log.yml
+++ b/modules/core/migrate/config/install/migrate_plus.migration_group.farm_migrate_log.yml
@@ -104,7 +104,7 @@ shared_configuration:
     is_group_assignment:
       plugin: get
       source: is_group_assignment
-    log_category:
+    category:
       plugin: sub_process
       source: field_farm_log_category
       process:


### PR DESCRIPTION
I'm not sure how this went unnoticed, but it looks like the v2 migration of Log categories data is broken. The Log category taxonomy terms themselves are migrated properly, but none of them get assigned to logs created during the log migrations.

The bug is on this line of code:

https://github.com/farmOS/farmOS/blob/143967356080ff2259e53ece5a827be5aa1412d7/modules/core/migrate/config/install/migrate_plus.migration_group.farm_migrate_log.yml#L107

It is trying to assign categories to a field named `log_category` on logs, but that field does not exist. The field name should be simply `category`.

https://github.com/farmOS/farmOS/blob/143967356080ff2259e53ece5a827be5aa1412d7/modules/core/entity/modules/fields/farm_entity_fields.base_fields.inc#L77