### PR TITLE
Correct and standardize OAuth curl examples

### DIFF
--- a/docs/development/api/authentication.md
+++ b/docs/development/api/authentication.md
@@ -81,29 +81,28 @@ endpoint requesting an `Authorization Code`. The user logs in and authorizes
 the client to have the OAuth Scopes it is requesting.
 
     Copy this link to browser -
-    http://localhost/oauth/authorize?response_type=code&client_id=farmos_development&scope=user_access&redirect_uri=http://localhost/api/authorized&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
+    http://localhost/oauth/authorize?response_type=code&client_id=farm&scope=farm_manager&redirect_uri=http://thirdparty/api/authorized&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
 
 **Second**: after the user accepts, the server redirects
 to the `redirect_uri` with an authorization `code` and `state` in the query
 parameters.
 
     Example redirect url from server:
-    http://localhost/api/authorized?code=9eb9442c7a2b011fd59617635cca5421cd089943&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
+    http://thirdparty/api/authorized?code=9eb9442c7a2b011fd59617635cca5421cd089943&state=p4W8P5f7gJCIDbC1Mv78zHhlpJOidy
 
 **Third**: copy the `code` and `state` from the URL into the body of a POST
 request. The `grant_type`, `client_id`, `client_secret` and `redirect_uri` must
 also be included in the POST body. The client makes a POST request to the
 `/oauth/token` endpoint to retrieve an `access_token` and `refresh_token`.
 
-    foo@bar:~$ curl -X POST -d "grant_type=authorization_code&code=ae4d1381cc67def1c10dc88a19af6ac30d7b5959&client_id=farmos_development&redirect_uri=http://localhost/api/authorized" http://localhost/oauth/token
-    {"access_token":"3f9212c4a6656f1cd1304e47307927a7c224abb0","expires_in":"10","token_type":"Bearer","scope":"user_access","refresh_token":"292810b04d688bfb5c3cee28e45637ec8ef1dd9e"}
+    $ curl -X POST -d "grant_type=authorization_code&code=ae4d1381cc67def1c10dc88a19af6ac30d7b5959&client_id=farm&redirect_uri=http://thirdparty/api/authorized" http://localhost/oauth/token
+    {"access_token":"3f9212c4a6656f1cd1304e47307927a7c224abb0","expires_in":"10","token_type":"Bearer","scope":"farm_manager","refresh_token":"292810b04d688bfb5c3cee28e45637ec8ef1dd9e"}
 
 **Fourth**: the client sends the access token in the request header to access protected
 resources. The header is an Authorization header with a Bearer token:
  `Authorization: Bearer access_token`
 
-    foo@bar:~$ curl --header "Authorization: Bearer b872daf5827a75495c8194c6bfa4f90cf46c143e" http://localhost/farm.json
-    {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", ....
+    $ curl --header "Authorization: Bearer b872daf5827a75495c8194c6bfa4f90cf46c143e" http://localhost/api
 
 #### Password Credentials Grant
 
@@ -124,15 +123,14 @@ Requesting protected resources is a two step process:
 endpoint with `grant_type` set to `password` and a `username` and `password`
 included in the request body.
 
-    $ curl -X POST -d "grant_type=password&username=username&password=test&client_id=farm&scope=user_access" http://localhost/oauth/token
-    {"access_token":"e69c60dea3f5c59c95863928fa6fb860d3506fe9","expires_in":"300","token_type":"Bearer","scope":"user_access","refresh_token":"cead7d46d18d74daea83f114bc0b512ec4cc31c3"}
+    $ curl -X POST -d "grant_type=password&username=username&password=test&client_id=farm&scope=farm_manager" http://localhost/oauth/token
+    {"access_token":"e69c60dea3f5c59c95863928fa6fb860d3506fe9","expires_in":"300","token_type":"Bearer","scope":"farm_manager","refresh_token":"cead7d46d18d74daea83f114bc0b512ec4cc31c3"}
 
 **second**, the client sends the `access_token` in the request header to access protected
 resources. The header is an Authorization header with a Bearer token:
  `Authorization: Bearer access_token`
 
-    foo@bar:~$ curl --header "Authorization: Bearer e69c60dea3f5c59c95863928fa6fb860d3506fe9" http://localhost/farm.json
-    {"name":"farmos-server","url":"http:\/\/localhost","api_version":"1.1","user":{"uid":"1","name":"admin", ....
+    $ curl --header "Authorization: Bearer e69c60dea3f5c59c95863928fa6fb860d3506fe9" http://localhost/api
 
 #### Refreshing Tokens
 
@@ -145,7 +143,7 @@ The client sends an authenticated request to the `/oauth/token`endpoint with
 `grant_type` set to `refresh_token` and includes the `refresh_token`,
 `client_id` and `client_secret` in the request body.
 
-    foo@bar:~$ curl -X POST -H 'Authorization: Bearer ad52c04d26c1002084501d28b59196996f0bd93f' -d 'refresh_token=52e7a0e12e8ddd08b155b3b3ee385687fef01664&grant_type=refresh_token&client_id=farmos_api_client&client_secret=client_secret' http://localhost/oauth/token
+    $ curl -X POST -H 'Authorization: Bearer ad52c04d26c1002084501d28b59196996f0bd93f' -d 'refresh_token=52e7a0e12e8ddd08b155b3b3ee385687fef01664&grant_type=refresh_token&client_id=farm&client_secret=client_secret' http://localhost/oauth/token
     {"access_token":"acdbfabb736e42aa301b50fdda95d6b7fd3e7e14","expires_in":"300","token_type":"Bearer","scope":"user_access","refresh_token":"b73f4744840498a26f43447d8cf755238bfd391a"}
 
 The server responds with an `access_token` and `refresh_token` that can be used


### PR DESCRIPTION
These are still using 1.x conventions for the `client_id` and `scope`. A few other minor changes to standardize these docs.