### PR TITLE
Minor improvements to views task links

### DIFF
--- a/modules/core/ui/views/farm_ui_views.links.task.yml
+++ b/modules/core/ui/views/farm_ui_views.links.task.yml
@@ -15,20 +15,6 @@ farm.asset.logs.all:
 farm.asset.logs.type:
   deriver: Drupal\farm_ui_views\Plugin\Derivative\FarmLogViewsTaskLink
 
-# Add asset/log view tabs to taxonomy terms.
-farm.taxonomy_term.assets:
-  title: 'Assets'
-  route_name: view.farm_asset.page_term
-  route_parameters:
-    entity_bundle: 'all'
-  base_route: entity.taxonomy_term.canonical
-  weight: 50
-farm.taxonomy_term.logs:
-  title: 'Logs'
-  route_name: view.farm_log.page_term
-  route_parameters:
-    entity_bundle: 'all'
-  base_route: entity.taxonomy_term.canonical
-  weight: 50
+# Add asset and log view tabs to taxonomy terms.
 farm.taxonomy_term.entities.type:
   deriver: Drupal\farm_ui_views\Plugin\Derivative\FarmTaxonomyTermViewsTaskLink

--- a/modules/core/ui/views/farm_ui_views.links.task.yml
+++ b/modules/core/ui/views/farm_ui_views.links.task.yml
@@ -1,17 +1,4 @@
 # Add log view tabs to assets.
-farm.asset.logs:
-  title: 'Logs'
-  route_name: view.farm_log.page_asset
-  route_parameters:
-    log_type: 'all'
-  base_route: entity.asset.canonical
-  weight: 50
-farm.asset.logs.all:
-  title: 'All'
-  route_name: view.farm_log.page_asset
-  route_parameters:
-    log_type: 'all'
-  parent_id: farm.asset.logs
 farm.asset.logs.type:
   deriver: Drupal\farm_ui_views\Plugin\Derivative\FarmLogViewsTaskLink
 

