### PR TITLE
Remove create() implementations from classes that do not implement ContainerInjectionInterface

### DIFF
--- a/modules/asset/group/src/GroupMembership.php
+++ b/modules/asset/group/src/GroupMembership.php
@@ -8,7 +8,6 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\farm_log\LogQueryFactoryInterface;
 use Drupal\log\Entity\LogInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Asset group membership logic.
@@ -67,18 +66,6 @@ class GroupMembership implements GroupMembershipInterface {
     $this->entityTypeManager = $entity_type_manager;
     $this->time = $time;
     $this->database = $database;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('farm.log_query'),
-      $container->get('entity_type.manager'),
-      $container->get('datetime.time'),
-      $container->get('database')
-    );
   }
 
   /**

--- a/modules/core/location/src/AssetLocation.php
+++ b/modules/core/location/src/AssetLocation.php
@@ -8,7 +8,6 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\farm_log\LogQueryFactoryInterface;
 use Drupal\log\Entity\LogInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Asset location logic.
@@ -91,19 +90,6 @@ class AssetLocation implements AssetLocationInterface {
     $this->entityTypeManager = $entity_type_manager;
     $this->time = $time;
     $this->database = $database;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('log.location'),
-      $container->get('farm.log_query'),
-      $container->get('entity_type.manager'),
-      $container->get('datetime.time'),
-      $container->get('database')
-    );
   }
 
   /**

--- a/modules/core/log/modules/quantity/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/log/modules/quantity/src/EventSubscriber/LogEventSubscriber.php
@@ -4,7 +4,6 @@ namespace Drupal\farm_log_quantity\EventSubscriber;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\log\Event\LogEvent;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -24,15 +23,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')
-    );
   }
 
   /**

--- a/modules/core/log/src/LogQueryFactory.php
+++ b/modules/core/log/src/LogQueryFactory.php
@@ -4,7 +4,6 @@ namespace Drupal\farm_log;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Factory for generating a log query.
@@ -26,15 +25,6 @@ class LogQueryFactory implements LogQueryFactoryInterface {
    */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')
-    );
   }
 
   /**


### PR DESCRIPTION
The `create()` function is not needed for services that define their dependencies as in the `arguments` of `module.services.yml`. All of these services should be covered by our tests, removing this should be OK!

I noticed this because my IDE highlighted that the `create()` function's `{@inheritdoc}` was not inheriting from anywhere. The `create()` function is defined on the [`ContainerInjectionInterface`](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21DependencyInjection%21ContainerInjectionInterface.php/function/ContainerInjectionInterface%3A%3Acreate/9.3.x) which is only implemented by classes that need dependency injection but are not services themselves (things like form & plugin classes in Drupal).