### PR TITLE
Prevent circular group membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Prevent circular asset location #568](https://github.com/farmOS/farmOS/pull/568)
+- [Prevent circular group membership #562](https://github.com/farmOS/farmOS/pull/562)
 
 ## [2.0.0-rc1] 2022-12-15
 

--- a/modules/asset/group/farm_group.module
+++ b/modules/asset/group/farm_group.module
@@ -29,6 +29,18 @@ function farm_group_entity_base_field_info(EntityTypeInterface $entity_type) {
 }
 
 /**
+ * Implements hook_entity_base_field_info_alter().
+ */
+function farm_group_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
+  /** @var \Drupal\field\Entity\FieldConfig[] $fields */
+
+  // Prevent creating circular group memberships.
+  if ($entity_type->id() == 'log' && !empty($fields['asset'])) {
+    $fields['asset']->addConstraint('CircularGroupMembership');
+  }
+}
+
+/**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function farm_group_form_log_form_alter(&$form, FormStateInterface $form_state, $form_id) {

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraint.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraint.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\farm_group\Plugin\Validation\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Checks that a log is not creating a circular group membership.
+ *
+ * @Constraint(
+ *   id = "CircularGroupMembership",
+ *   label = @Translation("Circular group membership", context = "Validation"),
+ * )
+ */
+class CircularGroupMembershipConstraint extends Constraint {
+
+  /**
+   * The default violation message.
+   *
+   * @var string
+   */
+  public $message = '%asset cannot be a member of itself.';
+
+}

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\farm_group\Plugin\Validation\Constraint;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\farm_group\GroupMembershipInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates the CircularGroupMembership constraint.
+ */
+class CircularGroupMembershipConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
+
+  /**
+   * Group membership service.
+   *
+   * @var \Drupal\farm_group\GroupMembershipInterface
+   */
+  protected $groupMembership;
+
+  /**
+   * CircularGroupMembershipConstraintValidator constructor.
+   *
+   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
+   *   Group membership service.
+   */
+  public function __construct(GroupMembershipInterface $group_membership) {
+    $this->groupMembership = $group_membership;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('group.membership'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($value, Constraint $constraint) {
+    /** @var \Drupal\Core\Field\EntityReferenceFieldItemList $value */
+    /** @var \Drupal\farm_group\Plugin\Validation\Constraint\CircularGroupMembershipConstraint $constraint */
+
+    // Get the log that this field is on.
+    $log = $value->getParent()->getValue();
+
+    // If the log is not a group assignment, we have nothing to validate.
+    if (empty($log->get('is_group_assignment')->value)) {
+      return;
+    }
+
+    // Get the group(s) that asset(s) are being made members of.
+    $groups = $log->get('group')->referencedEntities();
+
+    // If there are no groups, we have nothing to validate.
+    if (empty($groups)) {
+      return;
+    }
+
+    // Get the log's timestamp.
+    $timestamp = $log->get('timestamp')->value;
+
+    // Iterate through referenced entities.
+    foreach ($value->referencedEntities() as $delta => $asset) {
+
+      // If this asset is not a group, skip it.
+      if ($asset->bundle() != 'group') {
+        continue;
+      }
+
+      // Load members of this group (recursively).
+      $members = $this->groupMembership->getGroupMembers([$asset], TRUE, $timestamp);
+
+      // Iterate through the groups and look for violations.
+      $violation = FALSE;
+      foreach ($groups as $group) {
+
+        // Make sure that the asset and group are not the same.
+        if ($group->id() == $asset->id()) {
+          $violation = TRUE;
+        }
+
+        // Make sure that none of the group(s) are members of this asset.
+        foreach ($members as $member) {
+          if ($group->id() == $member->id()) {
+            $violation = TRUE;
+            break;
+          }
+        }
+      }
+
+      // If a violation was found, flag it.
+      if ($violation) {
+        $this->context->buildViolation($constraint->message, ['%asset' => $asset->label()])
+          ->atPath((string) $delta . '.target_id')
+          ->setInvalidValue($asset->id())
+          ->addViolation();
+      }
+    }
+  }
+
+}

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\farm_group\Kernel;
 
 use Drupal\asset\Entity\Asset;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\log\Entity\Log;
@@ -16,6 +17,7 @@ use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
  */
 class GroupTest extends KernelTestBase {
 
+  use StringTranslationTrait;
   use FarmAssetTestTrait;
   use FarmEntityCacheTestTrait;
   use WktTrait;
@@ -54,6 +56,7 @@ class GroupTest extends KernelTestBase {
   protected static $modules = [
     'asset',
     'log',
+    'farm_entity_views',
     'farm_field',
     'farm_group',
     'farm_group_test',
@@ -62,7 +65,9 @@ class GroupTest extends KernelTestBase {
     'farm_log_asset',
     'geofield',
     'state_machine',
+    'system',
     'user',
+    'views',
   ];
 
   /**
@@ -78,6 +83,7 @@ class GroupTest extends KernelTestBase {
     $this->installEntitySchema('log');
     $this->installEntitySchema('user');
     $this->installConfig([
+      'farm_entity_views',
       'farm_group',
       'farm_group_test',
     ]);
@@ -424,6 +430,109 @@ class GroupTest extends KernelTestBase {
     // Assert that the first group has two recursive members.
     $first_group_recursive_members = $this->groupMembership->getGroupMembers([$first_group], TRUE);
     $this->assertCorrectAssets([$animal, $second_group], $first_group_recursive_members, TRUE, 'The first group has two recursive members.');
+  }
+
+  /**
+   * Test that circular group membership is prevented.
+   */
+  public function testCircularGroupMembership() {
+
+    // Create two group assets.
+    /** @var \Drupal\asset\Entity\AssetInterface $first_group */
+    $first_group = Asset::create([
+      'type' => 'group',
+      'name' => $this->randomMachineName(),
+      'status' => 'active',
+    ]);
+    $first_group->save();
+    /** @var \Drupal\asset\Entity\AssetInterface $second_group */
+    $second_group = Asset::create([
+      'type' => 'group',
+      'name' => $this->randomMachineName(),
+      'status' => 'active',
+    ]);
+    $second_group->save();
+
+    // First, make sure we can't create a group assignment log that references
+    // the same asset in both the asset and group fields.
+    /** @var \Drupal\log\Entity\LogInterface $first_log */
+    $first_log = Log::create([
+      'type' => 'test',
+      'status' => 'done',
+      'is_group_assignment' => TRUE,
+      'group' => ['target_id' => $first_group->id()],
+      'asset' => ['target_id' => $first_group->id()],
+    ]);
+
+    // Validate the log and confirm that a circular group constraint
+    // violation was set.
+    $violations = $first_log->validate();
+    $this->assertCount(1, $violations);
+    $this->assertEquals($this->t('%asset cannot be a member of itself.', ['%asset' => $first_group->label()]), $violations[0]->getMessage());
+
+    // Tweak the log so that it moves the first group to the second group.
+    $first_log->set('group', ['target_id' => $second_group->id()]);
+
+    // Confirm that validation passes.
+    $violations = $first_log->validate();
+    $this->assertCount(0, $violations);
+
+    // Save the first log.
+    $first_log->save();
+
+    // Start a log that assigns the second group to the first group (which
+    // would cause a circular group membership).
+    /** @var \Drupal\log\Entity\LogInterface $second_log */
+    $second_log = Log::create([
+      'type' => 'test',
+      'status' => 'done',
+      'is_group_assignment' => TRUE,
+      'group' => ['target_id' => $first_group->id()],
+      'asset' => ['target_id' => $second_group->id()],
+    ]);
+
+    // Validate the second log and confirm that a circular group constraint
+    // violation was set.
+    $violations = $second_log->validate();
+    $this->assertCount(1, $violations);
+    $this->assertEquals($this->t('%asset cannot be a member of itself.', ['%asset' => $second_group->label()]), $violations[0]->getMessage());
+
+    // Create a third group asset, so we can test recursive circular group
+    // membership constraint.
+    /** @var \Drupal\asset\Entity\AssetInterface $third_group */
+    $third_group = Asset::create([
+      'type' => 'group',
+      'name' => $this->randomMachineName(),
+      'status' => 'active',
+    ]);
+    $third_group->save();
+
+    // Update the second log to reference the third group instead.
+    $second_log->set('group', ['target_id' => $third_group->id()]);
+
+    // Confirm that validation passes.
+    $violations = $second_log->validate();
+    $this->assertCount(0, $violations);
+
+    // Save the second log.
+    $second_log->save();
+
+    // Now, start a third log that assigns the third group to the first group
+    // (which would create a recursive circular group membership).
+    /** @var \Drupal\log\Entity\LogInterface $third_log */
+    $third_log = Log::create([
+      'type' => 'test',
+      'status' => 'done',
+      'is_group_assignment' => TRUE,
+      'group' => ['target_id' => $first_group->id()],
+      'asset' => ['target_id' => $third_group->id()],
+    ]);
+
+    // Validate the third log and confirm that a circular group constraint
+    // violation was set.
+    $violations = $third_log->validate();
+    $this->assertCount(1, $violations);
+    $this->assertEquals($this->t('%asset cannot be a member of itself.', ['%asset' => $third_group->label()]), $violations[0]->getMessage());
   }
 
   /**


### PR DESCRIPTION
We decided to revert the PR that originally added this (#562), which addressed the bug reported in #541.

We discovered a critical flaw in the logic. The circular group membership check was not taking the timestamp of the log into account. This means that it might prevent saving an old log if it didn't pass validation against the CURRENT state of data.

Dependent on https://www.drupal.org/project/farm/issues/3310286

Remaining todo:

- Use $timestamp from https://www.drupal.org/project/farm/issues/3310286
- Changelog