--- a/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
@@ -54,10 +54,7 @@ class FarmTaxonomyTermEntityViewsAccessCheck implements AccessInterface {
    * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager service.
    */
-  public function __construct($base_entity_type,
-  EntityTypeManagerInterface $entity_type_manager,
-    EntityTypeBundleInfoInterface $entity_bundle_info,
-  EntityFieldManagerInterface $entity_field_manager) {
+  public function __construct(string $base_entity_type, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info, EntityFieldManagerInterface $entity_field_manager) {
     $this->baseEntityType = $base_entity_type;
     $this->taxonomyTermStorage = $entity_type_manager->getStorage('taxonomy_term');
     $this->entityTypeBundleInfo = $entity_bundle_info;

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
@@ -47,12 +47,38 @@ class FarmLogViewsTaskLink extends DeriverBase implements ContainerDeriverInterf
   public function getDerivativeDefinitions($base_plugin_definition) {
     $links = [];
 
-    // Add links for each bundle.
+    // Add primary tab for logs.
+    $log_entity = $this->entityTypeManager->getDefinition('log');
+    $links['logs'] = [
+      'title' => $log_entity->getCollectionLabel(),
+      'route_name' => 'view.farm_log.page_asset',
+      'route_parameters' => [
+        'log_type' => 'all',
+      ],
+      'base_route' => 'entity.asset.canonical',
+      'weight' => 50,
+    ] + $base_plugin_definition;
+
+    // Build the parent id from the base ID.
+    $base_id = $base_plugin_definition['id'];
+    $parent_id = "$base_id:logs";
+
+    // Add default "All" secondary tab.
+    $links['all'] = [
+      'title' => $this->t('All'),
+      'parent_id' => $parent_id,
+      'route_name' => 'view.farm_log.page_asset',
+      'route_parameters' => [
+        'log_type' => 'all',
+      ],
+    ] + $base_plugin_definition;
+
+    // Add secondary tab for each bundle.
     $bundles = $this->entityTypeManager->getStorage('log_type')->loadMultiple();
     foreach ($bundles as $type => $bundle) {
-      $links['farm.asset.logs.' . $type] = [
+      $links[$type] = [
         'title' => $bundle->label(),
-        'parent_id' => 'farm.asset.logs',
+        'parent_id' => $parent_id,
         'route_name' => 'view.farm_log.page_asset',
         'route_parameters' => [
           'log_type' => $type,

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
@@ -52,9 +52,6 @@ class FarmLogViewsTaskLink extends DeriverBase implements ContainerDeriverInterf
     $links['logs'] = [
       'title' => $log_entity->getCollectionLabel(),
       'route_name' => 'view.farm_log.page_asset',
-      'route_parameters' => [
-        'log_type' => 'all',
-      ],
       'base_route' => 'entity.asset.canonical',
       'weight' => 50,
     ] + $base_plugin_definition;

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -47,8 +47,10 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
   public function getDerivativeDefinitions($base_plugin_definition) {
     $links = [];
 
+    // Add asset and log task links to taxonomy term pages.
     foreach (['asset', 'log'] as $entity_type) {
 
+      // Add default "All" secondary tab for each entity type.
       $links["farm.taxonomy_term.{$entity_type}s.all"] = [
         'title' => 'All',
         'parent_id' => "farm.taxonomy_term.{$entity_type}s",
@@ -58,10 +60,9 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
         ],
       ] + $base_plugin_definition;
 
-      // Add links for each entity bundle.
+      // Add secondary tab for each entity bundle.
       $entity_bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type);
       foreach ($entity_bundles as $entity_bundle => $info) {
-
         $links["farm.taxonomy_term.{$entity_type}s.$entity_bundle"] = [
           'title' => $info['label'],
           'parent_id' => "farm.taxonomy_term.{$entity_type}s",
@@ -70,7 +71,6 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
             'entity_bundle' => $entity_bundle,
           ],
         ] + $base_plugin_definition;
-
       }
     }
 

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -4,6 +4,7 @@ namespace Drupal\farm_ui_views\Plugin\Derivative;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -16,6 +17,13 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
   use StringTranslationTrait;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * The entity type bundle info.
    *
    * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
@@ -25,10 +33,13 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
   /**
    * Constructs a FarmTaxonomyTermViewsTaskLink instance.
    *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
    * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_bundle_info
    *   The entity type bundle info service.
    */
-  public function __construct(EntityTypeBundleInfoInterface $entity_bundle_info) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info) {
+    $this->entityTypeManager = $entity_type_manager;
     $this->entityTypeBundleInfo = $entity_bundle_info;
   }
 
@@ -37,6 +48,7 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
     return new static(
+      $container->get('entity_type.manager'),
       $container->get('entity_type.bundle.info')
     );
   }
@@ -48,25 +60,39 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
     $links = [];
 
     // Add asset and log task links to taxonomy term pages.
-    foreach (['asset', 'log'] as $entity_type) {
+    foreach (['asset', 'log'] as $entity_type_id) {
+
+      // Get the entity type definition.
+      $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
+
+      // Add tab for each entity type.
+      $links["farm.taxonomy_term.{$entity_type_id}s"] = [
+        'title' => $entity_type->getCollectionLabel(),
+        'route_name' => "view.farm_$entity_type_id.page_term",
+        'route_parameters' => [
+          'entity_bundle' => 'all',
+        ],
+        'base_route' => 'entity.taxonomy_term.canonical',
+        'weight' => 50,
+      ] + $base_plugin_definition;
 
       // Add default "All" secondary tab for each entity type.
-      $links["farm.taxonomy_term.{$entity_type}s.all"] = [
+      $links["farm.taxonomy_term.{$entity_type_id}s.all"] = [
         'title' => $this->t('All'),
-        'parent_id' => "farm.taxonomy_term.{$entity_type}s",
-        'route_name' => "view.farm_$entity_type.page_term",
+        'parent_id' => "farm.taxonomy_term.entities.type:farm.taxonomy_term.{$entity_type_id}s",
+        'route_name' => "view.farm_$entity_type_id.page_term",
         'route_parameters' => [
           'entity_bundle' => 'all',
         ],
       ] + $base_plugin_definition;
 
       // Add secondary tab for each entity bundle.
-      $entity_bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type);
+      $entity_bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
       foreach ($entity_bundles as $entity_bundle => $info) {
-        $links["farm.taxonomy_term.{$entity_type}s.$entity_bundle"] = [
+        $links["farm.taxonomy_term.{$entity_type_id}s.$entity_bundle"] = [
           'title' => $info['label'],
-          'parent_id' => "farm.taxonomy_term.{$entity_type}s",
-          'route_name' => "view.farm_$entity_type.page_term",
+          'parent_id' => "farm.taxonomy_term.entities.type:farm.taxonomy_term.{$entity_type_id}s",
+          'route_name' => "view.farm_$entity_type_id.page_term",
           'route_parameters' => [
             'entity_bundle' => $entity_bundle,
           ],

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -52,7 +52,7 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
 
       // Add default "All" secondary tab for each entity type.
       $links["farm.taxonomy_term.{$entity_type}s.all"] = [
-        'title' => 'All',
+        'title' => $this->t('All'),
         'parent_id' => "farm.taxonomy_term.{$entity_type}s",
         'route_name' => "view.farm_$entity_type.page_term",
         'route_parameters' => [

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -66,7 +66,7 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
       $entity_type = $this->entityTypeManager->getDefinition($entity_type_id);
 
       // Add tab for each entity type.
-      $links["farm.taxonomy_term.{$entity_type_id}s"] = [
+      $links[$entity_type_id] = [
         'title' => $entity_type->getCollectionLabel(),
         'route_name' => "view.farm_$entity_type_id.page_term",
         'route_parameters' => [
@@ -76,10 +76,14 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
         'weight' => 50,
       ] + $base_plugin_definition;
 
+      // Build the parent id from the base ID.
+      $base_id = $base_plugin_definition['id'];
+      $parent_id = "$base_id:$entity_type_id";
+
       // Add default "All" secondary tab for each entity type.
-      $links["farm.taxonomy_term.{$entity_type_id}s.all"] = [
+      $links["$entity_type_id.all"] = [
         'title' => $this->t('All'),
-        'parent_id' => "farm.taxonomy_term.entities.type:farm.taxonomy_term.{$entity_type_id}s",
+        'parent_id' => $parent_id,
         'route_name' => "view.farm_$entity_type_id.page_term",
         'route_parameters' => [
           'entity_bundle' => 'all',
@@ -89,9 +93,9 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
       // Add secondary tab for each entity bundle.
       $entity_bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
       foreach ($entity_bundles as $entity_bundle => $info) {
-        $links["farm.taxonomy_term.{$entity_type_id}s.$entity_bundle"] = [
+        $links["$entity_type_id.$entity_bundle"] = [
           'title' => $info['label'],
-          'parent_id' => "farm.taxonomy_term.entities.type:farm.taxonomy_term.{$entity_type_id}s",
+          'parent_id' => $parent_id,
           'route_name' => "view.farm_$entity_type_id.page_term",
           'route_parameters' => [
             'entity_bundle' => $entity_bundle,

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -69,9 +69,6 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
       $links[$entity_type_id] = [
         'title' => $entity_type->getCollectionLabel(),
         'route_name' => "view.farm_$entity_type_id.page_term",
-        'route_parameters' => [
-          'entity_bundle' => 'all',
-        ],
         'base_route' => 'entity.taxonomy_term.canonical',
         'weight' => 50,
       ] + $base_plugin_definition;

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -50,7 +50,6 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
     foreach (['asset', 'log'] as $entity_type) {
 
       $links["farm.taxonomy_term.{$entity_type}s.all"] = [
-        'id' => "farm.taxonomy_term.{$entity_type}s.all",
         'title' => 'All',
         'parent_id' => "farm.taxonomy_term.{$entity_type}s",
         'route_name' => "view.farm_$entity_type.page_term",
@@ -64,7 +63,6 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
       foreach ($entity_bundles as $entity_bundle => $info) {
 
         $links["farm.taxonomy_term.{$entity_type}s.$entity_bundle"] = [
-          'id' => "farm.taxonomy_term.{$entity_type}s.$entity_bundle",
           'title' => $info['label'],
           'parent_id' => "farm.taxonomy_term.{$entity_type}s",
           'route_name' => "view.farm_$entity_type.page_term",

--- a/modules/core/ui/views/src/Routing/RouteSubscriber.php
+++ b/modules/core/ui/views/src/Routing/RouteSubscriber.php
@@ -20,6 +20,9 @@ class RouteSubscriber extends RouteSubscriberBase {
     // Add our _asset_logs_access requirement to view.farm_log.page_asset.
     if ($route = $collection->get('view.farm_log.page_asset')) {
       $route->setRequirement('_asset_logs_access', 'Drupal\farm_ui_views\Access\FarmAssetLogViewsAccessCheck::access');
+
+      // Set default log_type to mark primary tab as active.
+      $route->setDefault('log_type', 'all');
     }
 
     // Add our _asset_children_access requirement to
@@ -32,12 +35,18 @@ class RouteSubscriber extends RouteSubscriberBase {
     // view.farm_asset.page_term.
     if ($route = $collection->get('view.farm_asset.page_term')) {
       $route->setRequirement('_asset_term_access', 'Drupal\farm_ui_views\Access\FarmTaxonomyTermEntityViewsAccessCheck::access');
+
+      // Set default entity_bundle to mark primary tab as active.
+      $route->setDefault('entity_bundle', 'all');
     }
 
     // Add our _log_term_access requirement to
     // view.farm_log.page_term.
     if ($route = $collection->get('view.farm_log.page_term')) {
       $route->setRequirement('_log_term_access', 'Drupal\farm_ui_views\Access\FarmTaxonomyTermEntityViewsAccessCheck::access');
+
+      // Set default entity_bundle to mark primary tab as active.
+      $route->setDefault('entity_bundle', 'all');
     }
 
     // Add our _location_assets_access requirement to

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -119,7 +119,7 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
       $this->assertEquals($label, $elements[$url], "Link label not as expected.");
     };
 
-    $assert_has_link($primary_tab_links, "/$fava_term_url/assets/all", 'Assets');
+    $assert_has_link($primary_tab_links, "/$fava_term_url/assets", 'Assets');
 
     $this->drupalGet("$fava_term_url/assets/all");
     $this->assertSession()->statusCodeEquals(200);
@@ -130,7 +130,7 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
 
     $this->assertCount(3, $secondary_tab_links, 'Only 3 secondary tabs appear.');
 
-    $assert_has_link($secondary_tab_links, "/$fava_term_url/assets/all", 'All(active tab)');
+    $assert_has_link($secondary_tab_links, "/$fava_term_url/assets", 'All(active tab)');
     $assert_has_link($secondary_tab_links, "/$fava_term_url/assets/plant", 'Plant');
     $assert_has_link($secondary_tab_links, "/$fava_term_url/assets/seed", 'Seed');
   }


### PR DESCRIPTION
This PR is mostly to consolidate and simplify how our views task links are created. There is only one functional change (the last commit) which fixes a minor bug where the primary tab is not marked `active` when viewing secondary tabs other than "All". For example, on an Asset page, looking at `activity` logs referencing the asset, the "Activity" secondary tab is active, but the "Logs" primary tab is not.

While looking at the `drupal/entity` task links that are created for our entities, I realized that task links created through a derivative class end up with a prefix in their ID. This is a gotcha when trying to reference another task link as a `parent_id`. To further confuse things, our views tasks links are split between the static definition and derivative class. Consolidating all of these tasks links to the derivative class makes it easier to understand the relationship between them, as well as providing a consistent prefix to the task link IDs.

As an example, the views of logs that are included on asset pages. The taxonomy term asset/log views follow a similar pattern.

Before:
- "Logs" primary tab: `farm.asset.logs`
- "All" default secondary tab: `farm.asset.logs.all`
- "Activity" secondary tab: `farm.asset.logs.type:farm.asset.logs.activity`

After:
- "Logs" primary tab: `farm.asset.logs.type:logs`
- "All" default secondary tab: `farm.asset.logs.type:all`
- "Activity" secondary tab: `farm.asset.logs.type:activity`

