### PR TITLE
Update AssetLocationInterface::getAssetsByLocation to return asset objects keyed by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Improve API docs #557](https://github.com/farmOS/farmOS/pull/557)
 - [Issue #3305724 by pcambra, m.stenta: Allow map type and behaviors to be configurable in map blocks](https://www.drupal.org/project/farm/issues/3305724)
 - [Update Drupal core to 9.4.x](https://github.com/farmOS/farmOS/pull/566)
+- [Update AssetLocationInterface::getAssetsByLocation to return asset objects keyed by ID #565](https://github.com/farmOS/farmOS/pull/565)
 
 ### Fixed
 

--- a/modules/asset/group/src/GroupAssetLocation.php
+++ b/modules/asset/group/src/GroupAssetLocation.php
@@ -120,8 +120,7 @@ class GroupAssetLocation extends AssetLocation implements AssetLocationInterface
     $groups = array_filter($assets, function (AssetInterface $asset) {
       return $asset->bundle() === 'group';
     });
-    $members = $this->groupMembership->getGroupMembers($groups, TRUE);
-    $assets = array_merge($assets, $members);
+    $assets += $this->groupMembership->getGroupMembers($groups, TRUE);
 
     // Get location ids.
     $location_ids = array_map(function (AssetInterface $location) {

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -6,6 +6,7 @@ use Drupal\asset\Entity\Asset;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\log\Entity\Log;
+use Drupal\Tests\farm_test\Kernel\FarmAssetTestTrait;
 use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
 
 /**
@@ -16,6 +17,7 @@ use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
 class GroupTest extends KernelTestBase {
 
   use StringTranslationTrait;
+  use FarmAssetTestTrait;
   use FarmEntityCacheTestTrait;
 
   /**
@@ -113,8 +115,8 @@ class GroupTest extends KernelTestBase {
     // When an asset has no group assignment logs, it has no group membership.
     $this->assertFalse($this->groupMembership->hasGroup($animal), 'New assets do not have group membership.');
     $this->assertEmpty($this->groupMembership->getGroup($animal), 'New assets do not reference any groups.');
-    $this->assertEmpty($this->groupMembership->getGroupMembers([$first_group]), 'New groups have no members.');
-    $this->assertEmpty($this->groupMembership->getGroupMembers([$second_group]), 'New groups have no members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$first_group]), TRUE, 'New groups have no members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'New groups have no members.');
 
     // Assert that the animal's cache tags were not invalidated.
     $this->assertEntityTestCache($animal, TRUE);
@@ -133,8 +135,8 @@ class GroupTest extends KernelTestBase {
     // When an asset has a done group assignment logs, it has group membership.
     $this->assertTrue($this->groupMembership->hasGroup($animal), 'Asset with group assignment has group membership.');
     $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'Asset with group assignment is in the assigned group.');
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$first_group])), 'When an asset becomes a group member, the group has one member.');
-    $this->assertEmpty($this->groupMembership->getGroupMembers([$second_group]), 'When an asset becomes a group member, other groups are unaffected.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$first_group]), TRUE, 'When an asset becomes a group member, the group has one member.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'When an asset becomes a group member, other groups are unaffected.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -156,7 +158,7 @@ class GroupTest extends KernelTestBase {
     // When an asset has a pending group assignment logs, it still has the same
     // group membership as before.
     $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'Pending group assignment logs do not affect membership.');
-    $this->assertEmpty($this->groupMembership->getGroupMembers([$second_group]), 'Groups with only pending membership have zero members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Groups with only pending membership have zero members.');
 
     // Assert that the animal's cache tags were not invalidated.
     $this->assertEntityTestCache($animal, TRUE);
@@ -165,7 +167,7 @@ class GroupTest extends KernelTestBase {
     $second_log->status = 'done';
     $second_log->save();
     $this->assertEquals($second_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'A second group assignment log updates group membership.');
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$second_group])), 'Completed group assignment logs add group members.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Completed group assignment logs add group members.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -188,7 +190,7 @@ class GroupTest extends KernelTestBase {
     // When an asset has a "done" group assignment log in the future, the asset
     // group membership remains the same as the previous "done" movement log.
     $this->assertEquals($second_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'A third group assignment log in the future does not update group membership.');
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$second_group])), 'Future group assignment logs do not affect members.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Future group assignment logs do not affect members.');
 
     // Assert that the animal's cache tags were not invalidated.
     $this->assertEntityTestCache($animal, TRUE);
@@ -207,9 +209,9 @@ class GroupTest extends KernelTestBase {
     // When a group assignment log is created with no group references, it
     // effectively "unsets" the asset's group membership.
     $this->assertFalse($this->groupMembership->hasGroup($animal), 'Asset group membership can be unset.');
-    $this->assertEmpty($this->groupMembership->getGroup($animal), 'Unset group membership does not reference any groups.');
-    $this->assertEquals(0, count($this->groupMembership->getGroupMembers([$first_group])), 'Unset group membership unsets group members.');
-    $this->assertEquals(0, count($this->groupMembership->getGroupMembers([$second_group])), 'Unset group membership unsets group members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroup($animal), 'Unset group membership does not reference any groups.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$first_group]), TRUE, 'Unset group membership unsets group members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Unset group membership unsets group members.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -222,7 +224,7 @@ class GroupTest extends KernelTestBase {
 
     // When a group membership is deleted the last group membership log is used.
     $this->assertEquals($second_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'Deleting a group membership log updates group membership.');
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$second_group])), 'Deleting a group membership log updates group members.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Deleting a group membership log updates group members.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -251,11 +253,7 @@ class GroupTest extends KernelTestBase {
     $this->assertEquals($second_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'The first animal is in the second group.');
     $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($second_animal)[0]->id(), 'The second animal is in the first group.');
     $group_members = $this->groupMembership->getGroupMembers([$first_group, $second_group]);
-    $this->assertEquals(2, count($group_members), 'Group members from multiple groups can be queried together.');
-
-    // Test that asset IDs are preserved as the array keys.
-    $this->assertTrue(in_array($animal->id(), array_keys($group_members)), 'The ID of the first animal is preserved.');
-    $this->assertTrue(in_array($second_animal->id(), array_keys($group_members)), 'The ID of the second animal is preserved.');
+    $this->assertCorrectAssets([$animal, $second_animal], $group_members, TRUE, 'Group members from multiple groups can be queried together.');
   }
 
   /**
@@ -312,11 +310,11 @@ class GroupTest extends KernelTestBase {
 
     // Assert that the second group has no group and a single member.
     $this->assertFalse($this->groupMembership->hasGroup($second_group), 'The second group does not have a group.');
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$second_group])), 'The second group has one member.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'The second group has one member.');
 
     // Assert that the first group has no members.
-    $this->assertEmpty($this->groupMembership->getGroupMembers([$first_group], FALSE), 'The first group has no members.');
-    $this->assertEmpty($this->groupMembership->getGroupMembers([$first_group], TRUE), 'The first group has no recursive members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$first_group], FALSE), TRUE, 'The first group has no members.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$first_group], TRUE), TRUE, 'The first group has no recursive members.');
 
     // Save the second log to create the nested group membership.
     $second_log->status = 'done';
@@ -324,18 +322,15 @@ class GroupTest extends KernelTestBase {
 
     // Assert that the second group has a group and a single member.
     $this->assertTrue($this->groupMembership->hasGroup($second_group), 'The second group has a group.');
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$second_group])), 'The second group has one member.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'The second group has one member.');
 
     // Assert that the first group has a single direct member.
     $first_group_members = $this->groupMembership->getGroupMembers([$first_group], FALSE);
-    $this->assertEquals(1, count($first_group_members, FALSE), 'The first group has one direct member.');
-    $this->assertTrue(in_array($second_group->id(), array_keys($first_group_members)), 'The ID of the second group is preserved.');
+    $this->assertCorrectAssets([$second_group], $first_group_members, TRUE, 'The first group has one direct member.');
 
     // Assert that the first group has two recursive members.
     $first_group_recursive_members = $this->groupMembership->getGroupMembers([$first_group], TRUE);
-    $this->assertEquals(2, count($first_group_recursive_members), 'The first group has two recursive members.');
-    $this->assertTrue(in_array($second_group->id(), array_keys($first_group_recursive_members)), 'The ID of the second group is preserved.');
-    $this->assertTrue(in_array($animal->id(), array_keys($first_group_recursive_members)), 'The ID of the animal is preserved.');
+    $this->assertCorrectAssets([$animal, $second_group], $first_group_recursive_members, TRUE, 'The first group has two recursive members.');
   }
 
   /**
@@ -491,7 +486,8 @@ class GroupTest extends KernelTestBase {
     $second_pasture->save();
 
     // Confirm that new locations are empty.
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$first_pasture]), 'New locations are empty.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'New locations are empty.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]));
 
     // Create a log that moves the animal to the first pasture.
     /** @var \Drupal\log\Entity\LogInterface $second_log */
@@ -507,8 +503,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal is located in the first pasture.
     $this->assertEquals($this->logLocation->getLocation($second_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by asset membership log.');
     $this->assertEquals($this->logLocation->getGeometry($second_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by asset membership log.');
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$first_pasture])), 'Locations have assets that are moved to them.');
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$second_pasture]), 'Locations that do not have assets moved to them are unaffected.');
+    $this->assertCorrectAssets([$animal], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'Locations have assets that are moved to them.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'Locations that do not have assets moved to them are unaffected.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -530,8 +526,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal is located in the second pasture.
     $this->assertEquals($this->logLocation->getLocation($third_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by group membership log.');
     $this->assertEquals($this->logLocation->getGeometry($third_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by group membership log.');
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$first_pasture]), 'A group movement removes assets from their previous location.');
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$second_pasture])), 'A group movement adds assets to their new location.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'A group movement removes assets from their previous location.');
+    $this->assertCorrectAssets([$animal, $group], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'A group movement adds assets to their new location.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -553,8 +549,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal location was unset.
     $this->assertEquals($this->logLocation->getLocation($fourth_log), $this->assetLocation->getLocation($animal), 'Asset location can be unset by group membership log.');
     $this->assertEquals($this->logLocation->getGeometry($fourth_log), $this->assetLocation->getGeometry($animal), 'Asset geometry can be unset by group membership log.');
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$first_pasture]), 'Unsetting group location removes member assets from all locations.');
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$second_pasture]), 'Unsetting group location removes member assets from all locations.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'Unsetting group location removes member assets from all locations.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'Unsetting group location removes member assets from all locations.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -577,8 +573,8 @@ class GroupTest extends KernelTestBase {
     // logs now.
     $this->assertEquals($this->logLocation->getLocation($second_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by asset membership log.');
     $this->assertEquals($this->logLocation->getGeometry($second_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by asset membership log.');
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$first_pasture])), 'Unsetting group membership adds assets to their previous location.');
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$second_pasture]), 'Unsetting group membership removes member assets from the group location.');
+    $this->assertCorrectAssets([$animal], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'Unsetting group membership adds assets to their previous location.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'Unsetting group membership removes member assets from the group location.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -596,8 +592,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal is located in the second pasture.
     $this->assertEquals($this->logLocation->getLocation($third_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by group membership log.');
     $this->assertEquals($this->logLocation->getGeometry($third_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by group membership log.');
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$first_pasture]), 'A group movement removes assets from their previous location.');
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$second_pasture])), 'A group movement adds assets to their new location.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'A group movement removes assets from their previous location.');
+    $this->assertCorrectAssets([$animal, $group], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'A group movement adds assets to their new location.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -486,8 +486,8 @@ class GroupTest extends KernelTestBase {
     $second_pasture->save();
 
     // Confirm that new locations are empty.
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'New locations are empty.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]));
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE, 'New locations are empty.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE);
 
     // Create a log that moves the animal to the first pasture.
     /** @var \Drupal\log\Entity\LogInterface $second_log */
@@ -503,8 +503,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal is located in the first pasture.
     $this->assertEquals($this->logLocation->getLocation($second_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by asset membership log.');
     $this->assertEquals($this->logLocation->getGeometry($second_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by asset membership log.');
-    $this->assertCorrectAssets([$animal], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'Locations have assets that are moved to them.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'Locations that do not have assets moved to them are unaffected.');
+    $this->assertCorrectAssets([$animal], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE, 'Locations have assets that are moved to them.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), TRUE, 'Locations that do not have assets moved to them are unaffected.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -526,8 +526,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal is located in the second pasture.
     $this->assertEquals($this->logLocation->getLocation($third_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by group membership log.');
     $this->assertEquals($this->logLocation->getGeometry($third_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by group membership log.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'A group movement removes assets from their previous location.');
-    $this->assertCorrectAssets([$animal, $group], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'A group movement adds assets to their new location.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE, 'A group movement removes assets from their previous location.');
+    $this->assertCorrectAssets([$animal, $group], $this->assetLocation->getAssetsByLocation([$second_pasture]), TRUE, 'A group movement adds assets to their new location.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -549,8 +549,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal location was unset.
     $this->assertEquals($this->logLocation->getLocation($fourth_log), $this->assetLocation->getLocation($animal), 'Asset location can be unset by group membership log.');
     $this->assertEquals($this->logLocation->getGeometry($fourth_log), $this->assetLocation->getGeometry($animal), 'Asset geometry can be unset by group membership log.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'Unsetting group location removes member assets from all locations.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'Unsetting group location removes member assets from all locations.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE, 'Unsetting group location removes member assets from all locations.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), TRUE, 'Unsetting group location removes member assets from all locations.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -573,8 +573,8 @@ class GroupTest extends KernelTestBase {
     // logs now.
     $this->assertEquals($this->logLocation->getLocation($second_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by asset membership log.');
     $this->assertEquals($this->logLocation->getGeometry($second_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by asset membership log.');
-    $this->assertCorrectAssets([$animal], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'Unsetting group membership adds assets to their previous location.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'Unsetting group membership removes member assets from the group location.');
+    $this->assertCorrectAssets([$animal], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE, 'Unsetting group membership adds assets to their previous location.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$second_pasture]), TRUE, 'Unsetting group membership removes member assets from the group location.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);
@@ -592,8 +592,8 @@ class GroupTest extends KernelTestBase {
     // Confirm that the animal is located in the second pasture.
     $this->assertEquals($this->logLocation->getLocation($third_log), $this->assetLocation->getLocation($animal), 'Asset location is determined by group membership log.');
     $this->assertEquals($this->logLocation->getGeometry($third_log), $this->assetLocation->getGeometry($animal), 'Asset geometry is determined by group membership log.');
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), FALSE, 'A group movement removes assets from their previous location.');
-    $this->assertCorrectAssets([$animal, $group], $this->assetLocation->getAssetsByLocation([$second_pasture]), FALSE, 'A group movement adds assets to their new location.');
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$first_pasture]), TRUE, 'A group movement removes assets from their previous location.');
+    $this->assertCorrectAssets([$animal, $group], $this->assetLocation->getAssetsByLocation([$second_pasture]), TRUE, 'A group movement adds assets to their new location.');
 
     // Assert that the animal's cache tags were invalidated.
     $this->assertEntityTestCache($animal, FALSE);

--- a/modules/core/location/src/AssetLocationInterface.php
+++ b/modules/core/location/src/AssetLocationInterface.php
@@ -104,7 +104,7 @@ interface AssetLocationInterface {
    *   An array of location assets to lookup.
    *
    * @return \Drupal\asset\Entity\AssetInterface[]
-   *   Returns an array of assets.
+   *   An array of asset objects indexed by their IDs.
    */
   public function getAssetsByLocation(array $locations): array;
 

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -444,9 +444,9 @@ class LocationTest extends KernelTestBase {
     $first_log->save();
 
     // First location has one asset, second has none.
-    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]), TRUE);
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$this->locations[1]]), TRUE);
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]), TRUE);
 
     // Create a second asset and move it to the second location.
     /** @var \Drupal\asset\Entity\AssetInterface $second_asset */
@@ -467,9 +467,9 @@ class LocationTest extends KernelTestBase {
     $second_log->save();
 
     // Both locations have one asset.
-    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
-    $this->assertCorrectAssets([$second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]), TRUE);
+    $this->assertCorrectAssets([$second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]), TRUE);
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]), TRUE);
 
     // Create a third log that moves both assets to the first location.
     /** @var \Drupal\log\Entity\LogInterface $third_log */
@@ -486,9 +486,9 @@ class LocationTest extends KernelTestBase {
     $third_log->save();
 
     // First location has two assets, second has none.
-    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
-    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]), TRUE);
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$this->locations[1]]), TRUE);
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]), TRUE);
 
     // Create a fourth log that moves first asset to the second location.
     /** @var \Drupal\log\Entity\LogInterface $fourth_log */
