### PR TITLE
Update toolbar logo spacing for gin beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Issue #3275161: Allow IMG tags in default text format](https://www.drupal.org/project/farm/issues/3275161)
+- [Update toolbar logo spacing for gin beta #527](https://github.com/farmOS/farmOS/pull/527)
 
 ### Fixed
 

--- a/modules/core/ui/theme/css/toolbar.css
+++ b/modules/core/ui/theme/css/toolbar.css
@@ -3,10 +3,15 @@
  * Styling for farmOS toolbar.
  */
 
+/* Add padding to the wrapper around the logo. */
+.toolbar .toolbar-bar #toolbar-item-administration-tray .toolbar-logo {
+  padding: .5em !important;
+}
+
 /* Logo size and spacing. */
 .toolbar .toolbar-bar #toolbar-item-administration-tray .toolbar-logo img.toolbar-icon-home {
   max-width: 100px;
-  margin: 40px auto;
+  margin: 20px auto;
 }
 
 /* Locations icon. */


### PR DESCRIPTION
Two changes:
- Decrease the top/bottom margin to 20px. This centers the logo vertically.
- Add padding to the wrapper around the logo. Without this padding the logo touches the edges of the toolbar. Not sure if we can fix this without adding the `!important` here.