### PR TITLE
Add log asset filter to all displays of farm_quantity view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Issue #3309234: Add PHPStan to test and delivery workflow](https://www.drupal.org/project/farm/issues/3309234)
 - [Issue #3309198: Allow users to override Gin theme settings](https://www.drupal.org/project/farm/issues/3309198)
 - [Add owner field to assets #537](https://github.com/farmOS/farmOS/pull/537)
+- [Add log asset filter to all displays of farm_quantity view #569](https://github.com/farmOS/farmOS/pull/569)
 
 ### Changed
 

--- a/modules/core/ui/views/config/install/views.view.farm_quantity.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_quantity.yml
@@ -1334,6 +1334,56 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        asset_target_id:
+          id: asset_target_id
+          table: log__asset
+          field: asset_target_id
+          relationship: reverse__log__quantity
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: asset
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: asset_target_id_op
+            label: 'Log assets'
+            description: ''
+            use_operator: false
+            operator: asset_target_id_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: asset_target_id
+            required: false
+            remember: false
+            multiple: true
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_operator: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: true
+          handler: 'default:asset'
+          widget: autocomplete
+          handler_settings: {  }
       filter_groups:
         operator: AND
         groups:


### PR DESCRIPTION
This has been requested by Rothamsted: https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/281 I just dropped in a quick log.asset entity reference filter and it seems to be working well! I tested all displays, including CSV export.

One thing I tested was if this created duplicate quantity results in the view: indeed if a log references multiple assets, and multiple assets are included in the views filter, then the same quantity will be seen twice in the views output (easily identified by the first `id` column). **We should decide if this is a bug or a feature??** Generally, I think we should not show duplicates. This is the current behavior for the "Log assets" column, multiple log assets are included in the same row, and the row is not duplicated.

I then turned on the "Reduce duplicates" option for the log.asset entity reference filter. This worked as advertised and removed the duplicates! But this option does have a warning:

> This filter can cause items that have more than one of the selected options to appear as duplicate results. If this filter causes duplicate results to occur, this checkbox can reduce those duplicates; however, the more terms it has to search for, the less performant the query will be, so use this with caution. Shouldn't be set on single-value fields, as it may cause values to disappear from display, if used on an incompatible field.

"The more terms it has to search for" - in our case I'm assuming this means the "assets" but I'm not certain it doesn't mean the logs or quantities themselves. I wouldn't expect a user to manually filter by so many assets that performance becomes a major issue. But it is possible that there are many logs & quantities on an instance, which might make the query less performant anyways.