### PR TITLE
Increase map size so delete button is shown.

### DIFF
--- a/modules/core/map/css/farm_map.css
+++ b/modules/core/map/css/farm_map.css
@@ -1,5 +1,5 @@
 .farm-map {
-  height: 400px;
+  height: 450px;
 }
 
 /* Inline labels cause the map to cover other fields. */


### PR DESCRIPTION
Right now when editing geometries in the map the delete button is covered by the snapping grid toggle. This is a quick fix to increase the map height. I think we should consider this because it's pretty poor UX right now

I know there is additional discussion about this here https://github.com/farmOS/farmOS-map/issues/146 and here https://github.com/farmOS/farmOS-map/pull/152