### PR TITLE
Do not check php-geos requirement in the update phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Issue #3275161: Allow IMG tags in default text format](https://www.drupal.org/project/farm/issues/3275161)
 
+### Fixed
+
+- [Do not check php-geos requirement in the update phase #526](https://github.com/farmOS/farmOS/pull/526)
+
 ### Security
 
 - Update Drupal core to 9.3.12 for [SA-CORE-2022-008](https://www.drupal.org/sa-core-2022-008) and

--- a/modules/core/geo/farm_geo.install
+++ b/modules/core/geo/farm_geo.install
@@ -11,6 +11,12 @@
 function farm_geo_requirements($phase) {
   $requirements = [];
 
+  // Do not check requirements in the update phase.
+  // The REQUIREMENT_WARNING severity prevents updates from being run.
+  if ($phase == 'update') {
+    return $requirements;
+  }
+
   // Check for php-geos extension.
   if (geoPHP::geosInstalled()) {
     $severity = REQUIREMENT_OK;


### PR DESCRIPTION
Right now you cannot run `update.php` if the php-geos extension is not installed. This shouldn't be a blocker to running updates. I don't have php-geos at the moment in my local ddev development environment.

At first I was going to check if `$phase != 'runtime'` so that this requirement is only run at runtime, but I think it is good to include this during the `install` phase so that a warning message is displayed.

It seems like a core issue that `REQUIREMENT_WARNING` shouldn't block update.php but alas... the same issue here: https://www.drupal.org/project/email_noreply/issues/2184049

`hook_requirements` doc page for reference:
https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Extension%21module.api.php/function/hook_requirements/10.0.x

`/update.php` output:
![geos-update-error](https://user-images.githubusercontent.com/3116995/164527144-b29c38bb-4921-457c-9817-170f9200629b.png)
