### PR TITLE
Provide a helper function for loading flag options and allowed values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Provide a helper function for loading flag options and allowed values.](https://www.drupal.org/project/farm/issues/3253433)
+
 ## [2.0.0-beta2] 2022-01-19
 
 ### Added

--- a/modules/core/flag/farm_flag.module
+++ b/modules/core/flag/farm_flag.module
@@ -70,6 +70,82 @@ function farm_flag_field_allowed_values(FieldStorageDefinitionInterface $definit
 }
 
 /**
+ * Returns flag allowed values for the given the entity type and bundles.
+ *
+ * @param string|null $entity_type
+ *   The entity type. Returns all flags if NULL.
+ * @param string[] $bundles
+ *   Array of bundle ids to limit to. An empty array loads all bundles.
+ * @param bool $intersection
+ *   A flag indicating to return an intersection of the allowed options.
+ *
+ * @return array
+ *   Returns an array of allowed values for use in form select options.
+ */
+function farm_flag_allowed_values(string $entity_type = NULL, array $bundles = [], bool $intersection = FALSE): array {
+  return array_map(function ($flag) {
+    return $flag->label();
+  }, farm_flag_options($entity_type, $bundles, $intersection));
+}
+
+/**
+ * Returns flag options for the given the entity type and bundles.
+ *
+ * @param string|null $entity_type
+ *   The entity type. Returns all flags if NULL.
+ * @param string[] $bundles
+ *   Array of bundle ids to limit to. An empty array loads all bundles.
+ * @param bool $intersection
+ *   A flag indicating to return an intersection of the allowed options.
+ *
+ * @return \Drupal\farm_flag\Entity\FarmFlagInterface[]
+ *   An array of flag objects indexed by their IDs.
+ */
+function farm_flag_options(string $entity_type = NULL, array $bundles = [], bool $intersection = FALSE) {
+  /** @var \Drupal\farm_flag\Entity\FarmFlagInterface[] $flags */
+  $flags = \Drupal::entityTypeManager()->getStorage('flag')->loadMultiple();
+
+  // Return all flags if no entity type is provided.
+  if (empty($entity_type)) {
+    return $flags;
+  }
+
+  // If no bundles are specified, load all bundles of the specified entity type.
+  if (empty($bundles) && $bundle_entity_type = \Drupal::entityTypeManager()->getDefinition($entity_type)->getBundleEntityType()) {
+    $bundles = array_keys(\Drupal::entityTypeManager()->getStorage($bundle_entity_type)->loadMultiple());
+  }
+
+  // Return only the flags that apply to the entity type and bundles.
+  return array_filter($flags, function ($flag) use ($entity_type, $bundles, $intersection) {
+    $flag_entity_types = $flag->getEntityTypes();
+
+    // The flag applies if no entity type is specified.
+    if (empty($flag_entity_types)) {
+      return TRUE;
+    }
+
+    // Otherwise the flag must specify the entity type.
+    if (!array_key_exists($entity_type, $flag_entity_types)) {
+      return FALSE;
+    }
+
+    // The flag applies to the bundle if:
+    // Case 1: The flag specifies 'all' bundles of the entity type.
+    $bundle_applies = in_array('all', $flag_entity_types[$entity_type]);
+
+    // Case 2: No intersection.
+    // The flag applies if any of the requested bundles are supported.
+    $bundle_applies |= !$intersection && !empty(array_intersect($bundles, $flag_entity_types[$entity_type]));
+
+    // Case 3: Intersection.
+    // The flag only applies if all the requested bundles are supported.
+    $bundle_applies |= $intersection && empty(array_diff($bundles, $flag_entity_types[$entity_type]));
+
+    return $bundle_applies;
+  });
+}
+
+/**
  * Check to see if a flag applies to an entity type + bundle.
  *
  * @param \Drupal\farm_flag\Entity\FarmFlagInterface $flag

--- a/modules/core/flag/farm_flag.module
+++ b/modules/core/flag/farm_flag.module
@@ -51,22 +51,14 @@ function farm_flag_entity_base_field_info(EntityTypeInterface $entity_type) {
  *   Returns an array of allowed values for use in form select options.
  */
 function farm_flag_field_allowed_values(FieldStorageDefinitionInterface $definition, ContentEntityInterface $entity = NULL, bool &$cacheable = TRUE) {
-  /** @var \Drupal\farm_flag\Entity\FarmFlagInterface[] $flags */
-  $flags = \Drupal::entityTypeManager()->getStorage('flag')->loadMultiple();
-  $allowed_values = [];
   $entity_type = NULL;
-  $bundle = NULL;
+  $bundles = [];
   if (!empty($entity)) {
     $cacheable = FALSE;
     $entity_type = $entity->getEntityTypeId();
-    $bundle = $entity->bundle();
+    $bundles = [$entity->bundle()];
   }
-  foreach ($flags as $id => $flag) {
-    if (farm_flag_applies($flag, $entity_type, $bundle)) {
-      $allowed_values[$id] = $flag->getLabel();
-    }
-  }
-  return $allowed_values;
+  return farm_flag_allowed_values($entity_type, $bundles);
 }
 
 /**

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -161,19 +161,10 @@ class EntityFlagActionForm extends ConfirmFormBase {
     // Get allowed values for the selected entities.
     // We find the intersection of all the allowed values to ensure that
     // disallowed flags cannot be assigned.
-    $allowed_values = [];
-    $field_storage_definitions = $this->entityFieldManager->getFieldStorageDefinitions($entity_type_id);
-    if (!empty($field_storage_definitions['flag'])) {
-      foreach ($this->entities as $entity) {
-        $entity_allowed_values = farm_flag_field_allowed_values($field_storage_definitions['flag'], $entity);
-        if (empty($allowed_values)) {
-          $allowed_values = $entity_allowed_values;
-        }
-        else {
-          $allowed_values = array_intersect_assoc($allowed_values, $entity_allowed_values);
-        }
-      }
-    }
+    $entity_bundles = array_unique(array_map(function ($entity) {
+      return $entity->bundle();
+    }, $this->entities));
+    $allowed_values = farm_flag_allowed_values($entity_type_id, $entity_bundles, TRUE);
 
     $form['flags'] = [
       '#type' => 'select',

--- a/modules/core/flag/tests/src/Kernel/FlagTest.php
+++ b/modules/core/flag/tests/src/Kernel/FlagTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Drupal\Tests\farm_flag\Kernel;
+
+use Drupal\farm_flag\Entity\FarmFlag;
+use Drupal\Tests\token\Kernel\KernelTestBase;
+
+/**
+ * Tests for farm_flag logic.
+ *
+ * @group farm_flag
+ */
+class FlagTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'farm_field',
+    'farm_flag',
+    'log',
+    'asset',
+    'state_machine',
+  ];
+
+  /**
+   * Test farm flag options logic.
+   */
+  public function testFarmFlagOptions() {
+
+    // Create a general flag that applies to all entity types.
+    $general_flag = FarmFlag::create([
+      'id' => 'general',
+      'label' => 'General',
+      'entity_types' => NULL,
+    ]);
+    $general_flag->save();
+
+    // Create bundles and flags for testing.
+    $test_entity_types = [
+      'log' => ['activity', 'input', 'observation'],
+      'asset' => [],
+    ];
+    foreach ($test_entity_types as $entity_type => $bundles) {
+      $entity_type_id = $entity_type . '_type';
+
+      // Create a flag for all bundles of the entity type.
+      $flag = FarmFlag::create([
+        'id' => $entity_type . '_flag',
+        'entity_types' => [
+          $entity_type => ['all'],
+        ],
+      ]);
+      $flag->save();
+
+      // Create bundles and a flag for each bundle.
+      foreach ($bundles as $bundle_id) {
+
+        // Create the bundle.
+        $bundle = \Drupal::entityTypeManager()->getStorage($entity_type_id)->create([
+          'id' => $bundle_id,
+          'workflow' => $entity_type . '_default',
+        ]);
+        $bundle->save();
+
+        // Create a flag that only applies for the bundle.
+        $flag = FarmFlag::create([
+          'id' => $bundle_id . '_flag',
+          'entity_types' => [
+            $entity_type => [$bundle_id],
+          ],
+        ]);
+        $flag->save();
+      }
+    }
+
+    // Create a special flag that only applies to activity logs.
+    $flag = FarmFlag::create([
+      'id' => 'special_flag',
+      'entity_types' => [
+        'log' => ['activity'],
+      ],
+    ]);
+    $flag->save();
+
+    // Load all flag options.
+    $all_flags = \Drupal::entityTypeManager()->getStorage('flag')->loadMultiple();
+    $all_flag_ids = array_keys($all_flags);
+
+    // 1. With default parameters all flag options are returned.
+    $expected_flag_ids = array_keys(farm_flag_options());
+    $this->assertEmpty(array_diff($expected_flag_ids, $all_flag_ids), 'All flag options are returned.');
+
+    // 2. Flags applying to any asset type are returned.
+    $flag_ids = array_keys(farm_flag_options('asset'));
+    $expected_flag_ids = ['general', 'asset_flag'];
+    $this->assertEmpty(array_diff($expected_flag_ids, $flag_ids));
+
+    // 3. Flags applying to any log type are returned.
+    $flag_ids = array_keys(farm_flag_options('log'));
+    $expected_flag_ids = ['general', 'log_flag', 'special_flag', 'activity_flag', 'input_flag', 'observation_flag'];
+    $this->assertEmpty(array_diff($expected_flag_ids, $flag_ids));
+
+    // 4. Flags applying to every log type are returned.
+    $flag_ids = array_keys(farm_flag_options('log', [], TRUE));
+    $expected_flag_ids = ['general', 'log_flag'];
+    $this->assertEmpty(array_diff($expected_flag_ids, $flag_ids));
+
+    // 5. Flags applying to either activity or input log types are returned.
+    $flag_ids = array_keys(farm_flag_options('log', ['activity', 'input']));
+    $expected_flag_ids = ['general', 'log_flag', 'special_flag', 'activity_flag', 'input_flag'];
+    $this->assertEmpty(array_diff($expected_flag_ids, $flag_ids));
+
+    // 6. Flags applying to both activity and input log types are returned.
+    $flag_ids = array_keys(farm_flag_options('log', ['activity', 'input'], TRUE));
+    $expected_flag_ids = ['general', 'log_flag'];
+    $this->assertEmpty(array_diff($expected_flag_ids, $flag_ids));
+
+    // 7. Flags applying to only the activity log types are returned.
+    $flag_ids = array_keys(farm_flag_options('log', ['activity'], TRUE));
+    $expected_flag_ids = ['general', 'log_flag', 'special_flag', 'activity_flag'];
+    $this->assertEmpty(array_diff($expected_flag_ids, $flag_ids));
+  }
+
+}

