### PR TITLE
Update core map behaviors to properly depend on core/drupalSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update farmOS-map to [v2.0.5](https://github.com/farmOS/farmOS-map/releases/tag/v2.0.5) to fix [Uncaught (in promise) TypeError: o.getChangeEventType is not a function #551](https://github.com/farmOS/farmOS/issues/551)
 - [Fix [warning] Invalid argument supplied for foreach() EntityViewsDataTaxonomyFilterTrait.php:26 #575](https://github.com/farmOS/farmOS/pull/575)
 - [Set reduce_duplicates: true in Views exposed filters for multivalue fields #571](https://github.com/farmOS/farmOS/pull/571)
+- [Update core map behaviors to properly depend on core/drupalSettings #578](https://github.com/farmOS/farmOS/pull/578)
 
 ## [2.0.0-beta6] 2022-07-30
 

--- a/modules/core/map/farm_map.libraries.yml
+++ b/modules/core/map/farm_map.libraries.yml
@@ -23,6 +23,7 @@ farm_map:
   js:
     js/farm_map.js: { }
   dependencies:
+    - core/drupalSettings
     - farm_map/farmOS-map
 behavior_wkt:
   js:

--- a/modules/core/map/js/farm_map.js
+++ b/modules/core/map/js/farm_map.js
@@ -1,4 +1,4 @@
-(function (Drupal) {
+(function (Drupal, drupalSettings) {
   Drupal.behaviors.farm_map = {
     attach: function (context, settings) {
       context.querySelectorAll('[data-map-instantiator="farm_map"]').forEach(function (element) {
@@ -79,4 +79,4 @@
     }
 
   };
-}(Drupal));
+}(Drupal, drupalSettings));

--- a/modules/core/map/modules/mapbox/js/farmOS.map.behaviors.mapbox.js
+++ b/modules/core/map/modules/mapbox/js/farmOS.map.behaviors.mapbox.js
@@ -1,4 +1,4 @@
-(function () {
+(function (drupalSettings) {
   farmOS.map.behaviors.mapbox = {
     attach: function (instance) {
       var key = drupalSettings.farm_map.behaviors.mapbox.api_key;
@@ -27,4 +27,4 @@
       instance.addLayer('xyz', opts);
     }
   };
-}());
+}(drupalSettings));

--- a/modules/core/ui/map/farm_ui_map.libraries.yml
+++ b/modules/core/ui/map/farm_ui_map.libraries.yml
@@ -9,5 +9,6 @@ behavior_asset_type_layers:
   js:
     js/farmOS.map.behaviors.asset_type_layers.js: { }
   dependencies:
+    - core/drupalSettings
     - farm_ui_map/map_popup_iframe
     - farm_map/farm_map

--- a/modules/core/ui/map/js/farmOS.map.behaviors.asset_type_layers.js
+++ b/modules/core/ui/map/js/farmOS.map.behaviors.asset_type_layers.js
@@ -1,4 +1,4 @@
-(function () {
+(function (drupalSettings) {
   farmOS.map.behaviors.asset_type_layers = {
     attach: function (instance) {
 
@@ -110,4 +110,4 @@
       });
     }
   };
-}());
+}(drupalSettings));


### PR DESCRIPTION
Small fix. This all works right now because core/drupalSettings is a common dependency of other behaviors, but these should still declare it as a dependency themselves. They should also reference the `drupalSettings` object in anonymous JS function that runs the behavior.