### PR TITLE
Correct CSS classname for priority flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ soon as possible.
 
 - [Issue #3186530: farmOS 2.x PHP 8 support](https://www.drupal.org/project/farm/issues/3186530)
 
+### Fixed
+
+- [Correct CSS classname for priority flag #609](https://github.com/farmOS/farmOS/pull/609)
+
 ## [2.0.0-beta8.1] 2022-11-26
 
 ### Fixed

--- a/modules/core/ui/theme/css/flag.css
+++ b/modules/core/ui/theme/css/flag.css
@@ -28,7 +28,7 @@
   background-color: var(--colorGinPrimary);
   border-color: var(--colorGinPrimary);
 }
-.flag--monitor {
+.flag--priority {
   background-color: var(--colorGinDanger);
   border-color: var(--colorGinDanger);
 }

--- a/modules/core/ui/theme/css/flag.css
+++ b/modules/core/ui/theme/css/flag.css
@@ -24,15 +24,15 @@
   -webkit-appearance: none;
   -webkit-font-smoothing: antialiased;
 }
-.flag--monitor {
+.flag.flag--monitor {
   background-color: var(--colorGinPrimary);
   border-color: var(--colorGinPrimary);
 }
-.flag--priority {
+.flag.flag--priority {
   background-color: var(--colorGinDanger);
   border-color: var(--colorGinDanger);
 }
-.flag--review {
+.flag.flag--review {
   background-color: var(--colorGinWarning);
   border-color: var(--colorGinWarning);
 }


### PR DESCRIPTION
The `.flag--monitor` class was duplicated in our flag.css file! I believe one of these flags was supposed to be `.flag--priority`

Also included a commit to chain the flag specific class `.flag--priority` after the generic `.flag` class. This is a better pattern to follow and ensure that flags will receive their intended styles. This chaining was necessary for the farm_organic module to provide styles for its flags: https://git.drupalcode.org/project/farm_organic/-/merge_requests/1