### PR TITLE
Fix for Autocomplete dropdown not showing in Chrome on Android #552

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix for Autocomplete dropdown not showing in Chrome on Android #552](https://github.com/farmOS/farmOS/issues/552)
+
 ## [2.0.0-beta6] 2022-07-30
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
             "drupal/core": {
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-12-09/2339235-9.3.x-76.patch",
-                "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch"
+                "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2021-09-13/drupal-2909128.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"


### PR DESCRIPTION
Adds patch "https://www.drupal.org/files/issues/2021-09-13/drupal-2909128.patch
from issue https://www.drupal.org/project/drupal/issues/2909128