### PR TITLE
Simplify location query processing of asset ids.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Issue #3305724 by pcambra, m.stenta: Allow map type and behaviors to be configurable in map blocks](https://www.drupal.org/project/farm/issues/3305724)
 - [Update Drupal core to 9.4.x](https://github.com/farmOS/farmOS/pull/566)
 - [Update AssetLocationInterface::getAssetsByLocation to return asset objects keyed by ID #565](https://github.com/farmOS/farmOS/pull/565)
+- [Simplify location query processing of asset ids #564](https://github.com/farmOS/farmOS/pull/564)
 
 ### Fixed
 

--- a/modules/core/location/src/AssetLocation.php
+++ b/modules/core/location/src/AssetLocation.php
@@ -228,7 +228,7 @@ class AssetLocation implements AssetLocationInterface {
     // Build query for assets in locations.
     $query = "
       -- Select asset IDs from the asset base table.
-      SELECT a.id
+      SELECT DISTINCT a.id
       FROM {asset} a
 
       -- Inner join logs that reference the assets.
@@ -264,14 +264,7 @@ class AssetLocation implements AssetLocationInterface {
       ':timestamp' => $this->time->getRequestTime(),
       ':location_ids[]' => $location_ids,
     ];
-    $result = $this->database->query($query, $args)->fetchAll();
-    $asset_ids = [];
-    foreach ($result as $row) {
-      if (!empty($row->id)) {
-        $asset_ids[] = $row->id;
-      }
-    }
-    $asset_ids = array_unique($asset_ids);
+    $asset_ids = $this->database->query($query, $args)->fetchCol();
     return $this->entityTypeManager->getStorage('asset')->loadMultiple($asset_ids);
   }
 


### PR DESCRIPTION
Just a little improvement here to remove the iteration over each result record.

I also removed the `array_unique` by adding a `SELECT DISTINCT a.id`. I don't think passing unique ids is a requirement for the `entityStorage->loadMultiple($asset_ids)` but it doesn't hurt.