### PR TITLE
Adapt csv export logic to support a type filter allowing single or multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Adapt csv export logic to support a type filter allowing single or multiple values. #584](https://github.com/farmOS/farmOS/pull/584)
+
 ## [2.0.0-beta7] 2022-09-29
 
 ### Added

--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -44,16 +44,26 @@ function farm_ui_views_views_pre_view(ViewExecutable $view, $display_id, array &
   // If this is an asset/log/quantity "CSV export" display with a single type
   // filter applied, alter fields and filters to match the "By type" display.
   if (in_array($view->id(), ['farm_asset', 'farm_log', 'farm_quantity']) && $display_id == 'csv') {
-    $exposed_input = $view->getExposedInput();
-    if (!empty($exposed_input['type']) && count($exposed_input['type']) == 1) {
-      $bundle = $exposed_input['type'][0];
 
-      // If the entity type has a bundle_plugin manager, add all of its
-      // bundle fields and filters to the page_type view.
-      if (\Drupal::entityTypeManager()->hasHandler($view->getBaseEntityType()->id(), 'bundle_plugin')) {
-        farm_ui_views_add_bundle_handlers($view, $display_id, $bundle, 'field');
-        farm_ui_views_add_bundle_handlers($view, $display_id, $bundle, 'filter');
+    // Determine the bundle from the "type" exposed input filter.
+    // The input may be a string or an array depending on if the exposed filter
+    // allows multiple selections.
+    $bundle = NULL;
+    $exposed_input = $view->getExposedInput();
+    if (isset($exposed_input['type'])) {
+      if (is_string($exposed_input['type']) && $exposed_input['type'] != 'All') {
+        $bundle = $exposed_input['type'];
       }
+      elseif (is_array($exposed_input['type']) && count($exposed_input['type']) == 1) {
+        $bundle = $exposed_input['type'][0];
+      }
+    }
+
+    // If the entity type has a bundle_plugin manager, add all of its
+    // bundle fields and filters to the page_type view.
+    if ($bundle && \Drupal::entityTypeManager()->hasHandler($view->getBaseEntityType()->id(), 'bundle_plugin')) {
+      farm_ui_views_add_bundle_handlers($view, $display_id, $bundle, 'field');
+      farm_ui_views_add_bundle_handlers($view, $display_id, $bundle, 'filter');
     }
   }
 


### PR DESCRIPTION
The current logic is expecting the exposed type filter to always be an array. This causes csv exports to break when exporting from the all quantities page because the quantity type filter does not allow multiple values. When no quantity type is provided the type filter is set to 'All'.

Another solutiong would be to change the quantity type filter to allow multiple values... but more generally we should allow a single type to be provided as well. It's possible someone could manually build the CSV export link w/ query parameters and provide the type as a single value eg: `?type=animal` vs `?type[]=animal`.