### PR TITLE
Use GitHub Actions to build Docker Hub images

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -159,3 +159,54 @@ jobs:
           files: /tmp/farmOS-${{ env.FARMOS_VERSION }}.tar.gz
           draft: false
           prerelease: false
+  publish:
+    name: Publish to Docker Hub
+    # We only publish to Docker Hub if this is a tag or 2.x branch push event
+    # to the official repository.
+    if: github.repository == 'farmOS/farmOS' && github.event_name == 'push' && (github.ref_type == 'tag' || (github.ref_type == 'branch' && needs.build.outputs.farmos_version == '2.x'))
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - sniff
+      - test
+    steps:
+      - name: Set FARMOS_VERSION from previous output.
+        run: echo "FARMOS_VERSION=${{ needs.build.outputs.farmos_version }}" >> $GITHUB_ENV
+      - name: Restore farmOS 2.x Docker image from cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/farmos-2x.tar
+          key: farmos-2x-${{ github.run_id }}
+      - name: Load farmos/farmos:2.x image
+        run: docker load < /tmp/farmos-2x.tar
+      - name: Restore farmOS 2.x-dev Docker image from cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/farmos-2x-dev.tar
+          key: farmos-2x-dev-${{ github.run_id }}
+      - name: Load farmos/farmos:2.x-dev image
+        run: docker load < /tmp/farmos-2x-dev.tar
+      - name: Login to Docker Hub.
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      # If the 2.x branch was pushed...
+      - name: Publish farmos/farmos:2.x image to Docker Hub.
+        if: github.ref_type == 'branch' && env.FARMOS_VERSION == '2.x'
+        run: docker push farmos/farmos:2.x
+      - name: Publish farmos/farmos:2.x-dev image to Docker Hub.
+        if: github.ref_type == 'branch' && env.FARMOS_VERSION == '2.x'
+        run: docker push farmos/farmos:2.x-dev
+      # If a tag was pushed, tag the Docker image and push to Docker Hub.
+      # If the tag is a valid semantic versioning string, also tag "latest".
+      # Semver regex from https://github.com/semver/semver/issues/199#issuecomment-43640395
+      - name: Tag and publish farmos/farmos:{tag} image to Docker Hub.
+        if: github.ref_type == 'tag'
+        run: |
+          docker tag farmos/farmos:2.x farmos/farmos:${{ env.FARMOS_VERSION }}
+          docker push farmos/farmos:${{ env.FARMOS_VERSION }}
+          if echo ${{ env.FARMOS_VERSION }} | grep -Pq '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'; then
+            docker tag farmos/farmos:2.x farmos/farmos:latest
+            docker push farmos/farmos:latest
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Make translatable strings consistent between fields and actions #594](https://github.com/farmOS/farmOS/pull/594)
 - [Issue #3316925: Mark certain classes as @internal to indicate non-public APIs](https://www.drupal.org/project/farm/issues/3316925)
 - [Render link to taxonomy terms in farm entity views #595](https://github.com/farmOS/farmOS/pull/595)
+- [Issue #3203129: Use GitHub Actions to build Docker Hub images](https://www.drupal.org/project/farm/issues/3203129)
 
 ### Fixed
 


### PR DESCRIPTION
Draft commit to begin publishing our images to Docker Hub via GitHub Actions, per https://www.drupal.org/project/farm/issues/3203129

This is currently untested. Opened as a draft PR for initial sanity check and review of the logic with @symbioquine and @paul121.