### PR TITLE
Generate unique form IDs for quick forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Issue #3290929: Provide a farmOS map form element](https://www.drupal.org/project/farm/issues/3290929)
 - [Issue #3290993: Add "Move asset" button next to the current location field](https://www.drupal.org/project/farm/issues/3290993)
+- [Generate unique form IDs for quick forms #547](https://github.com/farmOS/farmOS/pull/547)
 
 ### Security
 

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\farm_quick\Form;
 
+use Drupal\Core\Form\BaseFormIdInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -13,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @ingroup farm
  */
-class QuickForm extends FormBase {
+class QuickForm extends FormBase implements BaseFormIdInterface {
 
   /**
    * The quick form manager.
@@ -51,8 +52,16 @@ class QuickForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getBaseFormId() {
     return 'quick_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    $id = $this->getRouteMatch()->getParameter('id');
+    return $this->getBaseFormId() . "_$id";
   }
 
   /**


### PR DESCRIPTION
Currently all quick forms get the same form ID `quick_form`. We can implement the core `BaseFormIdInterface` to make the base form ID be `quick_form` and build a unique form ID for each quick form from the `id` route parameter.