@@ -504,9 +504,9 @@ class LocationTest extends KernelTestBase {
     $fourth_log->save();
 
     // Both locations have one asset.
-    $this->assertCorrectAssets([$second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
-    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
+    $this->assertCorrectAssets([$second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]), TRUE);
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]), TRUE);
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]), TRUE);
 
     // Create a fifth log that moves first asset to the both locations.
     /** @var \Drupal\log\Entity\LogInterface $fifth_log */
@@ -525,9 +525,9 @@ class LocationTest extends KernelTestBase {
     $fifth_log->save();
 
     // First location has two asset, second location has one asset.
-    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
-    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]), TRUE);
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]), TRUE);
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]), TRUE);
   }
 
 }

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -6,6 +6,7 @@ use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\log\Entity\Log;
+use Drupal\Tests\farm_test\Kernel\FarmAssetTestTrait;
 use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
 
 /**
@@ -16,6 +17,7 @@ use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
 class LocationTest extends KernelTestBase {
 
   use FarmEntityCacheTestTrait;
+  use FarmAssetTestTrait;
   use WktTrait;
 
   /**
@@ -442,9 +444,9 @@ class LocationTest extends KernelTestBase {
     $first_log->save();
 
     // First location has one asset, second has none.
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[0]])));
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]])));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
 
     // Create a second asset and move it to the second location.
     /** @var \Drupal\asset\Entity\AssetInterface $second_asset */
