### PR TITLE
Add images to asset-related taxonomies

### DIFF
--- a/modules/taxonomy/animal_type/config/install/core.entity_form_display.taxonomy_term.animal_type.default.yml
+++ b/modules/taxonomy/animal_type/config/install/core.entity_form_display.taxonomy_term.animal_type.default.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.animal_type.image
+    - image.style.thumbnail
+    - taxonomy.vocabulary.animal_type
+  enforced:
+    module:
+      - farm_animal_type
+  module:
+    - image
+    - text
+id: taxonomy_term.animal_type.default
+targetEntityType: taxonomy_term
+bundle: animal_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  image:
+    type: image_image
+    weight: 6
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/taxonomy/animal_type/config/install/core.entity_view_display.taxonomy_term.animal_type.default.yml
+++ b/modules/taxonomy/animal_type/config/install/core.entity_view_display.taxonomy_term.animal_type.default.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.animal_type.image
+    - taxonomy.vocabulary.animal_type
+  enforced:
+    module:
+      - farm_animal_type
+  module:
+    - image
+    - text
+id: taxonomy_term.animal_type.default
+targetEntityType: taxonomy_term
+bundle: animal_type
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  image:
+    type: image
+    weight: 5
+    region: content
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/taxonomy/animal_type/config/install/field.field.taxonomy_term.animal_type.image.yml
+++ b/modules/taxonomy/animal_type/config/install/field.field.taxonomy_term.animal_type.image.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.image
+    - taxonomy.vocabulary.animal_type
+  enforced:
+    module:
+      - farm_animal_type
+  module:
+    - image
+id: taxonomy_term.animal_type.image
+field_name: image
+entity_type: taxonomy_term
+bundle: animal_type
+label: Photos
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: 'farm/[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/modules/taxonomy/material_type/config/install/core.entity_form_display.taxonomy_term.material_type.default.yml
+++ b/modules/taxonomy/material_type/config/install/core.entity_form_display.taxonomy_term.material_type.default.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.material_type.image
+    - image.style.thumbnail
+    - taxonomy.vocabulary.material_type
+  enforced:
+    module:
+      - farm_material_type
+  module:
+    - image
+    - text
+id: taxonomy_term.material_type.default
+targetEntityType: taxonomy_term
+bundle: material_type
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 1
+    region: content
+    settings:
+      placeholder: ''
+      rows: 5
+    third_party_settings: {  }
+  image:
+    type: image_image
+    weight: 6
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 7
+    region: content
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/taxonomy/material_type/config/install/core.entity_view_display.taxonomy_term.material_type.default.yml
+++ b/modules/taxonomy/material_type/config/install/core.entity_view_display.taxonomy_term.material_type.default.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.material_type.image
+    - taxonomy.vocabulary.material_type
+  enforced:
+    module:
+      - farm_material_type
+  module:
+    - image
+    - text
+id: taxonomy_term.material_type.default
+targetEntityType: taxonomy_term
+bundle: material_type
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  image:
+    type: image
+    weight: 5
+    region: content
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/taxonomy/material_type/config/install/field.field.taxonomy_term.material_type.image.yml
+++ b/modules/taxonomy/material_type/config/install/field.field.taxonomy_term.material_type.image.yml
@@ -1,0 +1,40 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.image
+    - taxonomy.vocabulary.material_type
+  enforced:
+    module:
+      - farm_material_type
+  module:
+    - image
+id: taxonomy_term.material_type.image
+field_name: image
+entity_type: taxonomy_term
+bundle: material_type
+label: Photos
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: 'farm/[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: false
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image


### PR DESCRIPTION
With the addition of entity views on taxonomy terms (https://github.com/farmOS/farmOS/pull/458) this pages are more used and having a image could be helpful. 