--- a/modules/core/ui/views/farm_ui_views.module
+++ b/modules/core/ui/views/farm_ui_views.module
@@ -115,24 +115,8 @@ function farm_ui_views_form_views_exposed_form_alter(&$form, FormStateInterface 
   // Get the entity type and (maybe) bundle.
   $entity_type = $storage['view']->getBaseEntityType()->id();
   $bundle = farm_ui_views_get_bundle_argument($storage['view'], $storage['display']['id'], $storage['view']->args);
-
-  // Load flag entities and filter out ones that don't apply.
-  /** @var \Drupal\farm_flag\Entity\FarmFlagInterface[] $flags */
-  $flags = \Drupal::entityTypeManager()->getStorage('flag')->loadMultiple();
-  $allowed_flag_ids = [];
-  foreach ($flags as $flag) {
-    if (farm_flag_applies($flag, $entity_type, $bundle)) {
-      $allowed_flag_ids[] = $flag->id();
-    }
-  }
-
-  // Alter exposed filters to remove flags that are not applicable.
-  $allowed_options = [];
-  foreach ($form['flag_value']['#options'] as $key => $value) {
-    if (in_array($key, $allowed_flag_ids)) {
-      $allowed_options[$key] = $value;
-    }
-  }
+  $bundles = !empty($bundle) ? [$bundle] : [];
+  $allowed_options = farm_flag_allowed_values($entity_type, $bundles, TRUE);
   $form['flag_value']['#options'] = $allowed_options;
 }
 


### PR DESCRIPTION
See https://www.drupal.org/project/farm/issues/3253433

As mentioned in the issue this is kind of the "reverse approach" that the existing `farm_flag_applies` takes. This change makes the existing implementation of `farm_flag_applies` much simpler, although I'm not sure we can remove the function altogether (breaking change?)

The terminology of this is a little confusing, so definitely open to ideas here, but this ability to load the "intersection" of flags that "apply" to *any* or *every* bundle is the key difference here. I think the tests should demonstrate this pretty well.