### PR TITLE
Allow importing KML with empty geometries. #510

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Only require a name to build map popups #515](https://github.com/farmOS/farmOS/pull/515)
 - [Issue #3269543 by paul121: Automatically remove prepopulated entities from quick forms](https://www.drupal.org/project/farm/issues/3269543)
 - [Do not add views handlers for unsupported field types #512](https://github.com/farmOS/farmOS/pull/512)
+- [Allow importing KML with empty geometries #510](https://github.com/farmOS/farmOS/issues/510)
 
 ### Security
 

--- a/modules/core/kml/src/Normalizer/KmlNormalizer.php
+++ b/modules/core/kml/src/Normalizer/KmlNormalizer.php
@@ -4,6 +4,7 @@ namespace Drupal\farm_kml\Normalizer;
 
 use Drupal\farm_geo\GeometryWrapper;
 use Drupal\geofield\GeoPHP\GeoPHPInterface;
+use GeometryCollection;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -118,6 +119,11 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
 
       // Load KML into a Geometry object.
       $geometry = $this->geoPHP->load($placemark['xml'], 'kml');
+
+      // Create an empty collection if no geometry was loaded.
+      if (empty($geometry)) {
+        $geometry = new GeometryCollection();
+      }
 
       // Build properties.
       $properties = [];


### PR DESCRIPTION
A simple fix for the bug identified in #510 

Attaching a screenshot that shows the result of parsing the following placemark:

```kml
<Placemark>
	<name>Placemark name</name>
      <MultiGeometry></MultiGeometry>
  </Placemark>
```
![Screenshot from 2022-03-15 16-50-57](https://user-images.githubusercontent.com/3116995/158490719-6fe7eb66-0c0a-4f2a-967d-03a4eea18c25.png)