### PR TITLE
Fix update hook for converting lab to taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix update hook for converting lab to taxonomy #606](https://github.com/farmOS/farmOS/pull/606)
+
 ## [2.0.0-beta8] 2022-11-25
 
 This release fixes an issue with the input log migration from farmOS v1. If you

--- a/modules/log/lab_test/farm_lab_test.post_update.php
+++ b/modules/log/lab_test/farm_lab_test.post_update.php
@@ -64,11 +64,6 @@ function farm_lab_test_post_update_migrate_lab_terms(&$sandbox) {
     // Save it to $sandbox for future reference.
     $sandbox['log_map'] = \Drupal::database()->query('SELECT entity_id, lab_value FROM log__lab WHERE deleted = 0')->fetchAllKeyed(0);
 
-    // If there are no lab test logs, bail.
-    if (empty($sandbox['log_map'])) {
-      return NULL;
-    }
-
     // Create taxonomy terms for each of the labs.
     // Add them to a term map in $sandbox for future reference.
     $unique_labs = array_unique($sandbox['log_map']);
@@ -101,6 +96,11 @@ function farm_lab_test_post_update_migrate_lab_terms(&$sandbox) {
     ];
     $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
     $update_manager->installFieldStorageDefinition('lab', 'log', 'farm_lab_test', $field_definition);
+
+    // If there are no lab test logs with lab field values, bail.
+    if (empty($sandbox['log_map'])) {
+      return NULL;
+    }
 
     // Track progress.
     $sandbox['current_log'] = 0;


### PR DESCRIPTION
Yesterday's release of farmOS 2.0.0-beta8 included this PR: #603

There is a small issue in the `hook_post_update_NAME()` logic for this update, which leaves the "Lab" field on "Lab test" logs in a broken state.

This issue only affects sites that did NOT have any "Lab test" logs with the "Lab" field filled in, so no data loss occurs due to this issue.

The problem is that the update hook checks to see if there are any logs with lab field values, and it stops execution early if there are none. However, it does this before applying the updates to the field type itself, which means that the field remains as a `string` rather than being converted to an `entity_reference`. This results in the field becoming unusable, and Drupal reports the following message in status report:

> The _Laboratory_ field needs to be updated.

The fix for this is simple (update the field type before `return NULL`), so I'm going to merge this and tag a 2.0.0-beta8.1 quick fix release.