### PR TITLE
Change default client secret to be NULL to avoid issue #3322325

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Click sort columns expand filters fieldset #586](https://github.com/farmOS/farmOS/pull/586)
 - [Issue #3189918: Broken relationship schema link in farmOS 2.x JSON:API](https://www.drupal.org/project/farm/issues/3189918)
 - [Issue #3322227: Document schema title wrong for multiple resource types](https://www.drupal.org/project/jsonapi_schema/issues/3322227)
+- [Change default client secret to be NULL to avoid issue #3322325 #597](https://github.com/farmOS/farmOS/pull/597)
 
 ## [2.0.0-beta7] 2022-09-29
 

--- a/modules/core/api/farm_api.install
+++ b/modules/core/api/farm_api.install
@@ -79,7 +79,7 @@ function farm_api_install() {
     'redirect' => $base_url,
     'is_default' => TRUE,
     'owner_id' => '',
-    'secret' => '',
+    'secret' => NULL,
     'confidential' => FALSE,
     'third_party' => FALSE,
     'grant_user_access' => TRUE,

--- a/modules/core/fieldkit/farm_fieldkit.install
+++ b/modules/core/fieldkit/farm_fieldkit.install
@@ -19,7 +19,7 @@ function farm_fieldkit_install() {
     'redirect' => 'https://farmOS.app',
     'allowed_origins' => 'https://farmos.app',
     'owner_id' => '',
-    'secret' => '',
+    'secret' => NULL,
     'confidential' => FALSE,
     'third_party' => FALSE,
     'grant_user_access' => TRUE,


### PR DESCRIPTION
It seems like a good idea to use `NULL` for the consumer/client `secret` going forward.. here's a PR for this approach if we'd like to do so

https://www.drupal.org/project/simple_oauth/issues/3322325