### PR TITLE
Return empty array if location field returns NULL.

### DIFF
--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -191,7 +191,7 @@ class AssetMoveActionForm extends ConfirmFormBase {
 
       // Load location assets.
       $locations = [];
-      $location_ids = array_column($form_state->getValue('location', []), 'target_id');
+      $location_ids = array_column($form_state->getValue('location', []) ?? [], 'target_id');
       if (!empty($location_ids)) {
         $locations = $this->entityTypeManager->getStorage('asset')->loadMultiple($location_ids);
       }


### PR DESCRIPTION
Submitting the `AssetMoveActionForm` without specifying any `location` produces a warning message:

```
Warning: array_column() expects parameter 1 to be array, null given in Drupal\farm_location\Form\AssetMoveActionForm->submitForm() (line 194 of profiles/farm/modules/core/location/src/Form/AssetMoveActionForm.php).
```