### PR TITLE
Include list_string, timestamp and boolean bundle fields in views.

### DIFF
--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -220,8 +220,10 @@ function farm_ui_views_add_bundle_handlers(ViewExecutable $view, string $display
             $field_options['settings']['date_format'] = 'html_date';
             break;
 
+          case 'boolean':
+          case 'list_string':
           case 'string':
-            // String fields do not need any modifications.
+            // Field types that do not need any modifications.
             break;
 
           default:
@@ -318,6 +320,11 @@ function farm_ui_views_add_bundle_handlers(ViewExecutable $view, string $display
           case 'string':
             // String fields use the contains operator.
             $filter_options['operator'] = 'contains';
+            break;
+
+          case 'list_string':
+          case 'timestamp':
+            // Field types that do not need any modifications.
             break;
 
           default:


### PR DESCRIPTION
Follow up to #512 

The `timestamp` and `boolean` had cases to add only add `field` or `filter` handlers (respectively), but not both.

Additionally, `list_string` fields were not included at all. This was particularly bad because the dashboard map did not filter the different map layers by the proper `land_type`; land assets were being included for every layer.

Would be good to get a test in that captures this for all of the "supported" field types that we add to views... but just a simple fix for now..