### PR TITLE
Explode drupal/core-dev require-dev dependency into the minimum packages we need.

### DIFF
--- a/composer.project.json
+++ b/composer.project.json
@@ -4,18 +4,22 @@
         "drupal/core-composer-scaffold": "9.4.8"
     },
     "require-dev": {
+        "behat/mink": "^1.10",
+        "behat/mink-selenium2-driver": "^1.6",
         "brianium/paratest": "^4",
-        "drupal/core-dev": "9.4.8",
+        "drupal/coder": "^8.3",
+        "friends-of-behat/mink-browserkit-driver": "^1.6",
         "mglaman/phpstan-drupal": "^1.1",
+        "mikey179/vfsstream": "^1.6",
         "phpstan/extension-installer": "^1.1",
         "phpcompatibility/php-compatibility": "^9",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-deprecation-rules": "^1.0",
+        "phpunit/phpunit": "^9",
         "phpspec/prophecy-phpunit": "^2",
-        "symfony/finder": "^4.0"
+        "symfony/phpunit-bridge": "^5.4"
     },
     "_comments": {
-        "symfony/finder": "Required to pin v4, otherwise composer-merge-plugin causes problem: package is fixed to v5.3.7 (lock file version) by a partial update",
         "phpspec/prophecy-phpunit": "Required to fix ProphecyTrait not found, until Drupal core drops support for PHPUnit 8. See https://www.drupal.org/node/3176567"
     },
     "conflict": {


### PR DESCRIPTION
The drupal/core-dev package is simply a shortcut for including dependencies necessary for running automated tests. See https://github.com/drupal/core-dev/blob/9.4.x/composer.json

It is designed specifically for running Drupal core automated tests. We used it as a simple way to get our automated tests running initially, but it includes some dependencies that we do not need.

It also pins some package versions, including symfony/finder and symfony/filesystem. This caused an issue for us when we refactored our composer.json files to use composer-merge-plugin. We got around this issue by pinning symfony/finder to ^4.

See https://www.drupal.org/project/farm/issues/3239420
See https://github.com/farmOS/farmOS/commit/bd33d0f139b67d291fa9a4bbf743173f323a767c

Furthermore, in testing Drush 11, I discovered that a similar conflict started occurring with symfony/filesystem (presumably because Drush depends on that as well now). I eventually managed to get it to work by pinning symfony/filesystem as well, but only if I moved both pins to the root farmOS composer.json (it didn't fix it if they were in composer.project.json). That is what ultimately drove me to dig into this and decide to split up our dependency on drupal/core-dev.

By removing the dependency on drupal/core-dev, we no longer have the issue with symfony/finder, so that pinned dependency can be removed.

I repeatedly ran tests with as few of the drupal/core-dev dependencies as possible until tests started passing again. So this final list represents the minimum requirements for our tests.