@@ -465,9 +467,9 @@ class LocationTest extends KernelTestBase {
     $second_log->save();
 
     // Both locations have one asset.
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[0]])));
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[1]])));
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]])));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
+    $this->assertCorrectAssets([$second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
 
     // Create a third log that moves both assets to the first location.
     /** @var \Drupal\log\Entity\LogInterface $third_log */
@@ -484,9 +486,9 @@ class LocationTest extends KernelTestBase {
     $third_log->save();
 
     // First location has two assets, second has none.
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$this->locations[0]])));
-    $this->assertEmpty($this->assetLocation->getAssetsByLocation([$this->locations[1]]));
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]])));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
+    $this->assertCorrectAssets([], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
 
     // Create a fourth log that moves first asset to the second location.
     /** @var \Drupal\log\Entity\LogInterface $fourth_log */
@@ -502,9 +504,9 @@ class LocationTest extends KernelTestBase {
     $fourth_log->save();
 
     // Both locations have one asset.
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[0]])));
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[1]])));
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]])));
+    $this->assertCorrectAssets([$second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
 
     // Create a fifth log that moves first asset to the both locations.
     /** @var \Drupal\log\Entity\LogInterface $fifth_log */
@@ -523,9 +525,9 @@ class LocationTest extends KernelTestBase {
     $fifth_log->save();
 
     // First location has two asset, second location has one asset.
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$this->locations[0]])));
-    $this->assertEquals(1, count($this->assetLocation->getAssetsByLocation([$this->locations[1]])));
-    $this->assertEquals(2, count($this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]])));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0]]));
+    $this->assertCorrectAssets([$first_asset], $this->assetLocation->getAssetsByLocation([$this->locations[1]]));
+    $this->assertCorrectAssets([$first_asset, $second_asset], $this->assetLocation->getAssetsByLocation([$this->locations[0], $this->locations[1]]));
   }
 
 }

