### PR TITLE
Separate Docker image build from testing jobs in run-test.yml workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,6 +45,22 @@ jobs:
           name: farmOS-artifacts
           path: /tmp/artifacts
           retention-days: 1
+  sniff:
+    name: Run PHP Codesniffer
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Retrieve saved Docker images from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: farmOS-artifacts
+          path: /tmp/artifacts
+      - name: Load farmos/farmos:2.x-dev image
+        run: docker load < /tmp/artifacts/farmos-2x-dev.tar
+      - name: Run PHP CodeSniffer
+        run: docker run farmos/farmos:2.x-dev phpcs /opt/drupal/web/profiles/farm
   test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest
@@ -97,8 +113,6 @@ jobs:
       # The www-container-fs-ready file is only created once we expect the containers to be online
       # so waiting for that lets us know it is safe to start the tests
         run: until [ -f ./www/www-container-fs-ready ]; do sleep 0.1; done
-      - name: Run PHP CodeSniffer
-        run: docker-compose exec -u www-data -T www phpcs /opt/drupal/web/profiles/farm
       - name: Run PHPUnit tests
         run: docker-compose exec -u www-data -T www paratest --verbose=1 --processes=${{ matrix.processes }} /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -34,12 +34,11 @@ jobs:
       # farmOS Composer project 2.x branch is always used.
       - name: Build farmOS 2.x-dev Docker image
         run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x-dev docker/dev
-      - name: Save Docker images as tarballs
+      - name: Save farmOS 2.x-dev Docker image as tarball
         run: |
           mkdir /tmp/artifacts
-          docker save farmos/farmos:2.x > /tmp/artifacts/farmos-2x.tar
           docker save farmos/farmos:2.x-dev > /tmp/artifacts/farmos-2x-dev.tar
-      - name: Upload Docker images as artifacts
+      - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: farmOS-artifacts
@@ -52,7 +51,7 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Retrieve saved Docker images from artifacts
+      - name: Retrieve saved artifacts
         uses: actions/download-artifact@v2
         with:
           name: farmOS-artifacts
@@ -92,7 +91,7 @@ jobs:
         run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Retrieve saved Docker images from artifacts
+      - name: Retrieve saved artifacts
         uses: actions/download-artifact@v2
         with:
           name: farmOS-artifacts

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,18 +32,15 @@ jobs:
       # This builds the dev Docker image using the specified FARMOS_VERSION,
       # but notably it does NOT override the default PROJECT_VERSION, so the
       # farmOS Composer project 2.x branch is always used.
-      - name: Build farmOS 2.x-dev Docker image
-        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x-dev docker/dev
-      - name: Save farmOS 2.x-dev Docker image as tarball
+      - name: Build and save farmOS 2.x-dev Docker image
         run: |
-          mkdir /tmp/artifacts
-          docker save farmos/farmos:2.x-dev > /tmp/artifacts/farmos-2x-dev.tar
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+          docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x-dev docker/dev
+          docker save farmos/farmos:2.x-dev > /tmp/farmos-2x-dev.tar
+      - name: Cache farmOS 2.x-dev Docker image
+        uses: actions/cache@v3
         with:
-          name: farmOS-artifacts
-          path: /tmp/artifacts
-          retention-days: 1
+          path: /tmp/farmos-2x-dev.tar
+          key: farmos-2x-dev-${{ github.run_id }}
   sniff:
     name: Run PHP Codesniffer
     runs-on: ubuntu-latest
@@ -51,13 +48,13 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Retrieve saved artifacts
-        uses: actions/download-artifact@v2
+      - name: Restore farmOS 2.x-dev Docker image from cache
+        uses: actions/cache@v3
         with:
-          name: farmOS-artifacts
-          path: /tmp/artifacts
+          path: /tmp/farmos-2x-dev.tar
+          key: farmos-2x-dev-${{ github.run_id }}
       - name: Load farmos/farmos:2.x-dev image
-        run: docker load < /tmp/artifacts/farmos-2x-dev.tar
+        run: docker load < /tmp/farmos-2x-dev.tar
       - name: Run PHP CodeSniffer
         run: docker run farmos/farmos:2.x-dev phpcs /opt/drupal/web/profiles/farm
   test:
@@ -91,13 +88,13 @@ jobs:
         run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Retrieve saved artifacts
-        uses: actions/download-artifact@v2
+      - name: Restore farmOS 2.x-dev Docker image from cache
+        uses: actions/cache@v3
         with:
-          name: farmOS-artifacts
-          path: /tmp/artifacts
+          path: /tmp/farmos-2x-dev.tar
+          key: farmos-2x-dev-${{ github.run_id }}
       - name: Load farmos/farmos:2.x-dev image
-        run: docker load < /tmp/artifacts/farmos-2x-dev.tar
+        run: docker load < /tmp/farmos-2x-dev.tar
       # Build a new docker-compose.yml file from docker-compose.testing.common + docker-compose.testing.{dbms}.yml.
       # Copy to the current directory so that farmOS volume mounts don't change to the docker/www folder.
       - name: Create docker-compose.yml

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,8 +12,43 @@ on:
 
 jobs:
   build:
