### PR TITLE
Add "Date received" and "Date processed" fields to lab test logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ If you would like to skip the automatic fix, add the following line to your
 - [Add action to bulk categorize logs #590](https://github.com/farmOS/farmOS/pull/590)
 - [Add action for bulk assigning asset parent #588](https://github.com/farmOS/farmOS/pull/588)
 - [Show "Add log" action links on /asset/[id]/logs/[type] #596](https://github.com/farmOS/farmOS/pull/596)
+- [Add "Date received" and "Date processed" fields to lab test logs](https://github.com/farmOS/farmOS/pull/602)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ If you would like to skip the automatic fix, add the following line to your
 - [Render link to taxonomy terms in farm entity views #595](https://github.com/farmOS/farmOS/pull/595)
 - [Issue #3203129: Use GitHub Actions to build Docker Hub images](https://www.drupal.org/project/farm/issues/3203129)
 - [Announce new releases on Mastodon/Twitter via farmOS-microblog #599](https://github.com/farmOS/farmOS/pull/599)
+- [Improve dependency relationships of asset/log/quantity modules #601](https://github.com/farmOS/farmOS/pull/601)
 
 ### Fixed
 

--- a/docs/development/module/index.md
+++ b/docs/development/module/index.md
@@ -51,6 +51,12 @@ dependencies:
   - log:log
 ```
 
+In this example, we declare dependencies on the `farm_entity` module (provided
+by the Drupal `farm` project, aka farmOS) and the `log` module (a separate
+Drupal contrib project), because this module adds a log type. Dependencies will
+vary depending on the needs of your module. Refer to the modules included with
+farmOS for examples.
+
 Other common files and directories in a module include:
 
 - `[modulename].module` - Optional PHP file for Drupal hook implementations.

--- a/docs/development/module/index.md
+++ b/docs/development/module/index.md
@@ -48,6 +48,7 @@ package: farmOS Contrib
 core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
+  - log:log
 ```
 
 Other common files and directories in a module include:

--- a/modules/asset/animal/farm_animal.info.yml
+++ b/modules/asset/animal/farm_animal.info.yml
@@ -4,5 +4,6 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_animal_type
   - farm:farm_entity

--- a/modules/asset/compost/farm_compost.info.yml
+++ b/modules/asset/compost/farm_compost.info.yml
@@ -4,4 +4,5 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity

--- a/modules/asset/equipment/farm_equipment.info.yml
+++ b/modules/asset/equipment/farm_equipment.info.yml
@@ -4,4 +4,5 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity

--- a/modules/asset/group/farm_group.info.yml
+++ b/modules/asset/group/farm_group.info.yml
@@ -4,6 +4,7 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity
   - farm:farm_location
   - farm:farm_log

--- a/modules/asset/land/farm_land.info.yml
+++ b/modules/asset/land/farm_land.info.yml
@@ -4,4 +4,5 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity

--- a/modules/asset/material/farm_material.info.yml
+++ b/modules/asset/material/farm_material.info.yml
@@ -4,5 +4,6 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity
   - farm:farm_material_type

--- a/modules/asset/plant/farm_plant.info.yml
+++ b/modules/asset/plant/farm_plant.info.yml
@@ -4,6 +4,7 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity
   - farm:farm_plant_type
   - farm:farm_season

--- a/modules/asset/seed/farm_seed.info.yml
+++ b/modules/asset/seed/farm_seed.info.yml
@@ -4,6 +4,7 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity
   - farm:farm_plant_type
   - farm:farm_season

--- a/modules/asset/sensor/farm_sensor.info.yml
+++ b/modules/asset/sensor/farm_sensor.info.yml
@@ -4,5 +4,6 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:data_stream
   - farm:farm_entity

--- a/modules/asset/structure/farm_structure.info.yml
+++ b/modules/asset/structure/farm_structure.info.yml
@@ -4,4 +4,5 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity

--- a/modules/asset/water/farm_water.info.yml
+++ b/modules/asset/water/farm_water.info.yml
@@ -4,4 +4,5 @@ type: module
 package: farmOS Assets
 core_version_requirement: ^9
 dependencies:
+  - farm:asset
   - farm:farm_entity

--- a/modules/core/inventory/tests/modules/farm_inventory_test/config/install/log.type.adjustment.yml
+++ b/modules/core/inventory/tests/modules/farm_inventory_test/config/install/log.type.adjustment.yml
@@ -6,3 +6,6 @@ description: ''
 name_pattern: 'Adjustment log [log:id]'
 workflow: log_default
 new_revision: true
+third_party_settings:
+  farm_log_quantity:
+    default_quantity_type: test

--- a/modules/core/inventory/tests/modules/farm_inventory_test/config/install/quantity.type.test.yml
+++ b/modules/core/inventory/tests/modules/farm_inventory_test/config/install/quantity.type.test.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_inventory_test
+id: test
+label: Test
+default_measure: ''
+description: 'Test quantity type.'
+new_revision: true

--- a/modules/core/inventory/tests/modules/farm_inventory_test/farm_inventory_test.info.yml
+++ b/modules/core/inventory/tests/modules/farm_inventory_test/farm_inventory_test.info.yml
@@ -5,4 +5,5 @@ package: Testing
 core_version_requirement: ^9
 dependencies:
   - farm:asset
+  - farm:quantity
   - log:log

--- a/modules/core/inventory/tests/src/Functional/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Functional/InventoryTest.php
@@ -31,7 +31,6 @@ class InventoryTest extends FarmBrowserTestBase {
   protected static $modules = [
     'farm_inventory',
     'farm_inventory_test',
-    'farm_quantity_standard',
     'farm_unit',
     'farm_api',
   ];
@@ -86,7 +85,7 @@ class InventoryTest extends FarmBrowserTestBase {
     // Create an inventory adjustment log+quantity that resets the volume
     // (liters) inventory of the asset.
     $quantity = $quantity_storage->create([
-      'type' => 'standard',
+      'type' => 'test',
       'measure' => 'volume',
       'value' => [
         'numerator' => '2',

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -38,7 +38,6 @@ class InventoryTest extends KernelTestBase {
     'farm_inventory_test',
     'farm_log',
     'farm_log_quantity',
-    'farm_quantity_standard',
     'farm_unit',
     'fraction',
     'log',
@@ -63,7 +62,6 @@ class InventoryTest extends KernelTestBase {
     $this->installEntitySchema('taxonomy_term');
     $this->installConfig([
       'farm_inventory_test',
-      'farm_quantity_standard',
     ]);
   }
 
@@ -305,7 +303,7 @@ class InventoryTest extends KernelTestBase {
     $fraction = Fraction::createFromDecimal($value);
     /** @var \Drupal\quantity\Entity\Quantity $quantity */
     $quantity = Quantity::create([
-      'type' => 'standard',
+      'type' => 'test',
       'value' => [
         'numerator' => $fraction->getNumerator(),
         'denominator' => $fraction->getDenominator(),

--- a/modules/core/log/modules/quantity/farm_log_quantity.module
+++ b/modules/core/log/modules/quantity/farm_log_quantity.module
@@ -51,22 +51,53 @@ function farm_log_quantity_form_log_form_alter(&$form, FormStateInterface $form_
     // Load the log type storage.
     /** @var \Drupal\log\Entity\Log $entity */
     $entity = $form_state->getFormObject()->getEntity();
-    /** @var \Drupal\log\Entity\LogType $log_type_storage */
-    $log_type_storage = \Drupal::service('entity_type.manager')->getStorage('log_type')->load($entity->bundle());
 
-    // Load default quantity type from the bundle's third party settings.
-    // Default to standard, if it exists. Note that we do NOT add a dependency
-    // on farm_quantity_standard, because that would create a circular
-    // dependency. This only changes the default type to 'standard' if that
-    // option is available.
-    $default_type = $log_type_storage->getThirdPartySetting('farm_log_quantity', 'default_quantity_type');
-    if (empty($default_type)) {
-      $default_type = 'standard';
-    }
+    // Determine the default quantity type.
+    $default_type = farm_log_quantity_default_type($entity->bundle());
 
     // Set the default value.
     if (array_key_exists($default_type, $bundle_select['#options'])) {
       $bundle_select['#default_value'] = $default_type;
     }
   }
+}
+
+/**
+ * Returns the default quantity type.
+ *
+ * @param string|null $log_type
+ *   The log type (optional).
+ *
+ * @return string|null
+ *   The log's default quantity type, or NULL if a default is unavailable.
+ */
+function farm_log_quantity_default_type(?string $log_type = NULL) {
+
+  // If a log type is specified, attempt to look up the default quantity type
+  // from the log type's third party settings.
+  if (!empty($log_type)) {
+    /** @var \Drupal\log\Entity\LogType $log_type_storage */
+    $log_type_definition = \Drupal::service('entity_type.manager')->getStorage('log_type')->load($log_type);
+    $type = $log_type_definition->getThirdPartySetting('farm_log_quantity', 'default_quantity_type', NULL);
+    if (!empty($type)) {
+      return $type;
+    }
+  }
+
+  // If the farm_quantity_standard module is installed, default to "standard".
+  if (\Drupal::moduleHandler()->moduleExists('farm_quantity_standard')) {
+    return 'standard';
+  }
+
+  // Look up all quantity types and take the first one.
+  /** @var \Drupal\quantity\Entity\QuantityInterface[] $quantity_types */
+  $quantity_types = \Drupal::service('entity_type.manager')->getStorage('quantity_type')->loadMultiple();
+  foreach ($quantity_types as $quantity_type) {
+    if (!empty($quantity_type->id())) {
+      return $quantity_type->id();
+    }
+  }
+
+  // Otherwise return NULL.
+  return NULL;
 }

--- a/modules/core/quick/farm_quick.info.yml
+++ b/modules/core/quick/farm_quick.info.yml
@@ -6,5 +6,6 @@ core_version_requirement: ^9
 dependencies:
   - drupal:taxonomy
   - farm:asset
-  - farm:farm_quantity_standard
+  - farm:farm_log_quantity
+  - farm:quantity
   - log:log

--- a/modules/core/quick/src/Traits/QuickLogTrait.php
+++ b/modules/core/quick/src/Traits/QuickLogTrait.php
@@ -52,7 +52,7 @@ trait QuickLogTrait {
 
         // If the quantity is an array of values, pass it to createQuantity.
         if (is_array($qty)) {
-          $log->quantity[] = $this->createQuantity($qty);
+          $log->quantity[] = $this->createQuantity($qty, $log->bundle());
         }
 
         // Otherwise, add it directly to the log.

--- a/modules/core/quick/src/Traits/QuickQuantityTrait.php
+++ b/modules/core/quick/src/Traits/QuickQuantityTrait.php
@@ -18,20 +18,24 @@ trait QuickQuantityTrait {
    *
    * @param array $values
    *   An array of values to initialize the quantity with.
+   * @param string|null $log_type
+   *   Optionally specify the log type this quantity will be added to. This is
+   *   used to automatically determine what the default quantity type of the
+   *   log should be.
    *
    * @return \Drupal\quantity\Entity\QuantityInterface
    *   The quantity entity that was created.
    */
-  protected function createQuantity(array $values = []) {
+  protected function createQuantity(array $values = [], ?string $log_type = NULL) {
 
     // Trim the quantity label to 255 characters.
     if (!empty($values['label'])) {
       $values['label'] = $this->trimString($values['label'], 255);
     }
 
-    // If a type isn't set, default to "standard".
+    // If a type isn't set, get the default type.
     if (empty($values['type'])) {
-      $values['type'] = 'standard';
+      $values['type'] = farm_log_quantity_default_type($log_type);
     }
 
     // Split value into numerator and denominator, if it isn't already.

--- a/modules/core/quick/tests/modules/farm_quick_test/config/install/log.type.test.yml
+++ b/modules/core/quick/tests/modules/farm_quick_test/config/install/log.type.test.yml
@@ -6,3 +6,6 @@ description: ''
 name_pattern: 'Test log [log:id]'
 workflow: log_default
 new_revision: true
+third_party_settings:
+  farm_log_quantity:
+    default_quantity_type: test

--- a/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test.yml
+++ b/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_quick_test
+id: test
+label: Test
+default_measure: ''
+description: 'Test quantity type.'
+new_revision: true

--- a/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test2.yml
+++ b/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test2.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_quick_test
+id: test2
+label: Test2
+default_measure: ''
+description: 'Test2 quantity type.'
+new_revision: true

--- a/modules/core/quick/tests/modules/farm_quick_test/farm_quick_test.info.yml
+++ b/modules/core/quick/tests/modules/farm_quick_test/farm_quick_test.info.yml
@@ -5,4 +5,6 @@ package: Testing
 core_version_requirement: ^8.8 || ^9
 dependencies:
   - farm:farm_quick
+  - farm:asset
+  - farm:quantity
   - log:log

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/Test.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/Test.php
@@ -76,6 +76,7 @@ class Test extends QuickFormBase {
       'value' => $value,
       'units' => 'tests',
       'label' => $this->t('test label'),
+      'type' => 'test2',
     ]);
 
     // Create a term.

--- a/modules/core/quick/tests/src/Kernel/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTest.php
@@ -24,7 +24,9 @@ class QuickFormTest extends KernelTestBase {
    */
   protected static $modules = [
     'asset',
-    'farm_quantity_standard',
+    'entity_reference_revisions',
+    'farm_field',
+    'farm_log_quantity',
     'farm_quick',
     'farm_quick_test',
     'farm_unit',
@@ -102,8 +104,12 @@ class QuickFormTest extends KernelTestBase {
     // Confirm that the log is linked to the quick form.
     $this->assertEquals('test', $storage['logs'][0]->quick[0]);
 
-    // Confirm that a quantity was created.
+    // Confirm that the log's quantity type is test.
+    $this->assertEquals('test', $storage['logs'][0]->get('quantity')->referencedEntities()[0]->bundle());
+
+    // Confirm that a quantity was created and its type is test2.
     $this->assertNotEmpty($storage['quantities'][0]->id());
+    $this->assertEquals('test2', $storage['quantities'][0]->bundle());
 
     // Confirm that three terms were created or loaded.
     $this->assertEquals(3, count($storage['terms']));

--- a/modules/log/activity/farm_activity.info.yml
+++ b/modules/log/activity/farm_activity.info.yml
@@ -5,3 +5,4 @@ package: farmOS Logs
 core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
+  - log:log

--- a/modules/log/harvest/farm_harvest.info.yml
+++ b/modules/log/harvest/farm_harvest.info.yml
@@ -5,3 +5,4 @@ package: farmOS Logs
 core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
+  - log:log

--- a/modules/log/input/config/install/log.type.input.yml
+++ b/modules/log/input/config/install/log.type.input.yml
@@ -6,6 +6,7 @@ dependencies:
       - farm_input
   module:
     - farm_log_quantity
+    - farm_quantity_material
 id: input
 label: Input
 description: ''

--- a/modules/log/input/farm_input.info.yml
+++ b/modules/log/input/farm_input.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
   - farm:farm_quantity_material
+  - log:log

--- a/modules/log/lab_test/farm_lab_test.info.yml
+++ b/modules/log/lab_test/farm_lab_test.info.yml
@@ -5,3 +5,4 @@ package: farmOS Logs
 core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
+  - log:log

--- a/modules/log/lab_test/farm_lab_test.post_update.php
+++ b/modules/log/lab_test/farm_lab_test.post_update.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the farm_lab_test module.
+ */
+
+/**
+ * Add "Date received" and "Date processed" fields to lab test logs.
+ */
+function farm_lab_test_post_update_add_received_processed_date_fields(&$sandbox) {
+
+  // Date received.
+  $options = [
+    'type' => 'timestamp',
+    'label' => t('Date received'),
+    'description' => t('The date when the sample was received by the lab.'),
+    'weight' => [
+      'form' => -35,
+      'view' => -35,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('lab_received_date', 'log', 'farm_lab_test', $field_definition);
+
+  // Date processed.
+  $options = [
+    'type' => 'timestamp',
+    'label' => t('Date processed'),
+    'description' => t('The date when the sample was processed by the lab.'),
+    'weight' => [
+      'form' => -34,
+      'view' => -34,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('lab_processed_date', 'log', 'farm_lab_test', $field_definition);
+}

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -20,18 +20,6 @@ class LabTest extends FarmLogType {
   public function buildFieldDefinitions() {
     $fields = parent::buildFieldDefinitions();
 
-    // Lab.
-    $options = [
-      'type' => 'string',
-      'label' => $this->t('Laboratory'),
-      'description' => $this->t('What laboratory performed this test?'),
-      'weight' => [
-        'form' => -40,
-        'view' => -40,
-      ],
-    ];
-    $fields['lab'] = $this->farmFieldFactory->bundleFieldDefinition($options);
-
     // Lab test type.
     $options = [
       'type' => 'list_string',
@@ -43,6 +31,18 @@ class LabTest extends FarmLogType {
       ],
     ];
     $fields['lab_test_type'] = $this->farmFieldFactory->bundleFieldDefinition($options);
+
+    // Lab.
+    $options = [
+      'type' => 'string',
+      'label' => $this->t('Laboratory'),
+      'description' => $this->t('What laboratory performed this test?'),
+      'weight' => [
+        'form' => -40,
+        'view' => -40,
+      ],
+    ];
+    $fields['lab'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -44,6 +44,30 @@ class LabTest extends FarmLogType {
     ];
     $fields['lab'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
+    // Date received.
+    $options = [
+      'type' => 'timestamp',
+      'label' => $this->t('Date received'),
+      'description' => $this->t('The date when the sample was received by the lab.'),
+      'weight' => [
+        'form' => -35,
+        'view' => -35,
+      ],
+    ];
+    $fields['lab_received_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
+
+    // Date processed.
+    $options = [
+      'type' => 'timestamp',
+      'label' => $this->t('Date processed'),
+      'description' => $this->t('The date when the sample was processed by the lab.'),
+      'weight' => [
+        'form' => -34,
+        'view' => -34,
+      ],
+    ];
+    $fields['lab_processed_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
+
     return $fields;
   }
 

--- a/modules/log/maintenance/farm_maintenance.info.yml
+++ b/modules/log/maintenance/farm_maintenance.info.yml
@@ -5,3 +5,4 @@ package: farmOS Logs
 core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
+  - log:log

--- a/modules/log/medical/farm_medical.info.yml
+++ b/modules/log/medical/farm_medical.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^9
 dependencies:
   - farm:farm_animal
   - farm:farm_entity
+  - log:log

--- a/modules/log/observation/farm_observation.info.yml
+++ b/modules/log/observation/farm_observation.info.yml
@@ -5,3 +5,4 @@ package: farmOS Logs
 core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
+  - log:log

--- a/modules/log/seeding/farm_seeding.info.yml
+++ b/modules/log/seeding/farm_seeding.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
   - farm:farm_plant
+  - log:log

--- a/modules/log/transplanting/farm_transplanting.info.yml
+++ b/modules/log/transplanting/farm_transplanting.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^9
 dependencies:
   - farm:farm_entity
   - farm:farm_plant
+  - log:log

--- a/modules/quantity/material/farm_quantity_material.info.yml
+++ b/modules/quantity/material/farm_quantity_material.info.yml
@@ -4,5 +4,6 @@ type: module
 package: farmOS Quantities
 core_version_requirement: ^9
 dependencies:
-  - farm:quantity
+  - farm:farm_entity
   - farm:farm_material_type
+  - farm:quantity

--- a/modules/quantity/standard/farm_quantity_standard.info.yml
+++ b/modules/quantity/standard/farm_quantity_standard.info.yml
@@ -4,4 +4,5 @@ type: module
 package: farmOS Quantities
 core_version_requirement: ^9
 dependencies:
+  - farm:farm_entity
   - farm:quantity


### PR DESCRIPTION
This adds two new optional fields to lab test logs, to represent when the lab received the sample, and when they processed it.

This comes out of the work we are doing with OpenTEAM to support importing soil test data in the Modus forum. Modus includes these fields and farmOS does not.