### PR TITLE
Encourage GEOS PHP extension use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Encourage GEOS PHP extension use #521](https://github.com/farmOS/farmOS/pull/521)
+
 ### Fixed
 
 - [Only require a name to build map popups #515](https://github.com/farmOS/farmOS/pull/515)

--- a/docs/hosting/install.md
+++ b/docs/hosting/install.md
@@ -23,8 +23,9 @@ dependencies. The [farmOS Docker images](#farmos-in-docker) include these.
     - `realpath_cache_size=4096K`
     - `realpath_cache_ttl=3600`
 - **[PHP BCMath extension](https://www.php.net/manual/en/book.bc.php)** and
-  **[GEOS](https://trac.osgeo.org/geos)** are recommended for more accurate
-  geometric calculations.
+  **[GEOS](https://trac.osgeo.org/geos)** are required for accurate geometric
+  calculations. farmOS can be installed without these, but production usage
+  without them is strongly discouraged.
 
 ### Database server
 

--- a/modules/core/geo/farm_geo.install
+++ b/modules/core/geo/farm_geo.install
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall function for the farm_geo module.
+ */
+
+/**
+ * Implements hook_requirements().
+ */
+function farm_geo_requirements($phase) {
+  $requirements = [];
+
+  // Check for php-geos extension.
+  if (geoPHP::geosInstalled()) {
+    $severity = REQUIREMENT_OK;
+    $message = t('GEOS PHP extension installed');
+  }
+  else {
+    $severity = REQUIREMENT_WARNING;
+    $message = t('The GEOS PHP extension is not installed. While not required, it is strongly recommended for accurate geometry arithmetic. See %link for more information.', ['%link' => 'https://geophp.net/geos.html']);
+  }
+  $requirements['geos'] = [
+    'title' => t('GEOS PHP extension'),
+    'severity' => $severity,
+    'value' => $message,
+  ];
+
+  return $requirements;
+}


### PR DESCRIPTION
Add `hook_requirements()` to check if the GEOS PHP extension is installed. This is copied/modified from https://git.drupalcode.org/project/geophp/-/blob/8.x-1.x/geophp.module#L79

Here is the message displayed in `/admin/reports/status` when GEOS is present:

![Screenshot from 2022-04-07 14-11-50](https://user-images.githubusercontent.com/95381/162270070-1a439fae-fc94-4b79-977b-613f1b6c8a91.png)

And when it is not present:

![Screenshot from 2022-04-07 14-09-02](https://user-images.githubusercontent.com/95381/162270083-a0e84861-67da-4a53-a31d-df3d86f34ea6.png)

Also changed the wording of the server requirements to strongly encourage GEOS.