### PR TITLE
Change getGroupMembers to return an array of assets keyed by their ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Issue #3259245: Change getGroupMembers to return an array of assets keyed by their ID](https://www.drupal.org/project/farm/issues/3259245)
+
 ### Fixed
 
 - [Issue #3260645: CSV Export in Quantities not functioning](https://www.drupal.org/project/farm/issues/3260645)

--- a/modules/asset/group/src/GroupMembership.php
+++ b/modules/asset/group/src/GroupMembership.php
@@ -216,7 +216,8 @@ class GroupMembership implements GroupMembershipInterface {
       $groups = array_filter($assets, function (AssetInterface $asset) {
         return $asset->bundle() === 'group';
       });
-      $assets = array_merge($assets, $this->getGroupMembers($groups));
+      // Use array_replace so that numeric keys are preserved.
+      $assets = array_replace($assets, $this->getGroupMembers($groups));
     }
     return $assets;
   }

--- a/modules/asset/group/src/GroupMembershipInterface.php
+++ b/modules/asset/group/src/GroupMembershipInterface.php
@@ -53,7 +53,7 @@ interface GroupMembershipInterface {
    *   Defaults to TRUE.
    *
    * @return \Drupal\asset\Entity\AssetInterface[]
-   *   Returns an array of assets.
+   *   An array of asset objects indexed by their IDs.
    */
   public function getGroupMembers(array $groups, bool $recurse = TRUE): array;
 

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -246,6 +246,10 @@ class GroupTest extends KernelTestBase {
     $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($second_animal)[0]->id(), 'The second animal is in the first group.');
     $group_members = $this->groupMembership->getGroupMembers([$first_group, $second_group]);
     $this->assertEquals(2, count($group_members), 'Group members from multiple groups can be queried together.');
+
+    // Test that asset IDs are preserved as the array keys.
+    $this->assertTrue(in_array($animal->id(), array_keys($group_members)), 'The ID of the first animal is preserved.');
+    $this->assertTrue(in_array($second_animal->id(), array_keys($group_members)), 'The ID of the second animal is preserved.');
   }
 
   /**


### PR DESCRIPTION
See https://www.drupal.org/project/farm/issues/3259245

> Add/update tests to ensure asset IDs are returned as the keys, with both $recurse options.

It didn't seem like we had any explicit tests for the `recursive` parameter so I added a new dedicated test method for this.