### PR TITLE
Check PHP compatibility with codesniffer

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -75,6 +75,10 @@ jobs:
         run: docker run farmos/farmos:2.x-dev phpcs /opt/drupal/web/profiles/farm
       - name: Run PHPStan
         run: docker run farmos/farmos:2.x-dev phpstan analyze /opt/drupal/web/profiles/farm
+      - name: Check PHP compatibility of contrib modules and themes (ignore warnings).
+        run: |
+          docker run farmos/farmos:2.x-dev phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- --warning-severity=0 /opt/drupal/web/modules
+          docker run farmos/farmos:2.x-dev phpcs --standard=PHPCompatibility --runtime-set testVersion 7.4- --warning-severity=0 /opt/drupal/web/themes
   test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest

--- a/composer.project.json
+++ b/composer.project.json
@@ -8,6 +8,7 @@
         "drupal/core-dev": "9.4.7",
         "mglaman/phpstan-drupal": "^1.1",
         "phpstan/extension-installer": "^1.1",
+        "phpcompatibility/php-compatibility": "^9",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpspec/prophecy-phpunit": "^2",

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -55,6 +55,8 @@ RUN { \
     # @todo https://www.drupal.org/project/coder/issues/2159253
     echo '    <exclude name="DrupalPractice.Commenting.CommentEmptyLine.SpacingAfter"/>'; \
     echo '  </rule>'; \
+    echo '  <rule ref="PHPCompatibility"/>'; \
+    echo '  <config name="testVersion" value="7.4-"/>'; \
     echo '  <rule ref="Internal.Tokenizer.Exception"><severity>0</severity></rule>'; \
     echo '</ruleset>'; \
   } > /var/farmOS/phpcs.xml

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationCondition/NumericCondition.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationCondition/NumericCondition.php
@@ -15,7 +15,7 @@ use Drupal\Core\Form\FormStateInterface;
  *   }
  * )
  */
-class Numeric extends NotificationConditionBase {
+class NumericCondition extends NotificationConditionBase {
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Recommended by @pcambra. This will give us the ability to quickly check that all our code is compatible with the version(s) of PHP we claim to support.