### PR TITLE
Fix user admin permissions form alter for managed roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ soon as possible.
 
 - [Correct hook_farm_update_exclude_config API docs #608](https://github.com/farmOS/farmOS/pull/608)
 - [Correct CSS classname for priority flag #609](https://github.com/farmOS/farmOS/pull/609)
+- [Fix user admin permissions form alter for managed roles #610](https://github.com/farmOS/farmOS/pull/610)
 
 ## [2.0.0-beta8.1] 2022-11-26
 

--- a/modules/core/role/farm_role.module
+++ b/modules/core/role/farm_role.module
@@ -27,20 +27,16 @@ function farm_role_form_user_admin_permissions_alter(&$form, FormStateInterface 
   // Attach managed role CSS.
   $form['#attached']['library'][] = 'farm_role/managed_role';
 
-  // Save the role names.
-  $role_names = array_keys($form['role_names']['#value']);
-
   // Get the managed role permissions service.
   /** @var \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_manager */
   $managed_role_manager = \Drupal::service('plugin.manager.managed_role_permissions');
 
   // Save a list of managed role IDs keyed by their index in the form.
   $managed_roles = $managed_role_manager->getMangedRoles();
-  $managed_roles_indices = [];
-  foreach ($managed_roles as $role) {
-    $index = array_search($role->id(), $role_names);
-    $managed_roles_indices[$index] = $role->id();
-  }
+  $managed_roles_indices = array_intersect(
+    array_keys($form['role_names']['#value']),
+    array_keys($managed_roles)
+  );
 
   // Append '(managed)' to managed role labels in the table header.
   foreach ($managed_roles_indices as $index => $role) {


### PR DESCRIPTION
We have a form alter to check and disable checkboxes for managed roles on the role permissions page. This works for the form with all role permissions `admin/people/permissions` but doesn't work correctly on the individual role permissions page eg: `admin/people/permissions/anonymous`. Interestingly both of these forms use the same form ID `user_admin_permissions` which is why both forms are being altered.

On the individual role permissions page it states that *all* roles are "managed" and does not check or disable the permission checkboxes as it should. This happens because the `array_search($role->id(), $role_names)` returns `FALSE` when a role ID is not found and the 0 index is used in the `$managed_role_indices` array.

Fixing the index calculation solves the issue and all this logic continues to work on both permission forms :rocket: 

![Screenshot from 2022-11-29 11-30-31](https://user-images.githubusercontent.com/3116995/204632599-c8115f2b-9837-44c9-9647-e277140d1e72.png)

![Screenshot from 2022-11-29 11-46-21](https://user-images.githubusercontent.com/3116995/204632965-612c072d-51f0-44d7-aca2-2f5dc8f063b7.png)