### PR TITLE
Remove default_measure configuration from quantity type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ soon as possible.
 
 - [Issue #3186530: farmOS 2.x PHP 8 support](https://www.drupal.org/project/farm/issues/3186530)
 
+### Changed
+
+- [Remove default_measure configuration from quantity type definitions #612](https://github.com/farmOS/farmOS/pull/612)
+
 ### Fixed
 
 - [Correct hook_farm_update_exclude_config API docs #608](https://github.com/farmOS/farmOS/pull/608)

--- a/modules/core/inventory/tests/modules/farm_inventory_test/config/install/quantity.type.test.yml
+++ b/modules/core/inventory/tests/modules/farm_inventory_test/config/install/quantity.type.test.yml
@@ -6,6 +6,5 @@ dependencies:
       - farm_inventory_test
 id: test
 label: Test
-default_measure: ''
 description: 'Test quantity type.'
 new_revision: true

--- a/modules/core/quantity/config/schema/quantity.schema.yml
+++ b/modules/core/quantity/config/schema/quantity.schema.yml
@@ -18,9 +18,6 @@ quantity.type.*:
     description:
       type: text
       label: 'Description'
-    default_measure:
-      type: string
-      label: 'Default quantity measure'
     new_revision:
       type: boolean
       label: 'Create new revision'

--- a/modules/core/quantity/quantity.module
+++ b/modules/core/quantity/quantity.module
@@ -6,7 +6,6 @@
  */
 
 use Drupal\Core\Entity\ContentEntityInterface;
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Render\Element;
 use Drupal\quantity\Entity\QuantityInterface;
@@ -103,36 +102,6 @@ function quantity_measure_options() {
  */
 function quantity_measure_field_allowed_values(FieldStorageDefinitionInterface $definition, ContentEntityInterface $entity = NULL, bool &$cacheable = TRUE) {
   return quantity_measure_options();
-}
-
-/**
- * Sets the default value for the quantity measure field.
- *
- * @param \Drupal\Core\Entity\ContentEntityInterface $entity
- *   The entity being created.
- * @param \Drupal\Core\Field\FieldDefinitionInterface $definition
- *   The field definition.
- *
- * @return array
- *   An array of default value keys with each entry keyed with the “value” key.
- *
- * @see \Drupal\Core\Field\FieldConfigBase::getDefaultValue()
- */
-function quantity_measure_default_value(ContentEntityInterface $entity, FieldDefinitionInterface $definition): array {
-
-  // Defaults to an empty array.
-  $default = [];
-
-  // Get the quantity type default measure.
-  /** @var \Drupal\quantity\Entity\QuantityTypeInterface $quantity_type */
-  $quantity_type = $entity->get('type')->entity;
-  $measure = $quantity_type->getDefaultMeasure();
-
-  // Only use the measure if not empty.
-  if (!empty($measure)) {
-    $default[] = ['value' => $measure];
-  }
-  return $default;
 }
 
 /**

--- a/modules/core/quantity/src/Entity/Quantity.php
+++ b/modules/core/quantity/src/Entity/Quantity.php
@@ -135,7 +135,6 @@ class Quantity extends RevisionableContentEntityBase implements QuantityInterfac
       ->setLabel(t('Measure'))
       ->setDescription(t('The measure of the quantity.'))
       ->setRevisionable(TRUE)
-      ->setDefaultValueCallback('quantity_measure_default_value')
       ->setSettings([
         'allowed_values_function' => 'quantity_measure_field_allowed_values',
       ])

--- a/modules/core/quantity/src/Entity/QuantityType.php
+++ b/modules/core/quantity/src/Entity/QuantityType.php
@@ -31,7 +31,6 @@ use Drupal\Core\Config\Entity\ConfigEntityBundleBase;
  *     "id",
  *     "label",
  *     "description",
- *     "default_measure",
  *     "new_revision",
  *   }
  * )
@@ -60,13 +59,6 @@ class QuantityType extends ConfigEntityBundleBase implements QuantityTypeInterfa
   protected $description;
 
   /**
-   * The default measure of this quantity type.
-   *
-   * @var string|null
-   */
-  protected $default_measure;
-
-  /**
    * Default value of the 'Create new revision' checkbox of the quantity type.
    *
    * @var bool
@@ -85,13 +77,6 @@ class QuantityType extends ConfigEntityBundleBase implements QuantityTypeInterfa
    */
   public function setDescription($description) {
     return $this->set('description', $description);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getDefaultMeasure() {
-    return $this->default_measure;
   }
 
   /**

--- a/modules/core/quantity/src/Entity/QuantityTypeInterface.php
+++ b/modules/core/quantity/src/Entity/QuantityTypeInterface.php
@@ -11,12 +11,4 @@ use Drupal\Core\Entity\RevisionableEntityBundleInterface;
  */
 interface QuantityTypeInterface extends ConfigEntityInterface, EntityDescriptionInterface, RevisionableEntityBundleInterface {
 
-  /**
-   * Get the quantity type's default measure.
-   *
-   * @return string
-   *   The default measure, or null if none is specified.
-   */
-  public function getDefaultMeasure();
-
 }

--- a/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test.yml
+++ b/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test.yml
@@ -6,6 +6,5 @@ dependencies:
       - farm_quick_test
 id: test
 label: Test
-default_measure: ''
 description: 'Test quantity type.'
 new_revision: true

--- a/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test2.yml
+++ b/modules/core/quick/tests/modules/farm_quick_test/config/install/quantity.type.test2.yml
@@ -6,6 +6,5 @@ dependencies:
       - farm_quick_test
 id: test2
 label: Test2
-default_measure: ''
 description: 'Test2 quantity type.'
 new_revision: true

--- a/modules/quantity/material/config/install/quantity.type.material.yml
+++ b/modules/quantity/material/config/install/quantity.type.material.yml
@@ -6,6 +6,5 @@ dependencies:
       - farm_quantity_material
 id: material
 label: Material
-default_measure: ''
 description: 'Material quantity type.'
 new_revision: true

--- a/modules/quantity/standard/config/install/quantity.type.standard.yml
+++ b/modules/quantity/standard/config/install/quantity.type.standard.yml
@@ -6,6 +6,5 @@ dependencies:
       - farm_quantity_standard
 id: standard
 label: Standard
-default_measure: ''
 description: 'Standard quantity type.'
 new_revision: true

--- a/modules/quantity/test/config/install/quantity.type.test.yml
+++ b/modules/quantity/test/config/install/quantity.type.test.yml
@@ -6,6 +6,5 @@ dependencies:
       - farm_quantity_test
 id: test
 label: Test
-default_measure: ''
 description: 'Test measurement quantity type.'
 new_revision: true


### PR DESCRIPTION
This was originally added so that the Price quantity type could set its default measure to "value" all the time. This was back when price quantities were part of farmOS core. It was then moved to the farm_ledger contrib module, and is being refactored such that it will no longer need to make use of this default_measure configuration.