### PR TITLE
Don't lock ext-simplexml to PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "drupal/token": "^1.7",
         "drupal/views_geojson": "^1.1",
         "drush/drush": "^10.3",
-        "ext-simplexml": "^7.4",
+        "ext-simplexml": "*",
         "phayes/geophp": "1.2"
     },
     "extra": {


### PR DESCRIPTION
When installing from scratch, I am getting a PHP7 requirement:

```
 ddev composer create farmos/project --stability dev --no-interaction
Warning: MOST EXISTING CONTENT in the composer root (/Users/pcambra/webs/ecotrust/vanilla-farmos) will be deleted by the composer create-project operation. Only .ddev, .git and .tarballs will be preserved.
Would you like to continue? [Y/n] (yes): 
Removing any existing files in composer root
Executing composer command: [composer create-project farmos/project --stability dev --no-interaction /tmp/GtolPx]

Creating a "farmos/project" project at "/tmp/GtolPx"
Installing farmos/project (2.x-dev 5214879c44c421e5160a0091412279ea6790f979)
  - Downloading farmos/project (2.x-dev 5214879)
  - Installing farmos/project (2.x-dev 5214879): Extracting archive
Created project in /tmp/GtolPx
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - farmos/farmos[2.0.0-beta1, ..., 2.0.0-beta5] require ext-simplexml ^7.4 -> it has the wrong version installed (8.0.16).
    - Root composer.json requires farmos/farmos ^2@beta -> satisfiable by farmos/farmos[2.0.0-beta1, ..., 2.0.0-beta5].

To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php/8.0/cli/php.ini
    - /etc/php/8.0/cli/conf.d/10-mysqlnd.ini
    - /etc/php/8.0/cli/conf.d/10-opcache.ini
    - /etc/php/8.0/cli/conf.d/10-pdo.ini
    - /etc/php/8.0/cli/conf.d/15-xml.ini
    - /etc/php/8.0/cli/conf.d/20-apcu.ini
    - /etc/php/8.0/cli/conf.d/20-assert.ini
    - /etc/php/8.0/cli/conf.d/20-bcmath.ini
    - /etc/php/8.0/cli/conf.d/20-bz2.ini
    - /etc/php/8.0/cli/conf.d/20-calendar.ini
    - /etc/php/8.0/cli/conf.d/20-ctype.ini
    - /etc/php/8.0/cli/conf.d/20-curl.ini
    - /etc/php/8.0/cli/conf.d/20-dom.ini
    - /etc/php/8.0/cli/conf.d/20-exif.ini
    - /etc/php/8.0/cli/conf.d/20-ffi.ini
    - /etc/php/8.0/cli/conf.d/20-fileinfo.ini
    - /etc/php/8.0/cli/conf.d/20-ftp.ini
    - /etc/php/8.0/cli/conf.d/20-gd.ini
    - /etc/php/8.0/cli/conf.d/20-gettext.ini
    - /etc/php/8.0/cli/conf.d/20-iconv.ini
    - /etc/php/8.0/cli/conf.d/20-igbinary.ini
    - /etc/php/8.0/cli/conf.d/20-imagick.ini
    - /etc/php/8.0/cli/conf.d/20-intl.ini
    - /etc/php/8.0/cli/conf.d/20-ldap.ini
    - /etc/php/8.0/cli/conf.d/20-mbstring.ini
    - /etc/php/8.0/cli/conf.d/20-msgpack.ini
    - /etc/php/8.0/cli/conf.d/20-mysqli.ini
    - /etc/php/8.0/cli/conf.d/20-pdo_mysql.ini
    - /etc/php/8.0/cli/conf.d/20-pdo_pgsql.ini
    - /etc/php/8.0/cli/conf.d/20-pdo_sqlite.ini
    - /etc/php/8.0/cli/conf.d/20-pgsql.ini
    - /etc/php/8.0/cli/conf.d/20-phar.ini
    - /etc/php/8.0/cli/conf.d/20-posix.ini
    - /etc/php/8.0/cli/conf.d/20-readline.ini
    - /etc/php/8.0/cli/conf.d/20-redis.ini
    - /etc/php/8.0/cli/conf.d/20-shmop.ini
    - /etc/php/8.0/cli/conf.d/20-simplexml.ini
    - /etc/php/8.0/cli/conf.d/20-soap.ini
    - /etc/php/8.0/cli/conf.d/20-sockets.ini
    - /etc/php/8.0/cli/conf.d/20-sqlite3.ini
    - /etc/php/8.0/cli/conf.d/20-sysvmsg.ini
    - /etc/php/8.0/cli/conf.d/20-sysvsem.ini
    - /etc/php/8.0/cli/conf.d/20-sysvshm.ini
    - /etc/php/8.0/cli/conf.d/20-tokenizer.ini
    - /etc/php/8.0/cli/conf.d/20-uploadprogress.ini
    - /etc/php/8.0/cli/conf.d/20-xmlreader.ini
    - /etc/php/8.0/cli/conf.d/20-xmlrpc.ini
    - /etc/php/8.0/cli/conf.d/20-xmlwriter.ini
    - /etc/php/8.0/cli/conf.d/20-xsl.ini
    - /etc/php/8.0/cli/conf.d/20-zip.ini
    - /etc/php/8.0/cli/conf.d/25-memcached.ini
You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
Alternatively, you can run Composer with `--ignore-platform-req=ext-simplexml` to temporarily ignore these required extensions.
Failed to create project:exit status 2, stderr=
```

I think leaving the dependency as "*" would fix this.