### PR TITLE
Do not add views handlers for unsupported field types.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Only require a name to build map popups #515](https://github.com/farmOS/farmOS/pull/515)
 - [Issue #3269543 by paul121: Automatically remove prepopulated entities from quick forms](https://www.drupal.org/project/farm/issues/3269543)
+- [Do not add views handlers for unsupported field types #512](https://github.com/farmOS/farmOS/pull/512)
 
 ### Security
 

--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -223,6 +223,10 @@ function farm_ui_views_add_bundle_handlers(ViewExecutable $view, string $display
           case 'string':
             // String fields do not need any modifications.
             break;
+
+          default:
+            // Do not add field handlers for unsupported field types.
+            continue 2;
         }
 
         // Add the field handler.
@@ -315,6 +319,10 @@ function farm_ui_views_add_bundle_handlers(ViewExecutable $view, string $display
             // String fields use the contains operator.
             $filter_options['operator'] = 'contains';
             break;
+
+          default:
+            // Do not add filter handlers for unsupported field types.
+            continue 2;
         }
 
         // Add the filter handler.

--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -219,6 +219,10 @@ function farm_ui_views_add_bundle_handlers(ViewExecutable $view, string $display
             $field_options['type'] = 'timestamp';
             $field_options['settings']['date_format'] = 'html_date';
             break;
+
+          case 'string':
+            // String fields do not need any modifications.
+            break;
         }
 
         // Add the field handler.


### PR DESCRIPTION
Experiencing the following error when viewing the `page_type` asset view, like the Plant Assets page:

> Notice: Undefined index: intrinsic_area_value in Drupal\views\Plugin\views\filter\FilterPluginBase->acceptExposedInput() (line 1497 of core/modules/views/src/Plugin/views/filter/FilterPluginBase.php).
Drupal\views\Plugin\views\filter\FilterPluginBase->acceptExposedInput(Array) (Line: 188)
Drupal\views\Form\ViewsExposedForm->submitForm(Array, Object)
call_user_func_array(Array, Array) (Line: 114)
Drupal\Core\Form\FormSubmitter->executeSubmitHandlers(Array, Object) (Line: 52)
Drupal\Core\Form\FormSubmitter->doSubmitForm(Array, Object) (Line: 592)
Drupal\Core\Form\FormBuilder->processForm('views_exposed_form', Array, Object) (Line: 320)
Drupal\Core\Form\FormBuilder->buildForm('\Drupal\views\Form\ViewsExposedForm', Object) (Line: 134)
Drupal\views\Plugin\views\exposed_form\ExposedFormPluginBase->renderExposedForm() (Line: 1238)
Drupal\views\ViewExecutable->build() (Line: 395)
Drupal\views\Plugin\views\display\PathPluginBase->execute() (Line: 196)
Drupal\views\Plugin\views\display\Page->execute() (Line: 1630)
Drupal\views\ViewExecutable->executeDisplay('page_type', Array) (Line: 81)
Drupal\views\Element\View::preRenderViewElement(Array)

This happens when I have my `farm_asset_area` module installed: https://github.com/Vital-Agronomics/farm_asset_area. The module adds a `decimal` bundle field called `intrinsic_area` to all asset types for the purpose of tracking a specific "Total area" value: https://github.com/Vital-Agronomics/farm_asset_area/blob/db07b4fcf520fdec758fd67090ebadbc6908856e/farm_asset_area.module#L19

Interestingly, when viewing a `page_type` view of assets there is a "Total area" column added to the view, but no exposed filter added to the form. For this reason I thought it was odd that `intrinsic_area_value` would even appear in the processing of the exposed form input as the error message suggests. Turns out our `farm_ui_views._views_execution.inc` logic is adding a Views filter handler for this field, but without any `type` because we don't handle any `decimal` fields. This seems to prevent it from being rendered in the form, but still includes the field in the filter processing, which causes this error because no value or default value was submitted for the `intrinsic_area` field.

I propose that we simply don't add a Views field or filter handler for any non-supported field type. It's interesting that the "Total area" is added to the table & works despite being a `decimal` field type, but this could be a larger issue for other field types that are added as a bundle field to logs or assets.
