### PR TITLE
Attempt to update the map size until it is rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Fix map ui being unreadable on dark mode #642](https://github.com/farmOS/farmOS/pull/642)
 - Patch Drupal core to fix [Issue #3266341: Views pagers do math on disparate data types, resulting in type errors in PHP 8](https://www.drupal.org/project/drupal/issues/3266341)
 - [Implement FarmBreadcrumbBuilder::applies() to only affect desired routes](https://github.com/farmOS/farmOS/pull/644)
+- [Attempt to update the map size until it is rendered #576](https://github.com/farmOS/farmOS/issues/576)
 
 ## [2.0.1] 2023-02-08
 

--- a/modules/core/map/js/farm_map.js
+++ b/modules/core/map/js/farm_map.js
@@ -75,6 +75,24 @@
         });
       }
 
+      // Handle other cases where the map may not have a correct size when
+      // it is initially rendered. This happens for modal and off-canvas
+      // dialogs where there is no easy way to detect when the dialog is
+      // finished loading and the map can be updated.
+      // Iterate every 0.5 seconds for 3 seconds until the map
+      // can be rendered and gets a size. Once rendered end the loop.
+      const delay = ms => new Promise(res => setTimeout(res, ms));
+      async function updateSize(instance) {
+        for (let i = 0; i < 6; i++) {
+          if (!instance.map.getSize().includes(0)) {
+            return;
+          }
+          instance.map.updateSize();
+          await delay(500);
+        }
+      }
+      updateSize(instance);
+
       return instance;
     }
 


### PR DESCRIPTION
This fixes a bug where the map is not rendered in modal and off-canvas dialogs until the map size is updated. This is a challenging edge case because it is hard to determine when the dialog is done loading and the map size can be updated. Here is what I ran into:
- There are jQuery events fired for when the dialog is created/closed ([change record](https://www.drupal.org/node/1852224)), but unfortunately we cannot subscribe to these with simple native JS event subscribers, we have to use jQuery. I don't think we should add a dependency on jQuery for this and even when I tried this in my console it didn't seem sufficient to update the map:
```js
jQuery(window).on('dialog:aftercreate', () => window.farmOS.map.instances[0].map.updateSize());
```
- When the map is initially created it is not a child of the `<div role="dialog">` parent. This makes it hard to identify which maps may be included in a dialog, unlike our existing code that can check for maps included in a form or details element quite easily. I figured this out by logging the following a few times after the map is created:

```js
window.farmOS.map.instances[0].map.getTargetElement().closest('div[role="dialog"]')
```

-  It seems that very soon after the map becomes a child of the dialog element it can finally have its size updated to render in the dialog. I'm not sure that there is an easy way to determine *when* this parent change happens. As a result, I've implemented a simple for loop that iterates every 0.5 seconds for 3 seconds attempting to update the map size. Once rendered, the loop is exited. I feel that this is a pretty safe addition and shouldn't have any noticeable impact on client side performance, even when a map is intentionally rendered in a hidden state.
- I also tested this with the internet connection throttled to slow 3G and saw that this still worked even though it took much  longer than 3 seconds after `farm_map.js` and `farmOS-map.js` were loaded before the map was rendered. My thought was the map might be created way before being added to the dialog but I don't think this is the case. Soon after the dialog was displayed the map appeared & rendered as expected.