### PR TITLE
Improve fields documentation

### DIFF
--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -102,46 +102,103 @@ function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type
 
 ## Field options
 The following keys are available to use when specifying fields:
+### `'label'`
+What the field should be called when displayed to the user. 
 
-| Option | Description |
-|:-:|:--|
-| `'label'` | What the field should be called when displayed to the user. |
-| `'description'` | A description of the field and how to use it. |
-| `'computed'` | Whether the field is computed. |
-| `'required'` | Specify this to force the user to enter a value into this field. |
-| `'revisionable'` | Make the field revisionable, unless told otherwise. |
-| `'cardinality'` | Set cardinality, if specified. If neither `'cardinality'` or `'multiple'` is specified, this defaults to 1. |
-| `'multiple'` | If `'cardinality'` is not specified and `'multiple'` is, set the cardinality to unlimited. |
-| `'translatable'` | Only makes the field translatable if it is specified |
-| `'default_value_callback'` | Sets the default value callback, if specified |
-| `'type'` | The datatype of the field, represented as one of the following strings: <ul><li>[`'boolean'`](#boolean)</li><li>[`'entity_reference'`](#entity-reference)</li><li>[`'entity_reference_revisions'`](#entity-reference-revisions)</li><li>[`'file'`](#file-and-image)</li><li>[`'image'`](#file-and-image)</li><li>[`'fraction'`](#fraction)</li><li>[`'geofield'`](#geofield)</li><li>[`'id_tag'`](#id-tag)</li><li>[`'inventory'`](#inventory)</li><li>[`'list_string'`](#list-string)</li><li>[`'string'`](#string)</li><li>[`'string_long'`](#long-string)</li><li>[`'timestamp'`](#timestamp)</li></ul> Click one of the above or scroll down for options relating to each specific type.  |
-| `'hidden'` | Hide the field in form and view displays, if specified. The hidden option can either be set to `true`, which will hide it in both form and view displays, or it can be set to `'form'` or `'view'`, which will only hide it in the form or view display. |
-| `'form_display_options'` & `'view_display_options'` | Override form and view display options, if specified. |
-| `'weight'` | Contains an associative array with the keys `'form'` and `'view'`, giving hints on whereabouts the field should appear. |
+### `'description'`
+A description of the field and how to use it.
 
-### Datatype specific options
+### `'computed'`
+Whether the field is computed.
+
+### `'required'`
+Specify this to force the user to enter a value into this field.
+
+### `'revisionable'`
+Make the field revisionable, unless told otherwise.
+
+### `'cardinality'`
+Set cardinality, if specified. If neither `'cardinality'` or `'multiple'` is
+specified, this defaults to 1.
+
+### `'multiple'`
+If `'cardinality'` is not specified and `'multiple'` is, set the cardinality to
+unlimited.
+
+### `'translatable'`
+Only makes the field translatable if it is specified.
+
+### `'default_value_callback'`
+Sets the default value callback, if specified.
+
+### `'type'`
+The datatype of the field, represented as one of the following strings:
+- [`'boolean'`](#boolean)
+- [`'entity_reference'`](#entity-reference)
+- [`'entity_reference_revisions'`](#entity-reference-revisions)
+- [`'file'`](#file-and-image)
+- [`'image'`](#file-and-image)
+- [`'fraction'`](#fraction)
+- [`'geofield'`](#geofield)
+- [`'id_tag'`](#id-tag)
+- [`'inventory'`](#inventory)
+- [`'list_string'`](#list-string)
+- [`'string'`](#string)
+- [`'string_long'`](#long-string)
+- [`'timestamp'`](#timestamp)
+
+Click one of the above or scroll down for additional options relating to each
+specific type.
+
+### `'hidden'`
+Hide the field in form and view displays, if specified. The hidden option can
+either be set to `true`, which will hide it in both form and view displays, or
+it can be set to `'form'` or `'view'`, which will only hide it in the form or
+view display.
+
+### `'form_display_options'` & `'view_display_options'`
+Override form and view display options, if specified.
+
+### `'weight'`
+Contains an associative array with the keys `'form'` and `'view'`, giving hints
+on whereabouts the field should appear (See the examples).
+
+### Type specific options
 #### Boolean
 Currently there are no boolean-specific options.
 
 #### Entity reference
-| Option     | Description             |
-|:----------:|:------------------------|
-| `'target_type'` | Required. What sort of entity the reference should be targeting. This can be one of: <ul><li>`'asset'`</li><li>`'log'`</li><li>`'taxonomy_term'`</li><li>`'user'`</li><li>`'data_stream'`</li></ul> |
-| `'target_bundle'` | Used when `'target_type'` is set to `'asset'` or `'taxonomy_term'`. Used to specify the bundle to look for. |
-| `'auto_create'` | Used when `'target_type'` is set to `'taxonomy_term'`. If `'auto_create'` is set, term references will be created automatically if not already defined. |
+##### `'target_type'`
+Required. What sort of entity the reference should be targeting. This can be
+one of: - `'asset'`
+- `'log'`
+- `'taxonomy_term'`
+- `'user'`
+- `'data_stream'`
+
+##### `'target_bundle'`
+Used when `'target_type'` is set to `'asset'` or `'taxonomy_term'`. Used to
+specify the bundle to look for.
+
+##### `'auto_create'`
+Used when `'target_type'` is set to `'taxonomy_term'`. If `'auto_create'` is
+set, term references will be created automatically if not already defined.
 
 #### Entity reference revisions
-| Option     | Description             |
-|:----------:|:------------------------|
-| `'target_type'` | Required. This currently must be `'quantity'`. |
+##### `'target_type'`
+Required. This currently must be `'quantity'`.
 
 #### File and image
-| Option | Description |
-|:------:|:------------|
-| `'file_directory'` | The directory that the image will be uploaded to in relation to the private file system path. If not set, this will be `farm/[date:custom:Y]-[date:custom:m]`. |
+##### `'file_directory'`
+The directory that the image will be uploaded to in relation to the private
+file system path. If not set, this will be
+`farm/[date:custom:Y]-[date:custom:m]`. |
 
 For images, the allowed file extensions are `png`, `gif`, `jpg` and `jpeg`.  
-For other files, the allowed file extensions are `csv`, `doc`, `docx`, `gz`, `geojson`, `gpx`, `kml`, `kmz`, `logz`, `mp3`, `odp`, `ods`, `odt`, `ogg`, `pdf`, `ppt`, `pptx`, `tar`, `tif`, `tiff`, `txt`, `wav`, `xls`, `xlsx` and `zip`.
+For other files, the allowed file extensions are `csv`, `doc`, `docx`, `gz`,
+`geojson`, `gpx`, `kml`, `kmz`, `logz`, `mp3`, `odp`, `ods`, `odt`, `ogg`,
+`pdf`, `ppt`, `pptx`, `tar`, `tif`, `tiff`, `txt`, `wav`, `xls`, `xlsx` and
+`zip`.
 
 #### Fraction
 Currently there are no fraction-specific options.
@@ -156,16 +213,19 @@ Currently there are no ID tag-specific options.
 Currently there are no inventory-specific options.
 
 #### List string
-| Option | Description |
-|:------:|:------------|
-| `'allowed_values'` | Optionally specify allowed values |
-| `'allowed_values_function'` | Optionally specify a function that returns the allowed values |
+##### `'allowed_values'`
+Optionally specify allowed values.
+
+##### `'allowed_values_function'`
+Optionally specify a function that returns the allowed values.
 
 #### String
-Maximum length of 255 characters. Currently there are no string-specific coptions.
+Maximum length of 255 characters. Currently there are no string-specific
+coptions.
 
 #### Long string
-This is for longer messages than the string type. Currently there are no long string-specific options.
+This is for longer messages than the string type. Currently there are no long
+string-specific options.
 
 #### Timestamp
 Currently there are no long timestamp-specific options.

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -102,100 +102,55 @@ function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type
 
 ## Field options
 The following keys are available to use when specifying fields:
-### `'label'`
-What the field should be called when displayed to the user. 
 
-### `'description'`
-A description of the field and how to use it.
-
-### `'computed'`
-Whether the field is computed.
-
-### `'required'`
-Specify this to force the user to enter a value into this field.
-
-### `'revisionable'`
-Make the field revisionable, unless told otherwise.
-
-### `'cardinality'`
-Set cardinality, if specified. If neither `'cardinality'` or `'multiple'` is
-specified, this defaults to 1.
-
-### `'multiple'`
-If `'cardinality'` is not specified and `'multiple'` is, set the cardinality to
-unlimited.
-
-### `'translatable'`
-Only makes the field translatable if it is specified.
-
-### `'default_value_callback'`
-Sets the default value callback, if specified.
-
-### `'type'`
-The datatype of the field, represented as one of the following strings:
-- [`'boolean'`](#boolean)
-- [`'entity_reference'`](#entity-reference)
-- [`'entity_reference_revisions'`](#entity-reference-revisions)
-- [`'file'`](#file-and-image)
-- [`'image'`](#file-and-image)
-- [`'fraction'`](#fraction)
-- [`'geofield'`](#geofield)
-- [`'id_tag'`](#id-tag)
-- [`'inventory'`](#inventory)
-- [`'list_string'`](#list-string)
-- [`'string'`](#string)
-- [`'string_long'`](#long-string)
-- [`'timestamp'`](#timestamp)
-
-Click one of the above or scroll down for additional options relating to each
-specific type.
-
-### `'hidden'`
-Hide the field in form and view displays, if specified. The hidden option can
-either be set to `true`, which will hide it in both form and view displays, or
-it can be set to `'form'` or `'view'`, which will only hide it in the form or
-view display.
-
-### `'form_display_options'` & `'view_display_options'`
-Override form and view display options, if specified.
-
-### `'weight'`
-Contains an associative array with the keys `'form'` and `'view'`, giving hints
-on whereabouts the field should appear (See the examples).
+- **`'label'`:** What the field should be called when displayed to the user. 
+- **`'description'`:** A description of the field and how to use it.
+- **`'computed'`:** Whether the field is computed.
+- **`'required'`:** Specify this to force the user to enter a value into this field.
+- **`'revisionable'`:** Make the field revisionable, unless told otherwise.
+- **`'cardinality'`:** Set cardinality, if specified. If neither `'cardinality'` or `'multiple'` is specified, this defaults to 1.
+- **`'multiple'`:** If `'cardinality'` is not specified and `'multiple'` is, set the cardinality to unlimited.
+- **`'translatable'`:** Only makes the field translatable if it is specified.
+- **`'default_value_callback'`:** Sets the default value callback, if specified.
+- **`'type'`:** The datatype of the field, represented as a string. Click one of the following or scroll down for additional options relating to each specific type:
+  - [`'boolean'`](#boolean)
+  - [`'entity_reference'`](#entity-reference)
+  - [`'entity_reference_revisions'`](#entity-reference-revisions)
+  - [`'file'`](#file-and-image)
+  - [`'image'`](#file-and-image)
+  - [`'fraction'`](#fraction)
+  - [`'geofield'`](#geofield)
+  - [`'id_tag'`](#id-tag)
+  - [`'inventory'`](#inventory)
+  - [`'list_string'`](#list-string)
+  - [`'string'`](#string)
+  - [`'string_long'`](#long-string)
+  - [`'timestamp'`](#timestamp)
+- **`'hidden'`:** Hide the field in form and view displays, if specified. The hidden option can either be set to `true`, which will hide it in both form and view displays, or it can be set to `'form'` or `'view'`, which will only hide it in the form or view display.
+- **`'form_display_options'` & `'view_display_options'`:** Override form and view display options, if specified.
+- **`'weight'`:** Contains an associative array with the keys `'form'` and `'view'`, giving hints on whereabouts the field should appear (See the examples).
 
 ### Type specific options
 #### Boolean
 Currently there are no boolean-specific options.
 
 #### Entity reference
-##### `'target_type'`
-Required. What sort of entity the reference should be targeting. This can be
-one of: - `'asset'`
-- `'log'`
-- `'taxonomy_term'`
-- `'user'`
-- `'data_stream'`
-
-##### `'target_bundle'`
-Used when `'target_type'` is set to `'asset'` or `'taxonomy_term'`. Used to
-specify the bundle to look for.
-
-##### `'auto_create'`
-Used when `'target_type'` is set to `'taxonomy_term'`. If `'auto_create'` is
-set, term references will be created automatically if not already defined.
+- **`'target_type'`:** Required. What sort of entity the reference should be targeting. This can be one of:
+  - `'asset'`
+  - `'log'`
+  - `'taxonomy_term'`
+  - `'user'`
+  - `'data_stream'`
+- **`'target_bundle'`:** Used when `'target_type'` is set to `'asset'` or `'taxonomy_term'`. Used to specify the bundle to look for.
+- **`'auto_create'`:** Used when `'target_type'` is set to `'taxonomy_term'`. If `'auto_create'` is set, term references will be created automatically if not already defined.
 
 #### Entity reference revisions
-##### `'target_type'`
-Required. This currently must be `'quantity'`.
+- **`'target_type'`:** Required. This currently must be `'quantity'`.
 
 #### File and image
-##### `'file_directory'`
-The directory that the image will be uploaded to in relation to the private
-file system path. If not set, this will be
-`farm/[date:custom:Y]-[date:custom:m]`. |
-
-For images, the allowed file extensions are `png`, `gif`, `jpg` and `jpeg`.  
-For other files, the allowed file extensions are `csv`, `doc`, `docx`, `gz`,
+- **`'file_directory'`:** The directory that the image will be uploaded to in relation to the private file system path. If not set, this will be `farm/[date:custom:Y]-[date:custom:m]`.
+- For images, the allowed file extensions are `png`, `gif`, `jpg` and `jpeg`.  
+- For other files, the allowed file extensions are `csv`, `doc`, `docx`, `gz`,
 `geojson`, `gpx`, `kml`, `kmz`, `logz`, `mp3`, `odp`, `ods`, `odt`, `ogg`,
 `pdf`, `ppt`, `pptx`, `tar`, `tif`, `tiff`, `txt`, `wav`, `xls`, `xlsx` and
 `zip`.
@@ -213,11 +168,8 @@ Currently there are no ID tag-specific options.
 Currently there are no inventory-specific options.
 
 #### List string
-##### `'allowed_values'`
-Optionally specify allowed values.
-
-##### `'allowed_values_function'`
-Optionally specify a function that returns the allowed values.
+- **`'allowed_values'`:** Optionally specify allowed values.
+- **`'allowed_values_function'`:** Optionally specify a function that returns the allowed values.
 
 #### String
 Maximum length of 255 characters. Currently there are no string-specific

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -26,12 +26,12 @@ use Drupal\Core\Entity\EntityTypeInterface;
 /**
  * Implements hook_entity_base_field_info().
  */
-function mymodule_entity_base_field_info(EntityTypeInterface $entity_type) {
+function mymodule_entity_base_field_info(EntityTypeInterface $entity_type) {                    // <-- Replace 'mymodule' with the module name.
   $fields = [];
 
   // Add a new string field to Log entities.
-  if ($entity_type->id() == 'log') {
-    $options = [
+  if ($entity_type->id() == 'log') {                                                            // <-- Specifies the entity type to apply to.
+    $options = [                                                                                // <-- Options for the new field. See Field options below.
       'type' => 'string',
       'label' => t('My new field'),
       'description' => t('My field description.'),
@@ -40,7 +40,7 @@ function mymodule_entity_base_field_info(EntityTypeInterface $entity_type) {
         'view' => 10,
       ],
     ];
-    $fields['myfield'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
+    $fields['myfield'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options); // <-- Replace 'myfield' with the internal name of the field.
   }
 
   return $fields;
@@ -70,12 +70,12 @@ use Drupal\Core\Entity\EntityTypeInterface;
 /**
  * Implements hook_farm_entity_bundle_field_info().
  */
-function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle) {
+function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle) {      // <-- Replace 'mymodule' with the module name.
   $fields = [];
 
   // Add a new string field to Input Logs.
-  if ($entity_type->id() == 'log' && $bundle == 'input') {
-    $options = [
+  if ($entity_type->id() == 'log' && $bundle == 'input') {                                        // <-- Specifies the entity type and bundle to apply to.
+    $options = [                                                                                  // <-- ptions for the new field. See Field options below.
       'type' => 'string',
       'label' => t('My new field'),
       'description' => t('My field description.'),
@@ -84,7 +84,7 @@ function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type
         'view' => 10,
       ],
     ];
-    $fields['myfield'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['myfield'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options); // <-- Replace 'myfield' with the internal name of the field.
   }
 
   return $fields;

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -18,6 +18,7 @@ types), then they should be added as "base fields" via
 A `farm_field.factory` helper service is provided to make this easier.
 
 To get started, place the following in the `[modulename].module` file:
+
 ```php
 <?php
 
@@ -25,13 +26,15 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Implements hook_entity_base_field_info().
+ * NOTE: Replace 'mymodule' with the module name.
  */
-function mymodule_entity_base_field_info(EntityTypeInterface $entity_type) {                    // <-- Replace 'mymodule' with the module name.
+function mymodule_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
 
-  // Add a new string field to Log entities.
-  if ($entity_type->id() == 'log') {                                                            // <-- Specifies the entity type to apply to.
-    $options = [                                                                                // <-- Options for the new field. See Field options below.
+  // 'log' specifies the entity type to apply to.
+  if ($entity_type->id() == 'log') {
+    // Options for the new field. See Field options below.
+    $options = [
       'type' => 'string',
       'label' => t('My new field'),
       'description' => t('My field description.'),
@@ -40,7 +43,8 @@ function mymodule_entity_base_field_info(EntityTypeInterface $entity_type) {    
         'view' => 10,
       ],
     ];
-    $fields['myfield'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options); // <-- Replace 'myfield' with the internal name of the field.
+    // NOTE: Replace 'myfield' with the internal name of the field.
+    $fields['myfield'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
   }
 
   return $fields;
@@ -62,6 +66,7 @@ The format for bundle field definitions is identical to base field definitions
 `baseFieldDefinition()`.
 
 To get started, place the following in the `[modulename].module` file:
+
 ```php
 <?php
 
@@ -69,13 +74,16 @@ use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
  * Implements hook_farm_entity_bundle_field_info().
+ * NOTE: Replace 'mymodule' with the module name.
  */
-function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle) {      // <-- Replace 'mymodule' with the module name.
+function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle) {
   $fields = [];
 
-  // Add a new string field to Input Logs.
-  if ($entity_type->id() == 'log' && $bundle == 'input') {                                        // <-- Specifies the entity type and bundle to apply to.
-    $options = [                                                                                  // <-- ptions for the new field. See Field options below.
+  // Add a new string field to Input Logs. 'log' specifies the entity type and
+  // 'input' specifies the bundle.
+  if ($entity_type->id() == 'log' && $bundle == 'input') {
+    // Options for the new field. See Field options below.
+    $options = [
       'type' => 'string',
       'label' => t('My new field'),
       'description' => t('My field description.'),
@@ -84,7 +92,8 @@ function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type
         'view' => 10,
       ],
     ];
-    $fields['myfield'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options); // <-- Replace 'myfield' with the internal name of the field.
+    // NOTE: Replace 'myfield' with the internal name of the field.
+    $fields['myfield'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
   }
 
   return $fields;
@@ -192,7 +201,7 @@ These include:
     - Tattoo (`tattoo`, on Animal assets)
 
 These options are provided as configuration entities by farmOS modules in the
-form of YAML files. 
+form of YAML files.
 
 Existing options can be overridden or removed by editing/deleting the entities
 in the active configuration of the site. (**Warning** changing core types runs
@@ -319,7 +328,7 @@ certain types of assets.
 For example, an "Ear tag" type, provided by the "Animal asset" module, only
 applies to "Animal" assets:
 
-`animal/config/install/farm_flag.flag.ear_tag.yml`
+`animal/config/install/farm_id_tag.id_tag.ear_tag.yml`
 
 ```yaml
 langcode: en

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -101,18 +101,24 @@ function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type
 ```
 
 ## Field options
+
 The following keys are available to use when specifying fields:
 
-- **`'label'`:** What the field should be called when displayed to the user. 
+- **`'label'`:** What the field should be called when displayed to the user.
 - **`'description'`:** A description of the field and how to use it.
 - **`'computed'`:** Whether the field is computed.
-- **`'required'`:** Specify this to force the user to enter a value into this field.
+- **`'required'`:** Specify this to force the user to enter a value into this
+  field.
 - **`'revisionable'`:** Make the field revisionable, unless told otherwise.
-- **`'cardinality'`:** Set cardinality, if specified. If neither `'cardinality'` or `'multiple'` is specified, this defaults to 1.
-- **`'multiple'`:** If `'cardinality'` is not specified and `'multiple'` is, set the cardinality to unlimited.
+- **`'cardinality'`:** Set cardinality, if specified. If neither `'cardinality'`
+   or `'multiple'` is specified, this defaults to 1.
+- **`'multiple'`:** If `'cardinality'` is not specified and `'multiple'` is, set
+  the cardinality to unlimited.
 - **`'translatable'`:** Only makes the field translatable if it is specified.
 - **`'default_value_callback'`:** Sets the default value callback, if specified.
-- **`'type'`:** The datatype of the field, represented as a string. Click one of the following or scroll down for additional options relating to each specific type:
+- **`'type'`:** The datatype of the field, represented as a string. Click one of
+  the following or scroll down for additional options relating to each specific
+  type:
   - [`'boolean'`](#boolean)
   - [`'entity_reference'`](#entity-reference)
   - [`'entity_reference_revisions'`](#entity-reference-revisions)
@@ -126,60 +132,87 @@ The following keys are available to use when specifying fields:
   - [`'string'`](#string)
   - [`'string_long'`](#long-string)
   - [`'timestamp'`](#timestamp)
-- **`'hidden'`:** Hide the field in form and view displays, if specified. The hidden option can either be set to `true`, which will hide it in both form and view displays, or it can be set to `'form'` or `'view'`, which will only hide it in the form or view display.
-- **`'form_display_options'` & `'view_display_options'`:** Override form and view display options, if specified.
-- **`'weight'`:** Contains an associative array with the keys `'form'` and `'view'`, giving hints on whereabouts the field should appear (See the examples).
+
+- **`'hidden'`:** Hide the field in form and view displays, if specified. The
+  hidden option can either be set to `true`, which will hide it in both form and
+  view displays, or it can be set to `'form'` or `'view'`, which will only hide
+  it in the form or view display.
+- **`'form_display_options'` & `'view_display_options'`:** Override form and
+  view display options, if specified.
+- **`'weight'`:** Contains an associative array with the keys `'form'` and
+  `'view'`, giving hints on whereabouts the field should appear (See the
+  examples).
 
 ### Type specific options
+
 #### Boolean
+
 Currently there are no boolean-specific options.
 
 #### Entity reference
-- **`'target_type'`:** Required. What sort of entity the reference should be targeting. This can be one of:
+
+- **`'target_type'`:** Required. What sort of entity the reference should be
+  targeting. This can be one of:
   - `'asset'`
   - `'log'`
   - `'taxonomy_term'`
   - `'user'`
   - `'data_stream'`
-- **`'target_bundle'`:** Used when `'target_type'` is set to `'asset'` or `'taxonomy_term'`. Used to specify the bundle to look for.
-- **`'auto_create'`:** Used when `'target_type'` is set to `'taxonomy_term'`. If `'auto_create'` is set, term references will be created automatically if not already defined.
+- **`'target_bundle'`:** Used when `'target_type'` is set to `'asset'` or
+  `'taxonomy_term'`. Used to specify the bundle to look for.
+- **`'auto_create'`:** Used when `'target_type'` is set to `'taxonomy_term'`. If
+  `'auto_create'` is set, term references will be created automatically if not
+  already defined.
 
 #### Entity reference revisions
+
 - **`'target_type'`:** Required. This currently must be `'quantity'`.
 
 #### File and image
-- **`'file_directory'`:** The directory that the image will be uploaded to in relation to the private file system path. If not set, this will be `farm/[date:custom:Y]-[date:custom:m]`.
-- For images, the allowed file extensions are `png`, `gif`, `jpg` and `jpeg`.  
+
+- **`'file_directory'`:** The directory that the image will be uploaded to in
+  relation to the private file system path. If not set, this will be
+  `farm/[date:custom:Y]-[date:custom:m]`.
+- For images, the allowed file extensions are `png`, `gif`, `jpg` and `jpeg`.
 - For other files, the allowed file extensions are `csv`, `doc`, `docx`, `gz`,
-`geojson`, `gpx`, `kml`, `kmz`, `logz`, `mp3`, `odp`, `ods`, `odt`, `ogg`,
-`pdf`, `ppt`, `pptx`, `tar`, `tif`, `tiff`, `txt`, `wav`, `xls`, `xlsx` and
-`zip`.
+  `geojson`, `gpx`, `kml`, `kmz`, `logz`, `mp3`, `odp`, `ods`, `odt`, `ogg`,
+  `pdf`, `ppt`, `pptx`, `tar`, `tif`, `tiff`, `txt`, `wav`, `xls`, `xlsx` and
+  `zip`.
 
 #### Fraction
+
 Currently there are no fraction-specific options.
 
 #### Geofield
+
 Currently there are no geofield-specific options.
 
 #### ID tag
+
 Currently there are no ID tag-specific options.
 
 #### Inventory
+
 Currently there are no inventory-specific options.
 
 #### List string
+
 - **`'allowed_values'`:** Optionally specify allowed values.
-- **`'allowed_values_function'`:** Optionally specify a function that returns the allowed values.
+- **`'allowed_values_function'`:** Optionally specify a function that returns
+  the allowed values.
 
 #### String
+
 Maximum length of 255 characters. Currently there are no string-specific
 coptions.
 
 #### Long string
+
 This is for longer messages than the string type. Currently there are no long
 string-specific options.
 
 #### Timestamp
+
 Currently there are no long timestamp-specific options.
 
 ## Select options

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -15,8 +15,9 @@ If the field should be added to all bundles of a given entity type (eg: all log
 types), then they should be added as "base fields" via
 `hook_entity_base_field_info()`.
 
-A `farm_field.factory` helper service is provided to make this easier:
+A `farm_field.factory` helper service is provided to make this easier.
 
+To get started, place the following in the `[modulename].module` file:
 ```php
 <?php
 
@@ -60,6 +61,7 @@ The format for bundle field definitions is identical to base field definitions
 (above), but the `bundleFieldDefinition()` method must be used instead of
 `baseFieldDefinition()`.
 
+To get started, place the following in the `[modulename].module` file:
 ```php
 <?php
 
@@ -88,6 +90,76 @@ function mymodule_farm_entity_bundle_field_info(EntityTypeInterface $entity_type
   return $fields;
 }
 ```
+
+## Field options
+The following keys are available to use when specifying fields:
+
+| Option | Description |
+|:-:|:--|
+| `'label'` | What the field should be called when displayed to the user. |
+| `'description'` | A description of the field and how to use it. |
+| `'computed'` | Whether the field is computed. |
+| `'required'` | Specify this to force the user to enter a value into this field. |
+| `'revisionable'` | Make the field revisionable, unless told otherwise. |
+| `'cardinality'` | Set cardinality, if specified. If neither `'cardinality'` or `'multiple'` is specified, this defaults to 1. |
+| `'multiple'` | If `'cardinality'` is not specified and `'multiple'` is, set the cardinality to unlimited. |
+| `'translatable'` | Only makes the field translatable if it is specified |
+| `'default_value_callback'` | Sets the default value callback, if specified |
+| `'type'` | The datatype of the field, represented as one of the following strings: <ul><li>[`'boolean'`](#boolean)</li><li>[`'entity_reference'`](#entity-reference)</li><li>[`'entity_reference_revisions'`](#entity-reference-revisions)</li><li>[`'file'`](#file-and-image)</li><li>[`'image'`](#file-and-image)</li><li>[`'fraction'`](#fraction)</li><li>[`'geofield'`](#geofield)</li><li>[`'id_tag'`](#id-tag)</li><li>[`'inventory'`](#inventory)</li><li>[`'list_string'`](#list-string)</li><li>[`'string'`](#string)</li><li>[`'string_long'`](#long-string)</li><li>[`'timestamp'`](#timestamp)</li></ul> Click one of the above or scroll down for options relating to each specific type.  |
+| `'hidden'` | Hide the field in form and view displays, if specified. The hidden option can either be set to `true`, which will hide it in both form and view displays, or it can be set to `'form'` or `'view'`, which will only hide it in the form or view display. |
+| `'form_display_options'` & `'view_display_options'` | Override form and view display options, if specified. |
+| `'weight'` | Contains an associative array with the keys `'form'` and `'view'`, giving hints on whereabouts the field should appear. |
+
+### Datatype specific options
+#### Boolean
+Currently there are no boolean-specific options.
+
+#### Entity reference
+| Option     | Description             |
+|:----------:|:------------------------|
+| `'target_type'` | Required. What sort of entity the reference should be targeting. This can be one of: <ul><li>`'asset'`</li><li>`'log'`</li><li>`'taxonomy_term'`</li><li>`'user'`</li><li>`'data_stream'`</li></ul> |
+| `'target_bundle'` | Used when `'target_type'` is set to `'asset'` or `'taxonomy_term'`. Used to specify the bundle to look for. |
+| `'auto_create'` | Used when `'target_type'` is set to `'taxonomy_term'`. If `'auto_create'` is set, term references will be created automatically if not already defined. |
+
+#### Entity reference revisions
+| Option     | Description             |
+|:----------:|:------------------------|
+| `'target_type'` | Required. This currently must be `'quantity'`. |
+
+#### File and image
+| Option | Description |
+|:------:|:------------|
+| `'file_directory'` | The directory that the image will be uploaded to in relation to the private file system path. If not set, this will be `farm/[date:custom:Y]-[date:custom:m]`. |
+
+For images, the allowed file extensions are `png`, `gif`, `jpg` and `jpeg`.  
+For other files, the allowed file extensions are `csv`, `doc`, `docx`, `gz`, `geojson`, `gpx`, `kml`, `kmz`, `logz`, `mp3`, `odp`, `ods`, `odt`, `ogg`, `pdf`, `ppt`, `pptx`, `tar`, `tif`, `tiff`, `txt`, `wav`, `xls`, `xlsx` and `zip`.
+
+#### Fraction
+Currently there are no fraction-specific options.
+
+#### Geofield
+Currently there are no geofield-specific options.
+
+#### ID tag
+Currently there are no ID tag-specific options.
+
+#### Inventory
+Currently there are no inventory-specific options.
+
+#### List string
+| Option | Description |
+|:------:|:------------|
+| `'allowed_values'` | Optionally specify allowed values |
+| `'allowed_values_function'` | Optionally specify a function that returns the allowed values |
+
+#### String
+Maximum length of 255 characters. Currently there are no string-specific coptions.
+
+#### Long string
+This is for longer messages than the string type. Currently there are no long string-specific options.
+
+#### Timestamp
+Currently there are no long timestamp-specific options.
 
 ## Select options
 

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -192,11 +192,15 @@ These include:
     - Tattoo (`tattoo`, on Animal assets)
 
 These options are provided as configuration entities by farmOS modules in the
-form of YAML files.
+form of YAML files. 
 
 Existing options can be overridden or removed by editing/deleting the entities
 in the active configuration of the site. (**Warning** changing core types runs
 the risk of conflicting with future farmOS updates).
+
+Note that the file name is important and must follow a specific pattern. This
+is generally in the form `[select_module_name].[select_field].[id].yml`. See
+the examples for more info.
 
 ### Examples:
 
@@ -221,6 +225,7 @@ The most important parts are the `id`, which is a unique machine name for
 the flag, `label`, which is the human readable/translatable label that will be
 shown in the select field and other parts of the UI, and `entity_types`, which
 can optionally specify the entity types and bundles that this flag applies to.
+Note that the file name is in the form `farm_flag.flag.[id].yml`.
 
 The `langcode` and `status` and `dependencies` are standard configuration
 entity properties. By putting the module's name in "enforced modules" it will
@@ -266,6 +271,8 @@ id: field
 label: Field
 ```
 
+Note that the file name is in the form `farm_land.land_type.[id].yml`.
+
 #### Structure type
 
 The "Structure" module in farmOS provides a "Building" type like this:
@@ -282,6 +289,7 @@ dependencies:
 id: building
 label: Building
 ```
+Note that the file name is in the form `farm_structure.structure_type.[id].yml`.
 
 #### Lab test type
 
@@ -299,6 +307,8 @@ dependencies:
 id: soil
 label: Soil test
 ```
+Note that the file name is in the form `farm_lab_test.lab_test_type.[id].yml`
+
 
 #### ID tag type
 
@@ -324,6 +334,7 @@ label: Ear tag
 bundles:
   - animal
 ```
+Note that the file name is in the form `farm_flag.flag.ear_tag.[id].yml`
 
 If you want the tag type to apply to all assets, set `bundles: null`.
 (or can it just be omitted?)

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -212,8 +212,8 @@ dependencies:
   enforced:
     module:
       - my_module
-id: monitor
-label: Monitor
+id: organic
+label: Organic
 entity_types: null
 ```
 


### PR DESCRIPTION
Hello,
As a new user to farmOS / drupal, I have added a few extra hints to the fields page for creating custom fields.
I have also added documentation for options available when specifying fields. I'm not sure if this is the best way of representing it, but hopefully it is readable (feel free to improve or suggest improvements). Forum thread discussing this: https://farmos.discourse.group/t/is-it-possible-to-use-custom-fields-and-filtering-in-asset-views-and-filter-by-a-range-of-birth-dates/1139/5

After reading [this](https://farmos.discourse.group/t/custom-module-help/1149) thread, I also corrected a typo / copy paste error in the organic flag example.