### PR TITLE
Only show active plans by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Issue #3275161: Allow IMG tags in default text format](https://www.drupal.org/project/farm/issues/3275161)
 - [Update toolbar logo spacing for gin beta #527](https://github.com/farmOS/farmOS/pull/527)
+- [Only show active plans by default #529](https://github.com/farmOS/farmOS/pull/529)
 
 ### Fixed
 

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -3,9 +3,6 @@ status: true
 dependencies:
   config:
     - system.menu.admin
-  enforced:
-    module:
-      - farm_ui_views
   module:
     - csv_serialization
     - options
@@ -14,6 +11,9 @@ dependencies:
     - serialization
     - state_machine
     - user
+  enforced:
+    module:
+      - farm_ui_views
 id: farm_plan
 label: 'Farm Plans'
 module: views
@@ -23,129 +23,12 @@ base_table: plan_field_data
 base_field: id
 display:
   default:
-    display_plugin: default
     id: default
     display_title: Master
+    display_plugin: default
     position: 0
     display_options:
-      access:
-        type: perm
-        options:
-          perm: 'view any plan'
-      cache:
-        type: tag
-        options: {  }
-      query:
-        type: views_query
-        options:
-          disable_sql_rewrite: false
-          distinct: false
-          replica: false
-          query_comment: ''
-          query_tags: {  }
-      exposed_form:
-        type: basic
-        options:
-          submit_button: Apply
-          reset_button: true
-          reset_button_label: Reset
-          exposed_sorts_label: 'Sort by'
-          expose_sort_order: true
-          sort_asc_label: Asc
-          sort_desc_label: Desc
-      pager:
-        type: full
-        options:
-          items_per_page: 50
-          offset: 0
-          id: 0
-          total_pages: null
-          tags:
-            previous: ‹‹
-            next: ››
-            first: '« First'
-            last: 'Last »'
-          expose:
-            items_per_page: true
-            items_per_page_label: 'Items per page'
-            items_per_page_options: '25, 50, 100, 250, 500'
-            items_per_page_options_all: true
-            items_per_page_options_all_label: '- All -'
-            offset: false
-            offset_label: Offset
-          quantity: 9
-      style:
-        type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
-          columns:
-            plan_bulk_form: plan_bulk_form
-            image_target_id: image_target_id
-            id: id
-            name: name
-            type: type
-            flag_value: flag_value
-            status: status
-          info:
-            plan_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            image_target_id:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            id:
-              sortable: true
-              default_sort_order: desc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            type:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            flag_value:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          default: name
-          empty_table: true
-      row:
-        type: fields
-        options:
-          inline: {  }
-          separator: ''
-          hide_empty: false
-          default_field_elements: true
+      title: Plans
       fields:
         plan_bulk_form:
           id: plan_bulk_form
@@ -154,6 +37,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          plugin_id: bulk_form
           label: 'Bulk update'
           exclude: false
           alter:
@@ -198,8 +83,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: plan
-          plugin_id: bulk_form
         id:
           id: id
           table: plan_field_data
@@ -207,6 +90,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: id
+          plugin_id: field
           label: ID
           exclude: false
           alter:
@@ -263,9 +149,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: plan
-          entity_field: id
-          plugin_id: field
         name:
           id: name
           table: plan_field_data
@@ -273,6 +156,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: 'Plan name'
           exclude: false
           alter:
@@ -328,9 +214,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: name
-          plugin_id: field
         type:
           id: type
           table: plan_field_data
@@ -338,6 +221,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: type
+          plugin_id: field
           label: 'Plan type'
           exclude: false
           alter:
@@ -393,9 +279,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: plan
-          entity_field: type
-          plugin_id: field
         flag_value:
           id: flag_value
           table: plan__flag
@@ -403,6 +286,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: flag
+          plugin_id: field
           label: Flags
           exclude: false
           alter:
@@ -457,9 +343,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: true
-          entity_type: plan
-          entity_field: flag
-          plugin_id: field
         status:
           id: status
           table: plan_field_data
@@ -467,6 +350,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: status
+          plugin_id: field
           label: Status
           exclude: false
           alter:
@@ -521,9 +407,58 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: plan
-          entity_field: status
-          plugin_id: field
+      pager:
+        type: full
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '25, 50, 100, 250, 500'
+            items_per_page_options_all: true
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: true
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view any plan'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No plans found.'
+          tokenize: false
+      sorts: {  }
+      arguments: {  }
       filters:
         name:
           id: name
@@ -532,6 +467,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: name
+          plugin_id: string
           operator: contains
           value: ''
           group: 1
@@ -563,9 +501,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: plan
-          entity_field: name
-          plugin_id: string
         type:
           id: type
           table: plan_field_data
@@ -573,6 +508,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: type
+          plugin_id: bundle
           operator: in
           value: {  }
           group: 1
@@ -604,9 +542,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: plan
-          entity_field: type
-          plugin_id: bundle
         flag_value:
           id: flag_value
           table: plan__flag
@@ -614,6 +549,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: flag
+          plugin_id: list_field
           operator: or
           value: {  }
           group: 1
@@ -646,9 +584,6 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           reduce_duplicates: false
-          entity_type: plan
-          entity_field: flag
-          plugin_id: list_field
         status:
           id: status
           table: plan_field_data
@@ -656,6 +591,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: status
+          plugin_id: state_machine_state
           operator: in
           value: {  }
           group: 1
@@ -687,107 +625,26 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          entity_type: plan
-          entity_field: status
-          plugin_id: state_machine_state
-      sorts: {  }
-      header: {  }
-      footer:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          content: 'Displaying @start - @end of @total'
-          plugin_id: result
-        display_link:
-          id: display_link
-          table: views
-          field: display_link
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: false
-          display_id: csv
-          label: 'Export CSV'
-          plugin_id: display_link
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          empty: true
-          tokenize: false
-          content: 'No plans found.'
-          plugin_id: text_custom
-      relationships: {  }
-      arguments: {  }
-      display_extenders: {  }
-      title: Plans
       filter_groups:
         operator: AND
         groups:
           1: AND
-    cache_metadata:
-      max-age: 0
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - user.permissions
-      tags: {  }
-  block_active:
-    display_plugin: block
-    id: block_active
-    display_title: 'Active (block)'
-    position: 3
-    display_options:
-      display_extenders: {  }
-      display_description: ''
-      block_description: 'Active plans'
-      title: 'Active plans'
-      defaults:
-        title: false
-        style: false
-        row: false
-        filters: false
-        filter_groups: false
-        fields: false
-        footer: false
-        pager: false
       style:
         type: table
         options:
           grouping: {  }
           row_class: ''
           default_row_class: true
-          override: true
-          sticky: false
-          caption: ''
-          summary: ''
-          description: ''
           columns:
             plan_bulk_form: plan_bulk_form
-            image_target_id: image_target_id
             id: id
             name: name
             type: type
             flag_value: flag_value
             status: status
+          default: name
           info:
             plan_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            image_target_id:
               align: ''
               separator: ''
               empty_column: false
@@ -825,62 +682,68 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-          default: name
+          override: true
+          sticky: false
+          summary: ''
           empty_table: true
+          caption: ''
+          description: ''
       row:
         type: fields
         options:
+          default_field_elements: true
           inline: {  }
           separator: ''
           hide_empty: false
-          default_field_elements: true
-      filters:
-        status:
-          id: status
-          table: plan_field_data
-          field: status
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
           relationship: none
           group_type: group
           admin_label: ''
-          operator: in
-          value:
-            active: active
-          group: 1
-          exposed: false
-          expose:
-            operator_id: status_op
-            label: Status
-            description: ''
-            use_operator: false
-            operator: status_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: status
-            required: false
-            remember: false
-            multiple: true
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: plan
-          entity_field: status
-          plugin_id: state_machine_state
-      filter_groups:
-        operator: AND
-        groups:
-          1: AND
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+        display_link:
+          id: display_link
+          table: views
+          field: display_link
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: display_link
+          label: 'Export CSV'
+          empty: false
+          display_id: csv
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  block_active:
+    id: block_active
+    display_title: 'Active (block)'
+    display_plugin: block
+    position: 3
+    display_options:
+      title: 'Active plans'
       fields:
         plan_bulk_form:
           id: plan_bulk_form
@@ -889,6 +752,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          plugin_id: bulk_form
           label: 'Bulk update'
           exclude: false
           alter:
@@ -933,8 +798,6 @@ display:
           action_title: Action
           include_exclude: exclude
           selected_actions: {  }
-          entity_type: plan
-          plugin_id: bulk_form
         id:
           id: id
           table: plan_field_data
@@ -942,6 +805,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: id
+          plugin_id: field
           label: ID
           exclude: false
           alter:
@@ -998,9 +864,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: plan
-          entity_field: id
-          plugin_id: field
         name:
           id: name
           table: plan_field_data
@@ -1008,6 +871,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
           label: 'Plan name'
           exclude: false
           alter:
@@ -1063,9 +929,6 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: null
-          entity_field: name
-          plugin_id: field
         type:
           id: type
           table: plan_field_data
@@ -1073,6 +936,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: type
+          plugin_id: field
           label: 'Plan type'
           exclude: false
           alter:
@@ -1128,14 +994,142 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: plan
-          entity_field: type
-          plugin_id: field
-      footer: {  }
       pager:
         type: none
         options:
           offset: 0
+      filters:
+        status:
+          id: status
+          table: plan_field_data
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: status
+          plugin_id: state_machine_state
+          operator: in
+          value:
+            active: active
+          group: 1
+          exposed: false
+          expose:
+            operator_id: status_op
+            label: Status
+            description: ''
+            use_operator: false
+            operator: status_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: status
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            plan_bulk_form: plan_bulk_form
+            image_target_id: image_target_id
+            id: id
+            name: name
+            type: type
+            flag_value: flag_value
+            status: status
+          default: name
+          info:
+            plan_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            image_target_id:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            id:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            type:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            flag_value:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            status:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
+      defaults:
+        title: false
+        pager: false
+        style: false
+        row: false
+        fields: false
+        filters: false
+        filter_groups: false
+        footer: false
+      display_description: ''
+      footer: {  }
+      display_extenders: {  }
+      block_description: 'Active plans'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1145,26 +1139,21 @@ display:
         - user.permissions
       tags: {  }
   csv:
-    display_plugin: rest_export
     id: csv
     display_title: 'CSV export (rest)'
+    display_plugin: rest_export
     position: 4
     display_options:
-      display_extenders: {  }
+      pager:
+        type: none
+        options:
+          offset: 0
       style:
         type: serializer
         options:
           uses_fields: false
           formats:
             csv: csv
-      path: plans.csv
-      auth:
-        - cookie
-      pager:
-        type: none
-        options:
-          offset: 0
-      display_description: ''
       row:
         type: data_field
         options:
@@ -1190,6 +1179,11 @@ display:
             status:
               alias: ''
               raw_output: false
+      display_description: ''
+      display_extenders: {  }
+      path: plans.csv
+      auth:
+        - cookie
     cache_metadata:
       max-age: 0
       contexts:
@@ -1200,23 +1194,23 @@ display:
         - user.permissions
       tags: {  }
   page:
-    display_plugin: page
     id: page
     display_title: 'All plans (page)'
+    display_plugin: page
     position: 1
     display_options:
+      display_description: ''
       display_extenders: {  }
       path: plans
-      display_description: ''
       menu:
         type: normal
         title: Plans
         description: ''
-        expanded: true
-        parent: farm.base
         weight: 0
-        context: '0'
+        expanded: true
         menu_name: admin
+        parent: farm.base
+        context: '0'
     cache_metadata:
       max-age: 0
       contexts:
@@ -1227,14 +1221,11 @@ display:
         - user.permissions
       tags: {  }
   page_type:
-    display_plugin: page
     id: page_type
     display_title: 'By type (page)'
+    display_plugin: page
     position: 2
     display_options:
-      display_extenders: {  }
-      display_description: ''
-      path: plans/%
       arguments:
         type:
           id: type
@@ -1243,6 +1234,9 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: plan
+          entity_field: type
+          plugin_id: string
           default_action: 'not found'
           exception:
             value: all
@@ -1257,8 +1251,8 @@ display:
           summary_options:
             base_path: ''
             count: true
-            items_per_page: 25
             override: false
+            items_per_page: 25
           summary:
             sort_order: asc
             number_of_records: 0
@@ -1268,21 +1262,21 @@ display:
             type: 'entity:plan_type'
             fail: 'not found'
           validate_options:
+            bundles: {  }
+            access: false
             operation: view
             multiple: 0
-            access: false
-            bundles: {  }
           glossary: false
           limit: 0
           case: none
           path_case: none
           transform_dash: false
           break_phrase: false
-          entity_type: plan
-          entity_field: type
-          plugin_id: string
       defaults:
         arguments: false
+      display_description: ''
+      display_extenders: {  }
+      path: plans/%
     cache_metadata:
       max-age: 0
       contexts:

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -595,7 +595,8 @@ display:
           entity_field: status
           plugin_id: state_machine_state
           operator: in
-          value: {  }
+          value:
+            active: active
           group: 1
           exposed: true
           expose:


### PR DESCRIPTION
I noticed that right now the Plan views display both active and archived plans by default. I think we should make this only show active plans by default for consistency with the other views. Once a plan is archived you likely don't want to see it all the time.

After I first made this change and exported config there were lots of changes. So I went back and re-exported the `farm_plan` view to capture only these config schema/ordering changes (I believe the same as
c4d439c204895577af6a39a12408e89e2373f435)

Finally I exported the simple change for the `status` filter.