### PR TITLE
Correct list formatting in module development documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Issue #3260645: CSV Export in Quantities not functioning](https://www.drupal.org/project/farm/issues/3260645)
+- Correct list formatting in module development documentation.
 
 ## [2.0.0-beta2] 2022-01-19
 

--- a/docs/development/module/oauth.md
+++ b/docs/development/module/oauth.md
@@ -28,8 +28,8 @@ Standard Consumer configuration:
 
 - `consumer.label` - A label used to identify the third party integration.
 - `consumer.client_id` - An optional `client_id` machine name to identify the
- consumer. The `simple_oauth` module uses a UUID by default, but a machine
- name makes it easier to identify clients across multiple farmOS servers.
+  consumer. The `simple_oauth` module uses a UUID by default, but a machine
+  name makes it easier to identify clients across multiple farmOS servers.
 - `consumer.secret` - A `client_secret` used to secure the OAuth client.
 - `consumer.confidential` - A boolean indicating whether the client secret
   needs to be validated.
@@ -38,7 +38,7 @@ Standard Consumer configuration:
       third party must keep track of a different secret for each server. This
       challenge is due to the nature of farmOS being a self-hosted application.
 - `consumer.user_id` - When no specific user is authenticated Drupal will use
- this user as the author of all the actions made by this consumer.
+  this user as the author of all the actions made by this consumer.
     - This is only the case during the `Client Credentials` authorization flow.
 - `consumer.redirect_uri` - The URI this client will redirect to when needed.
     - This is used with the Authorization Code authorization flow.
@@ -58,17 +58,17 @@ a consumer entity programmatically.
 Authorization options (all are disabled by default):
 
 - `consumer.grant_user_access` - Always grant the authorizing user's access
- to this consumer.
+  to this consumer.
     - This is how the farmOS Field Kit consumer is configured. If this is the
       only option enabled, then the consumer will only be granted the roles
       the user has access to.
 - `consumer.limit_requested_access` - Only grant this consumer the scopes
- requested during authorization.
+  requested during authorization.
     - By default, all scopes configured with the consumer will be granted
       during authorization. This allows users to select which scopes they want
       to grant the third party during authorization.
 - `consumer.limit_user_access` - Never grant the consumer more access than
- the authorizing user.
+  the authorizing user.
     - It is possible that clients will be configured with different roles
       than the user that authorizes access to a third party. There are times
       that this may be intentional, but this setting ensures that consumers

--- a/docs/development/module/roles.md
+++ b/docs/development/module/roles.md
@@ -28,22 +28,22 @@ defines the structure of these settings.
       configuration. Only grant this to trusted roles.
     - `entity`: Access permissions relating to entities.
         - `view all`: Boolean that specifies the role should have access to view
-        all bundles of all entity types.
+          all bundles of all entity types.
         - `create all`: Boolean that specifies the role should have access to
-        create all bundles of all entity types.
+          create all bundles of all entity types.
         - `update all`: Boolean that specifies the role should have access to
-        update all bundles of all entity types.
+          update all bundles of all entity types.
         - `delete all`: Boolean that specifies the role should have access to
-        delete all bundles of all entity types.
+          delete all bundles of all entity types.
         - `type`: Access permissions for specific entity types.
             - `{entity_type}`: The id of the entity type. eg: `log`,`asset`,
-            `taxonomy_term`, etc.
-                - `{operation}`: The operation to grant bundles of this entity
+              `taxonomy_term`, etc.
+              - `{operation}`: The operation to grant bundles of this entity
                 type. Eg: `create`, `view any`, `view own`, `delete any`,
                 `delete own`, etc.
-                    - `{bundle}`: The id of the entity type bundle or `all` to
-                    grant the operation permission to all bundles of the entity
-                    type.
+                - `{bundle}`: The id of the entity type bundle or `all` to
+                  grant the operation permission to all bundles of the entity
+                  type.
 
 Settings used for the Manager role (full access to all entities + access to
 configuration):


### PR DESCRIPTION
Some of the long text in markdown lists is not fully indented, leading to some wonky formatting. Curious if there is a linter that could check for this type of thing? It's not easy to catch this in code, especially when it displays fine in the IDE preview (at least in PHPStorm for me - maybe I can change the markdown/formatter I'm using?)

![consumer_doc_bug](https://user-images.githubusercontent.com/3116995/152607012-1e24055f-639a-4125-8a0a-af11e3ad9752.png)