+    name: Build Docker images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set FARMOS_VERSION for push event.
+        if: ${{ !github.event.pull_request }}
+        run: |
+          echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+          echo "FARMOS_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for pull request event.
+        if: ${{ github.event.pull_request }}
+        run: |
+          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+      - name: Build farmOS 2.x Docker image
+        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x docker
+      # This builds the dev Docker image using the specified FARMOS_VERSION,
+      # but notably it does NOT override the default PROJECT_VERSION, so the
+      # farmOS Composer project 2.x branch is always used.
+      - name: Build farmOS 2.x-dev Docker image
+        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x-dev docker/dev
+      - name: Save Docker images as tarballs
+        run: |
+          mkdir /tmp/artifacts
+          docker save farmos/farmos:2.x > /tmp/artifacts/farmos-2x.tar
+          docker save farmos/farmos:2.x-dev > /tmp/artifacts/farmos-2x-dev.tar
+      - name: Upload Docker images as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: farmOS-artifacts
+          path: /tmp/artifacts
+          retention-days: 1
+  test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest
+    needs: build
     strategy:
       matrix:
         dbms:
@@ -41,23 +76,13 @@ jobs:
         run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
       - name: Checkout the repository
         uses: actions/checkout@v2
-      - name: Set FARMOS_VERSION for push event.
-        if: ${{ !github.event.pull_request }}
-        run: |
-          echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
-          echo "FARMOS_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
-      - name: Set FARMOS_VERSION for pull request event.
-        if: ${{ github.event.pull_request }}
-        run: |
-          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
-          echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
-      - name: Build farmOS 2.x Docker image
-        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x docker
-      # This builds the dev Docker image using the specified FARMOS_VERSION,
-      # but notably it does NOT override the default PROJECT_VERSION, so the
-      # farmOS Composer project 2.x branch is always used.
-      - name: Build farmOS 2.x-dev Docker image
-        run: docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t farmos/farmos:2.x-dev docker/dev
+      - name: Retrieve saved Docker images from artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: farmOS-artifacts
+          path: /tmp/artifacts
+      - name: Load farmos/farmos:2.x-dev image
+        run: docker load < /tmp/artifacts/farmos-2x-dev.tar
       # Build a new docker-compose.yml file from docker-compose.testing.common + docker-compose.testing.{dbms}.yml.
       # Copy to the current directory so that farmOS volume mounts don't change to the docker/www folder.
       - name: Create docker-compose.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update [farmOS-map](https://github.com/farmOS/farmOS-map) to [v2.0.4](https://github.com/farmOS/farmOS-map/releases/tag/v2.0.4).
 - [Issue #3270561: Upgrade to gin beta](https://www.drupal.org/project/farm/issues/3270561)
+- [Separate Docker image build from testing jobs in run-test.yml workflow #522](https://github.com/farmOS/farmOS/pull/522)
 
 ### Fixed
 


### PR DESCRIPTION
I'm opening this PR as a first step towards [Issue #3203129: Use GitHub Actions to build Docker Hub images](https://www.drupal.org/project/farm/issues/3203129).

This does not add any new functionality. It simply breaks up our existing job in `run-test.yml` into 3 separate jobs:

1. `build`: Build Docker images
2. `sniff`: Run PHP Codesniffer (depends on `build`)
3. `test`: Run PHPUnit tests (depends on `test`)

The first job (`build`) builds the `farmos/farmos:2.x` and `farmos/farmos:2.x-dev` Docker images, to test that they build successfully. Then it caches the `farmos/farmos:2.x-dev` image so that it can be used in `sniff` and `test`. These two run in parallel, so the automated tests don't necessarily depend on the codesniffer results. The `test` job uses a matrix strategy, like before, to run against all three database types. This means we are no longer building Docker images and running codesniffer three times unnecessarily.

In the GitHub Actions UI it went from looking like this:

![Screenshot from 2022-04-07 15-05-29](https://user-images.githubusercontent.com/95381/162278585-684ebef0-8280-45a2-9e21-8cab1133729d.png)

To looking like this:

![Screenshot from 2022-04-07 15-05-41](https://user-images.githubusercontent.com/95381/162278606-4b9e904b-a23e-42d9-a46e-20aa8c2476b4.png)

I expect this will increase the overall runtime slightly, due to the time required to cache and load the image between jobs, but this is going to be necessary for the things we are talking about in https://www.drupal.org/project/farm/issues/3203129, so I think it's justified. In the few tests I ran, it actually seemed a bit *faster* - but I don't know how consistent that will be.

Next steps after this PR may include:

- Pushing Docker images to Docker Hub after all tests pass.
- Merging the `package-release.yml` workflow into this one (and therefore probably renaming this to something more general than `run-tests.yml`)
- Building ARM images for Raspberry Pi

Those can all be follow-ups to this.