### PR TITLE
Only require a name to build map popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Only require a name to build map popups #515](https://github.com/farmOS/farmOS/pull/515)
+
 ### Security
 
 - Update Drupal core to 9.3.8 for [SA-CORE-2022-005](https://www.drupal.org/sa-core-2022-005).

--- a/modules/core/map/js/farmOS.map.behaviors.popup.js
+++ b/modules/core/map/js/farmOS.map.behaviors.popup.js
@@ -37,12 +37,16 @@
             feature.set('name', names.length + ' item(s):');
           }
 
+          // A popup name is required.
           var name = featureName(feature) || '';
-          var description = feature.get('description') || '';
-          var measurement = instance.measureGeometry(feature.getGeometry(), instance.units);
+          if (name !== '') {
 
-          // A popup name is required, along with a measurement and/or description.
-          if (name !== '' && (measurement !== '' || description !== '')) {
+            // Get the description and measurement.
+            var description = feature.get('description') || '';
+            var measurement = instance.measureGeometry(feature.getGeometry(), instance.units);
+
+            // Build content with all three values, even if empty. The measurement and description divs may be used
+            // as placeholders for map behaviors to place additional information.
             content = '<h4 class="ol-popup-name">' + name + '</h4><div class="ol-popup-measurement"><small>' + measurement + '</small></div><div class="ol-popup-description">' + description + '</div>';
           }
         }


### PR DESCRIPTION
Greg from OurSci and I ran into an issue where location assets with a `MULTIPOLYGON (((...` or `GEOMETRYCOLLECTION ( POLYGON((...` geometry were not "clickable" on the dashboard map, meaning they did not create a popup.

Chatting with @mstenta we identified the issue in the `farmOS.map.behaviors.popup.js` logic where a `name` *and* a `measurement` or `description` property is required. Openlayers does not compute the measurement for multipolygons, so this popup was not being created. I think this would also be the case for location assets with a single `point` geometry.

This change allows popups to be rendered for multipolygon geometries that will not have a measurement calculated.