### PR TITLE
Update excluded configuration example to not use module settings

### DIFF
--- a/docs/development/module/updates.md
+++ b/docs/development/module/updates.md
@@ -70,9 +70,9 @@ For example, in `mymodule.module`:
  */
 function mymodule_farm_update_exclude_config() {
 
-  // Exclude mymodule.settings from automatic configuration updates.
+  // Exclude mymodule_custom view from automatic configuration updates.
   return [
-    'mymodule.settings',
+    'views.view.mymodule_custom',
   ];
 }
 ```
@@ -89,6 +89,6 @@ For example, in `farm_update.settings.yml`:
 
 ```yaml
 exclude_config:
-  # Exclude mymodule.settings from automatic configuration updates.
-  - mymodule.settings
+  # Exclude mymodule_custom view from automatic configuration updates.
+  - views.view.mymodule_custom
 ```


### PR DESCRIPTION
Our automated update docs describe how farm_update "does not touch simple" configuration (eg: module settings) - only configuration entities (eg: Views)" *but* the example hook implementations use the `mymodule.settings` simple config. 
https://farmos.org/development/module/updates/#exclude-specific-configuration

Lets update this to be a custom view provided by mymodule, `views.view.mymodule_custom`.