### PR TITLE
Grant data stream and notification permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [Data stream and notification permissions are not granted to managed roles. #479](https://github.com/farmOS/farmOS/issues/479)
 - [Log categories are not migrated to v2 #481](https://github.com/farmOS/farmOS/pull/481)
 - Make local action buttons translatable.
 - Fix permission for map settings form (/farm/settings/map).

--- a/modules/core/data_stream/modules/notification/data_stream_notification.managed_role_permissions.yml
+++ b/modules/core/data_stream/modules/notification/data_stream_notification.managed_role_permissions.yml
@@ -1,0 +1,7 @@
+data_stream_notification:
+  config_permissions:
+    - access data_stream_notification overview
+    - create data_stream_notification
+    - delete data_stream_notification
+    - update data_stream_notification
+    - view data_stream_notification

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -222,6 +222,10 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
       // 'delete_all' operations to their specific operations.
       switch ($entity_type) {
 
+        // Entity types with EntityOwnerTrait and RevisionLogEntityTrait have
+        // additional permissions for view, update and delete operations:
+        // Owner adds "operation any bundle" or "operation own bundle".
+        // Revision adds "operation all bundle revisions".
         case 'asset':
         case 'log':
         case 'plan':
@@ -280,6 +284,9 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
           }
           break;
 
+        // Taxonomy terms are a unique case for two reasons:
+        // View access is determined by the "access content" permission
+        // and "edit" is the name for the update operation permission.
         case 'taxonomy_term':
 
           // Create.

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -194,7 +194,14 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
     $entity_settings = $access_settings['entity'] ? $access_settings['entity'] : [];
 
     // Managed entity types.
-    $managed_entity_types = ['asset', 'log', 'plan', 'taxonomy_term', 'quantity'];
+    $managed_entity_types = [
+      'asset',
+      'data_stream',
+      'log',
+      'plan',
+      'taxonomy_term',
+      'quantity',
+    ];
 
     // Start an array of permission rules. This will be a multi-dimensional
     // array that ultimately defines which permission strings will be given to
@@ -245,6 +252,31 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
           if (!empty($entity_settings['delete all'])) {
             $permission_rules[$entity_type]['delete any'] = ['all'];
             $permission_rules[$entity_type]['delete own'] = ['all'];
+          }
+          break;
+
+        // Entity types with basic CRUD permissions.
+        case 'data_stream':
+
+          // Create.
+          if (!empty($entity_settings['create all'])) {
+            $permission_rules[$entity_type]['create'] = ['all'];
+          }
+
+          // View.
+          if (!empty($entity_settings['view all'])) {
+            $perms[] = 'view ' . $entity_type;
+            $permission_rules[$entity_type]['view'] = ['all'];
+          }
+
+          // Update.
+          if (!empty($entity_settings['update all'])) {
+            $permission_rules[$entity_type]['update'] = ['all'];
+          }
+
+          // Delete.
+          if (!empty($entity_settings['delete all'])) {
+            $permission_rules[$entity_type]['delete'] = ['all'];
           }
           break;
 
@@ -303,6 +335,7 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
             case 'log':
             case 'plan':
             case 'quantity':
+            case 'data_stream':
               if (array_intersect(['all', $bundle], $allowed_bundles)) {
                 $perms[] = $operation . ' ' . $bundle . ' ' . $entity_type;
               }


### PR DESCRIPTION
Closes #479 

- Adds `data_stream` as a managed entity type.
- Adds all `{operation} data_stream_notification` permissions to roles with config access.

In the future it would be nice if the "managed entities" could support config entities and bundle-less entities as well. Right now our `role.*.third_party.farm_role` schema expects an array of bundles when declaring more granular permission sets.

Noting this here because I investigated a little bit. The logic for this could be fairly simple, based off `$entity_type->getBundleEntityType()`:
```php
          // ManagedRolePermissionsManager::getManagedPermissionsForRole() 
          switch ($entity_type) {

            case 'asset':
            case 'log':
            case 'plan':
            case 'quantity':
            case 'data_stream':
            case 'data_stream_notification':

              // Only include the bundle if necessary.
              if ($this->entityTypeManager->getDefinition($entity_type)->getBundleEntityType()) {
                if (array_intersect(['all', $bundle], $allowed_bundles)) {
                  $perms[] = $operation . ' ' . $bundle . ' ' . $entity_type;
                }
              } else {
                $perms[] = $operation . ' ' . $entity_type;
              }
              break;
 ```