--- a/modules/core/test/tests/src/Kernel/FarmAssetTestTrait.php
+++ b/modules/core/test/tests/src/Kernel/FarmAssetTestTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\Tests\farm_test\Kernel;
+
+use Drupal\asset\Entity\AssetInterface;
+
+/**
+ * Trait with helper functions for testing logic related to assets.
+ */
+trait FarmAssetTestTrait {
+
+  /**
+   * Helper function to assert the correct assets are included in an array.
+   *
+   * @param \Drupal\asset\Entity\AssetInterface[] $expected_assets
+   *   The expected assets.
+   * @param \Drupal\asset\Entity\AssetInterface[] $actual_assets
+   *   The actual assets, optionally keyed by asset ID.
+   * @param bool $check_keys
+   *   If the actual asset keys should be checked. Defaults to FALSE.
+   * @param string $message
+   *   An optional message for the assert statement.
+   */
+  protected function assertCorrectAssets(array $expected_assets, array $actual_assets, bool $check_keys = FALSE, string $message = '') {
+
+    // Message prefix.
+    $prefix = empty($message) ? '' : "$message : ";
+
+    // Test the asset count.
+    $this->assertEquals(count($expected_assets), count($actual_assets), $prefix . 'Expected asset count does not match actual asset count.');
+
+    // Test that expected assets are included in actual assets array.
+    $actual_assets_keys = array_keys($actual_assets);
+    $actual_assets_ids = array_map(function (AssetInterface $asset) {
+      return $asset->id();
+    }, $actual_assets);
+    foreach ($expected_assets as $asset) {
+      $this->assertTrue(in_array($asset->id(), $actual_assets_ids), $prefix . 'Expected asset is not included in the actual assets.');
+
+      if ($check_keys) {
+        $this->assertTrue(in_array($asset->id(), $actual_assets_keys), $prefix . 'Expected asset ID is not included in the actual assets array.');
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
I noticed this would be a super simple change to implement. Similar to #494 

The `farm_location` module already returns assets keyed by ID, but `farm_group` was using loosing this structure with its use of `array_merge`. Because `GroupMembershipInterface::getGroupMembers` already returns asset objected keyed by ID, we can simply change `array_merge` to use the `+=` assignment. I've done this in the last commit of this PR.

The bulk of this PR is actually updating the tests to accommodate this change. When revisiting the location and group membership tests I found it hard to follow the logic. In many places we're simply asserting that the `count()` of the asset array is correct, but not necessarily the actual contents of the array. I think this is OK once you understand the complete logic of the tests, but it makes understanding the logic of the tests a bit harder.

To (hopefully) make things easier I've added a new `FarmAssetTestTrait` with a helper function `assertCorrectAssets()` for asserting the correct contents of "asset arrays". The function allows you to *optionall*y check that the asset ids are included in the array keys, too. The large benefit of this is that it makes the tests more readable:

```diff
-    $this->assertEquals(1, count($this->groupMembership->getGroupMembers([$second_group])), 'Future group assignment logs do not affect members.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Future group assignment logs do not affect members.');
```

and also reduces the duplication of asserting multiple characteristics of the "asset array" while making our tests more consistent:
```diff
    $group_members = $this->groupMembership->getGroupMembers([$first_group, $second_group]);
-    $this->assertEquals(2, count($group_members), 'Group members from multiple groups can be queried together.');

    // Test that asset IDs are preserved as the array keys.
-    $this->assertTrue(in_array($animal->id(), array_keys($group_members)), 'The ID of the first animal is preserved.');
-    $this->assertTrue(in_array($second_animal->id(), array_keys($group_members)), 'The ID of the second animal is preserved.');
+    $this->assertCorrectAssets([$animal, $second_animal], $group_members, TRUE, 'Group members from multiple groups can be queried together.');
```

I added and implemented this trait in the first two commits of this PR (tests passing) to demonstrate how this can be used even for arrays that do not return asset IDs as their keys. I imagine there are various places in our tests that could be refactored to use this trait, however I only considered the location and group membership tests for now. I don't think there should too many other requirements for such a helper function. The message passing is a little odd, but effective enough for reporting test failures.
