### PR TITLE
Update composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Do not check php-geos requirement in the update phase #526](https://github.com/farmOS/farmOS/pull/526)
+- Patch entity_reference_revisions module to fix upstream issue [#3267304](https://www.drupal.org/project/entity_reference_revisions/issues/3267304).
 
 ### Security
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/entity": "1.3",
         "drupal/entity_browser": "^2.6",
         "drupal/entity_reference_integrity": "^1.1",
-        "drupal/entity_reference_revisions": "^1.8",
+        "drupal/entity_reference_revisions": "1.9",
         "drupal/entity_reference_validators": "^1.0@alpha",
         "drupal/exif_orientation": "^1.1",
         "drupal/fraction": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"
             },
+            "drupal/entity_reference_revisions": {
+                "Issue #3267304: Infer target_revision_id to be Latest Revision when Only a target_id is Provided": "https://www.drupal.org/files/issues/2022-05-13/3267304-9.patch"
+            },
             "drupal/jsonapi_schema": {
                 "Issue #3256795: Float fields have a null schema": "https://www.drupal.org/files/issues/2022-01-03/3256795-4.patch",
                 "Issue #3246251: Change format utc-millisec to date-time": "https://www.drupal.org/files/issues/2021-10-27/3246251-2.patch"


### PR DESCRIPTION
Infer target_revision_id to be Latest Revision when Only a target_id is Provided": "https://www.drupal.org/files/issues/2022-05-13/3267304-9.patch"