### PR TITLE
Set reduce_duplicates: true in Views exposed filters for multivalue fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Incorrect translation placeholders for asset names #540](https://github.com/farmOS/farmOS/issues/540)
 - Update farmOS-map to [v2.0.5](https://github.com/farmOS/farmOS-map/releases/tag/v2.0.5) to fix [Uncaught (in promise) TypeError: o.getChangeEventType is not a function #551](https://github.com/farmOS/farmOS/issues/551)
 - [Fix [warning] Invalid argument supplied for foreach() EntityViewsDataTaxonomyFilterTrait.php:26 #575](https://github.com/farmOS/farmOS/pull/575)
+- [Set reduce_duplicates: true in Views exposed filters for multivalue fields #571](https://github.com/farmOS/farmOS/pull/571)
 
 ## [2.0.0-beta6] 2022-07-30
 

--- a/modules/asset/group/config/optional/views.view.farm_group_members.yml
+++ b/modules/asset/group/config/optional/views.view.farm_group_members.yml
@@ -820,7 +820,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
         is_location:
           id: is_location
           table: asset_field_data

--- a/modules/core/ui/views/config/install/views.view.farm_asset.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_asset.yml
@@ -850,7 +850,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
         is_location:
           id: is_location
           table: asset_field_data

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -920,7 +920,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
           vid: log_category
           type: select
           hierarchy: false
@@ -967,7 +967,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
         timestamp:
           id: timestamp
           table: log_field_data
@@ -1184,7 +1184,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
           handler: views
           widget: select
           handler_settings:
@@ -1233,7 +1233,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
           handler: views
           widget: autocomplete
           handler_settings:
@@ -1282,7 +1282,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
           handler: views
           widget: autocomplete
           handler_settings:

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -583,7 +583,7 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-          reduce_duplicates: false
+          reduce_duplicates: true
         status:
           id: status
           table: plan_field_data


### PR DESCRIPTION
As identified in https://github.com/farmOS/farmOS/pull/569/#issuecomment-1253635123, a number of the exposed filters provided with default Views configuration in farmOS can lead to duplicate rows in query results.

@paul121 identified that the `reduce_duplicates` option provided by Drupal core in the `ManyToOneHelper` class fixes this by changing the way that the `JOIN` and `WHERE` clauses are crafted in the query.

There is a performance warning included in Drupal core for `reduce_duplicates`:

> This filter can cause items that have more than one of the selected options to appear as duplicate results. If this filter causes duplicate results to occur, this checkbox can reduce those duplicates; however, the more terms it has to search for, the less performant the query will be, so use this with caution. Shouldn't be set on single-value fields, as it may cause values to disappear from display, if used on an incompatible field.

In practice, I don't think this is a concern for farmOS's filters, because the typical need is to filter by a small handful of values.

This PR sets `reduce_duplicates: true` on the following exposed filters:

- `farm_asset` View
  - `flag_value`
- `farm_log` View
  - `category_target_id`
  - `flag_value`
  - `owner_target_id`
  - `asset_target_id`
  - `location_target_id`
- `farm_plan` View
  - `flag_value`
- `farm_group_members` View
  - `flag_value`