### PR TITLE
Allow dealerdirect/phpcodesniffer-composer-installer composer plugin.

### DIFF
--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -42,6 +42,7 @@ composer require farmos/farmos ${FARMOS_COMPOSER_VERSION} --no-install
 allowedPlugins=(
   "composer/installers"
   "cweagans/composer-patches"
+  "dealerdirect/phpcodesniffer-composer-installer"
   "drupal/core-composer-scaffold"
   "oomphinc/composer-installers-extender"
   "wikimedia/composer-merge-plugin"


### PR DESCRIPTION
This morning my contrib modules had failing tests due to a phpcs message. See this `farm_loocc` failed run: https://github.com/paul121/farm_loocc/runs/6866849203?check_suite_focus=true

```bash
$ docker-compose exec -u www-data -T www phpcs /opt/drupal/web/modules/custom --exclude=DrupalPractice.InfoFiles.NamespacedDependency
  
ERROR: Referenced sniff "DrupalPractice" does not exist
```
I've tracked this down to a new composer dependency on `dealerdirect/phpcodesniffer-composer-installer` that was introduced with drupal/core-dev 9.3.16. This is a composer plugin that configures the phpcs installed paths on `composer install`. We need to add this to our allowed plugins list.. I believe it will actually become a requirement in July 2022. For some background on why we did this see https://github.com/farmOS/farmOS/pull/467

Making this change in farm_loocc fixed the tests, but we should include this change directly in our 2.x image.
- Commit: https://github.com/paul121/farm_loocc/commit/73fee0ed9ba5af92f5c6e0d2ce5f9a0e945f6ca2
- Test: https://github.com/paul121/farm_loocc/actions/runs/2490294946

I'm also curious if/how we could *leverage* this [`dealerdirect/phpcodesniffer-composer-installer`](https://github.com/PHPCSStandards/composer-installer) plugin, but we should leave that for a separate issue. Presumably we could create our own composer package of `"type" : "phpcodesniffer-standard"` and maintain our standards there. I'm not sure if it's possible to alter the standards of other packages like `drupal/coder` in this way though.

Here are some command snippets demonstrating this issue:
```
$ docker pull farmos/farmos:2.x-dev
2.x-dev: Pulling from farmos/farmos
Digest: sha256:49f04221dc2cf821091e92c1224a9b07a35ba9165ec9697ba221df3ce198db3e
Status: Image is up to date for farmos/farmos:2.x-dev
docker.io/farmos/farmos:2.x-dev

$ docker run -d --name farmos_test farmos/farmos:2.x-dev
fcf51b852d16f62a07a822c9041439a542e771630eeba78139f3257155554dcb

$ docker exec -it farmos_test composer list
dealerdirect/phpcodesniffer-composer-installer contains a Composer plugin which is currently not in your allow-plugins config. See https://getcomposer.org/allow-plugins
Do you trust "dealerdirect/phpcodesniffer-composer-installer" to execute code and wish to enable it now? (writes "allow-plugins" to composer.json) [y,n,d,?] y
...

$ docker exec -it farmos_test composer why dealerdirect/phpcodesniffer-composer-installer
drupal/coder             8.3.15 requires dealerdirect/phpcodesniffer-composer-installer (^0.7.1)         
slevomat/coding-standard 7.2.1  requires dealerdirect/phpcodesniffer-composer-installer (^0.6.2 || ^0.7) 

$ docker exec -it farmos_test composer why drupal/coder
drupal/core-dev 9.3.16 requires drupal/coder (^8.3.10) 

$ docker exec -it farmos_test composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
Package symfony/debug is abandoned, you should avoid using it. Use symfony/error-handler instead.
Package webmozart/path-util is abandoned, you should avoid using it. Use symfony/filesystem instead.
Generating autoload files
90 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
PHP CodeSniffer Config installed_paths set to ../../drupal/coder/coder_sniffer,../../sirbrillig/phpcs-variable-analysis,../../slevomat/coding-standard,/var/farmOS/vendor/drupal/coder/coder_sniffer,/var/farmOS/vendor/slevomat/coding-standard

```