### PR TITLE
Add action for bulk assigning asset parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Add action to bulk categorize logs #590](https://github.com/farmOS/farmOS/pull/590)
+- [Add action for bulk assigning asset parent #588](https://github.com/farmOS/farmOS/pull/588)
 
 ### Changed
 

--- a/modules/core/entity/farm_entity.info.yml
+++ b/modules/core/entity/farm_entity.info.yml
@@ -6,7 +6,6 @@ core_version_requirement: ^9
 dependencies:
   - entity:entity
   - entity_reference_integrity:entity_reference_integrity_enforce
-  - entity_reference_validators:entity_reference_validators
   - exif_orientation:exif_orientation
   - farm:farm_entity_fields
   - farm:farm_entity_views

--- a/modules/core/entity/modules/fields/farm_entity_fields.base_fields.inc
+++ b/modules/core/entity/modules/fields/farm_entity_fields.base_fields.inc
@@ -43,28 +43,12 @@ function farm_entity_fields_asset_base_fields() {
         'view' => 10,
       ],
     ],
-    'parent' => [
-      'type' => 'entity_reference',
-      'label' => t('Parents'),
-      'description' => t('If this asset descends from other assets, they can referenced here to create a lineage relationship.'),
-      'target_type' => 'asset',
-      'multiple' => TRUE,
-      'weight' => [
-        'form' => 40,
-        'view' => 0,
-      ],
-    ],
   ];
   /** @var \Drupal\Core\Field\BaseFieldDefinition[] $fields */
   $fields = [];
   foreach ($field_info as $name => $info) {
     $fields[$name] = \Drupal::service('farm_field.factory')->baseFieldDefinition($info);
   }
-
-  // Add entity_reference_validators constraints to parent field.
-  // See entity_reference_validators_entity_base_field_info_alter.
-  $fields['parent']->addConstraint('CircularReference', ['deep' => TRUE]);
-  $fields['parent']->addConstraint('DuplicateReference');
 
   return $fields;
 }

--- a/modules/core/entity/modules/fields/farm_entity_fields.info.yml
+++ b/modules/core/entity/modules/fields/farm_entity_fields.info.yml
@@ -18,4 +18,5 @@ dependencies:
   - farm:farm_log_category
   - farm:farm_log_quantity
   - farm:farm_owner
+  - farm:farm_parent
   - token:token

--- a/modules/core/entity/modules/fields/farm_entity_fields.post_update.php
+++ b/modules/core/entity/modules/fields/farm_entity_fields.post_update.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Updates farm_entity_fields module.
+ */
+
+/**
+ * Install farm_parent module.
+ */
+function farm_entity_fields_post_update_enable_farm_parent(&$sandbox = NULL) {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_parent')) {
+    \Drupal::service('module_installer')->install(['farm_parent']);
+  }
+}

