### PR TITLE
Show "Add log" action links on /asset/[id]/logs/[type]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Add action to bulk categorize logs #590](https://github.com/farmOS/farmOS/pull/590)
 - [Add action for bulk assigning asset parent #588](https://github.com/farmOS/farmOS/pull/588)
+- [Show "Add log" action links on /asset/[id]/logs/[type] #596](https://github.com/farmOS/farmOS/pull/596)
 
 ### Changed
 

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -144,6 +144,12 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
             ],
           ];
           $this->derivatives[$name]['cache_tags'] = ['entity_bundles'];
+
+          // Add it to the /asset/%asset/logs/%log_type View, if the
+          // farm_ui_views module is enabled.
+          if ($this->moduleHandler->moduleExists('farm_ui_views')) {
+            $this->derivatives[$name]['appears_on'][] = 'view.farm_log.page_asset';
+          }
         }
       }
     }


### PR DESCRIPTION
Feature request from the forum: https://farmos.discourse.group/t/new-log-button-when-viewing-an-asset/1418