### PR TITLE
Correct hook_farm_update_exclude_config API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ soon as possible.
 
 - [Issue #3186530: farmOS 2.x PHP 8 support](https://www.drupal.org/project/farm/issues/3186530)
 
+### Fixed
+
+- [Correct hook_farm_update_exclude_config API docs #608](https://github.com/farmOS/farmOS/pull/608)
+
 ## [2.0.0-beta8.1] 2022-11-26
 
 ### Fixed

--- a/modules/core/update/farm_update.api.php
+++ b/modules/core/update/farm_update.api.php
@@ -22,8 +22,8 @@
  */
 function hook_farm_update_exclude_config() {
   return [
-    'views.view.farm_log.yml',
-    'asset.type.structure.yml',
+    'views.view.farm_log',
+    'asset.type.structure',
   ];
 }
 


### PR DESCRIPTION
The `.yml` is not needed here. This is already correct in the farmos.org development docs: https://farmos.org/development/module/updates/#hook_farm_update_exclude_config