### PR TITLE
Fix migration of lab field to taxonomy terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ soon as possible.
 - [Correct hook_farm_update_exclude_config API docs #608](https://github.com/farmOS/farmOS/pull/608)
 - [Correct CSS classname for priority flag #609](https://github.com/farmOS/farmOS/pull/609)
 - [Fix user admin permissions form alter for managed roles #610](https://github.com/farmOS/farmOS/pull/610)
+- [Fix migration of lab field to taxonomy terms #611](https://github.com/farmOS/farmOS/pull/611)
 
 ## [2.0.0-beta8.1] 2022-11-26
 

--- a/modules/core/migrate/config/optional/migrate_plus.migration.farm_migrate_log_lab_test.yml
+++ b/modules/core/migrate/config/optional/migrate_plus.migration.farm_migrate_log_lab_test.yml
@@ -36,7 +36,17 @@ process:
     source: '@_log_quantities'
   # Lab test specific fields.
   lab:
-    plugin: get_lab
+    -
+      plugin: get_lab
+    -
+      plugin: skip_on_empty
+      method: process
+    -
+      plugin: entity_generate
+      value_key: name
+      entity_type: taxonomy_term
+      bundle_key: vid
+      bundle: lab
   lab_test_type:
     plugin: static_map
     source: type

--- a/modules/core/migrate/src/Plugin/migrate/process/FarmMigrateGetLab.php
+++ b/modules/core/migrate/src/Plugin/migrate/process/FarmMigrateGetLab.php
@@ -29,11 +29,10 @@ class FarmMigrateGetLab extends ProcessPluginBase {
     }
 
     // If a lab was found, return it.
-    $return = [];
-    if (!empty($lab)) {
-      $return[] = $lab;
+    if (!empty($lab[0]['value'])) {
+      return $lab[0]['value'];
     }
-    return $return;
+    return '';
   }
 
 }


### PR DESCRIPTION
PR #603 changed the "Laboratory" field from a simple text field to a taxonomy term reference field. But it did not update the v1 migration logic accordingly.

See https://github.com/farmOS/farmOS/pull/603