--- a/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
@@ -41,6 +41,7 @@ class FarmEntityFieldTest extends KernelTestBase {
     'farm_log',
     'farm_log_asset',
     'farm_owner',
+    'farm_parent',
   ];
 
   /**

--- a/modules/core/parent/config/optional/system.action.asset_parent_action.yml
+++ b/modules/core/parent/config/optional/system.action.asset_parent_action.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - asset
+  enforced:
+    module:
+      - farm_parent
+id: asset_parent_action
+label: 'Assign asset parent'
+type: asset
+plugin: 'asset_parent_action'
+configuration: {  }

--- a/modules/core/parent/config/schema/farm_parent.schema.yml
+++ b/modules/core/parent/config/schema/farm_parent.schema.yml
@@ -1,0 +1,4 @@
+# Schema for actions.
+action.configuration.asset_parent_action:
+  type: action_configuration_default
+  label: 'Configuration for the asset parent action'

--- a/modules/core/parent/farm_parent.info.yml
+++ b/modules/core/parent/farm_parent.info.yml
@@ -1,0 +1,9 @@
+name: farmOS Parent
+description: Provides a Parent field for farmOS assets.
+type: module
+package: farmOS
+core_version_requirement: ^9
+dependencies:
+  - asset:asset
+  - entity_reference_validators:entity_reference_validators
+  - farm:farm_field

--- a/modules/core/parent/farm_parent.module
+++ b/modules/core/parent/farm_parent.module
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains farm_parent.module.
+ */
+
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function farm_parent_entity_base_field_info(EntityTypeInterface $entity_type) {
+
+  // Add parent base field to all asset types.
+  $fields = [];
+  if ($entity_type->id() == 'asset') {
+    $parent_info = [
+      'type' => 'entity_reference',
+      'label' => t('Parents'),
+      'description' => t('If this asset descends from other assets, they can referenced here to create a lineage relationship.'),
+      'target_type' => 'asset',
+      'multiple' => TRUE,
+      'weight' => [
+        'form' => 40,
+        'view' => 0,
+      ],
+    ];
+    $fields['parent'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($parent_info);
+
+    // Add entity_reference_validators constraints to parent field.
+    // See entity_reference_validators_entity_base_field_info_alter.
+    $fields['parent']->addConstraint('CircularReference', ['deep' => TRUE]);
+    $fields['parent']->addConstraint('DuplicateReference');
+  }
+  return $fields;
+}

--- a/modules/core/parent/farm_parent.routing.yml
+++ b/modules/core/parent/farm_parent.routing.yml
@@ -1,0 +1,6 @@
+farm_parent.asset_parent_action_form:
+  path: '/asset/assign-parent'
+  defaults:
+    _form: 'Drupal\farm_parent\Form\AssetParentActionForm'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Drupal\farm_parent\Form;
+
+use Drupal\asset\Entity\AssetInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Provides a form for assigning asset parent.
+ */
+class AssetParentActionForm extends ConfirmFormBase {
+
+  /**
+   * The tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\SharedTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $user;
+
+  /**
+   * The entity type.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeInterface
+   */
+  protected $entityType;
+
+  /**
+   * The assets to update.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface[]
+   */
+  protected $entities;
+
+  /**
+   * The current Request object.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * Constructs an AssetParentActionForm form object.
+   *
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The current Request object.
+   */
+  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
+    $this->tempStore = $temp_store_factory->get('asset_parent_confirm');
+    $this->entityTypeManager = $entity_type_manager;
+    $this->user = $user;
+    $this->request = $request;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('tempstore.private'),
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('request_stack')->getCurrentRequest(),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'asset_parent_action_confirm_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->formatPlural(count($this->entities), 'Are you sure you want to assign parent for this @item?', 'Are you sure you want to assign parents for these @items?', [
+      '@item' => $this->entityType->getSingularLabel(),
+      '@items' => $this->entityType->getPluralLabel(),
+    ]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    if ($this->entityType->hasLinkTemplate('collection')) {
+      return new Url('entity.' . $this->entityType->id() . '.collection');
+    }
+    else {
+      return new Url('<front>');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return '';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Save');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // Check if asset IDs were provided in the asset query param.
+    if ($asset_ids = $this->request->get('asset')) {
+
+      // Wrap in an array, if necessary.
+      if (!is_array($asset_ids)) {
+        $asset_ids = [$asset_ids];
+      }
+
+      // Add each asset the user has view access to.
+      $this->entities = array_filter($this->entityTypeManager->getStorage('asset')->loadMultiple($asset_ids), function (AssetInterface $asset) {
+        return $asset->access('view', $this->user);
+      });
+    }
+    // Else load entities from the tempStore state.
+    else {
+      $this->entities = $this->tempStore->get($this->user->id());
+    }
+
+    $this->entityType = $this->entityTypeManager->getDefinition('asset');
+    if (empty($this->entityType) || empty($this->entities)) {
+      return new RedirectResponse($this->getCancelUrl()
+        ->setAbsolute()
+        ->toString());
+    }
+
+    $form['parent'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Parents'),
+      '#description' => $this->t('The parent to assign for the asset.'),
+      '#target_type' => 'asset',
+      '#selection_handler' => 'views',
+      '#selection_settings' => [
+        'view' => [
+          'view_name' => 'farm_asset_reference',
+          'display_name' => 'entity_reference',
+        ],
+        'match_operator' => 'CONTAINS',
+        'match_limit' => 10,
+      ],
+      '#tags' => TRUE,
+      '#validate_reference' => FALSE,
+      '#maxlength' => 1024,
+    ];
+
+    $form['operation'] = [
+      '#type' => 'radios',
+      '#title' => $this->t('Append or replace'),
+      '#description' => $this->t('Select "Append" if you want to add a parent, but keep the existing asset parents. Select "Replace" if you want to replace the existing asset parent with the ones specified above.'),
+      '#options' => [
+        'append' => $this->t('Append'),
+        'replace' => $this->t('Replace'),
+      ],
+      '#default_value' => 'append',
+      '#required' => TRUE,
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Filter out entities the user doesn't have access to.
+    $inaccessible_entities = [];
+    $accessible_entities = [];
+    foreach ($this->entities as $entity) {
+      if (!$entity->access('update', $this->currentUser())) {
+        $inaccessible_entities[] = $entity;
+        continue;
+      }
+      $accessible_entities[] = $entity;
+    }
+
+    // Get submitted parent ids.
+    $submitted_parent_ids = array_column($form_state->getValue('parent', []), 'target_id');
+
+    // Update parent on accessible entities.
+    $total_count = 0;
+    foreach ($accessible_entities as $entity) {
+      /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $parent_field */
+      if ($parent_field = $entity->get('parent')) {
+
+        // Save existing values if appending.
+        $existing_values = [];
+        if ($form_state->getValue('operation') === 'append') {
+          $existing_values = array_column($parent_field->getValue(), 'target_id');
+        }
+
+        // Empty the field.
+        $parent_field->setValue([]);
+
+        $new_values = array_unique(array_merge($existing_values, $submitted_parent_ids));
+        foreach ($new_values as $parent_id) {
+          $parent_field->appendItem($parent_id);
+        }
+
+        // Validate the entity before saving.
+        $violations = $entity->validate();
+        if ($violations->count() > 0) {
+          $this->messenger()->addWarning(
+            $this->t('Could not assign parent for <a href=":entity_link">%entity_label</a>: validation failed.',
+              [
+                ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
+                '%entity_label' => $entity->label(),
+              ],
+            ),
+          );
+          continue;
+        }
+
+        $entity->save();
+        $total_count++;
+      }
+    }
+
+    // Add warning message for inaccessible entities.
+    if (!empty($inaccessible_entities)) {
+      $inaccessible_count = count($inaccessible_entities);
+      $this->messenger()->addWarning($this->formatPlural($inaccessible_count, 'Could not assign parent for @count @item because you do not have the necessary permissions.', 'Could not assign parent for @count @items because you do not have the necessary permissions.', [
+        '@item' => $this->entityType->getSingularLabel(),
+        '@items' => $this->entityType->getPluralLabel(),
+      ]));
+    }
+
+    // Add confirmation message.
+    if (!empty($total_count)) {
+      $this->messenger()->addStatus($this->formatPlural($total_count, 'Assigned parent for @count @item.', 'Assigned parent for @count @items', [
+        '@item' => $this->entityType->getSingularLabel(),
+        '@items' => $this->entityType->getPluralLabel(),
+      ]));
+    }
+
+    $this->tempStore->delete($this->currentUser()->id());
+    $form_state->setRedirectUrl($this->getCancelUrl());
+  }
+
+}

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Drupal\farm_parent\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\EntityActionBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Action that assigns asset parent.
+ *
+ * @Action(
+ *   id = "asset_parent_action",
+ *   label = @Translation("Assign asset parent."),
+ *   type = "asset",
+ *   confirm_form_route_name = "farm_parent.asset_parent_action_form"
+ * )
+ */
+class AssetParent extends EntityActionBase {
+
+  /**
+   * The tempstore object.
+   *
+   * @var \Drupal\Core\TempStore\SharedTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new AssetParent object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+    $this->currentUser = $current_user;
+    $this->tempStore = $temp_store_factory->get('asset_parent_confirm');
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('tempstore.private'),
+      $container->get('current_user')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function executeMultiple(array $entities) {
+    /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
+    $this->tempStore->set($this->currentUser->id(), $entities);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($object = NULL) {
+    $this->executeMultiple([$object]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    return $object->access('update', $account, $return_as_object);
+  }
+
+}

--- a/modules/log/birth/tests/src/Kernel/BirthTest.php
+++ b/modules/log/birth/tests/src/Kernel/BirthTest.php
@@ -31,6 +31,7 @@ class BirthTest extends KernelTestBase {
     'farm_field',
     'farm_id_tag',
     'farm_log_asset',
+    'farm_parent',
     'file',
     'geofield',
     'image',


### PR DESCRIPTION
This was originally requested here: https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/283

I've implemented the asset parent action in the Rothamsted module and opening this PR to add to farmOS core. They will depend on the feature being in farmOS core if/when this PR is merged.

At first it wasn't clear which core module should host this asset parent action. Chatting with @mstenta we decided we could create a new `farm_parent` module similar to what we did for `farm_owner`. This should work well, it's extra nice because the `parent` field depended on `entity_reference_validators` which means we can move this dependency off of `farm_entity_fields` to `farm_parent` in the process as well.