### PR TITLE
Decrease weight of farm info settings task link

### DIFF
--- a/modules/core/settings/farm_settings.links.task.yml
+++ b/modules/core/settings/farm_settings.links.task.yml
@@ -2,7 +2,7 @@ farm_settings.settings_page:
   base_route: farm_settings.settings_page
   route_name: farm_settings.settings_page
   title: 'Farm Info'
-  weight: -1
+  weight: -5
 
 farm_settings.modules_form:
   base_route: farm_settings.settings_page


### PR DESCRIPTION
Currently there is not a reliable way to add a new task link between "Farm info" and "Modules". If a new task has a weight of either -1 or 0 it could be rendered before or after the existing tasks with the same weight depending on what order they are discovered. Changing "Farm info" to have a weight of -5 gives us some flexibility here.