### PR TITLE
Include GEOS version in status report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ soon as possible.
 ### Added
 
 - [Issue #3186530: farmOS 2.x PHP 8 support](https://www.drupal.org/project/farm/issues/3186530)
+- [Include GEOS version in status report #614](https://github.com/farmOS/farmOS/pull/614)
 
 ### Changed
 

--- a/modules/core/geo/farm_geo.install
+++ b/modules/core/geo/farm_geo.install
@@ -20,7 +20,8 @@ function farm_geo_requirements($phase) {
   // Check for php-geos extension.
   if (geoPHP::geosInstalled()) {
     $severity = REQUIREMENT_OK;
-    $message = t('GEOS PHP extension installed');
+    // phpcs:ignore Squiz.PHP.LowercasePHPFunctions.CallUppercase -- GEOSVersion() function is defined in php-geos.
+    $message = t('GEOS PHP extension installed. GEOS version @version', ['@version' => GEOSVersion()]);
   }
   else {
     $severity = REQUIREMENT_WARNING;


### PR DESCRIPTION
I've been working on getting both my local and a few production environments up to PHP 8.0+. In the process I revisited the PHP-GEOS extension and libgeos "GEOS" requirements.

I noticed in my local environment the docker container ends up with GEOS 3.9.0. While the production environment on platformsh was failing to build PHP-GEOS with GEOS 3.11.1. The fix was to use GEOS 3.11.0 in the production environment. I'm not sure why this wasn't working.. but that is kinda beside the point.

In my debugging process it would have been convenient if the GEOS version was available right in the status report. It is currently available in the PHP info. Many other status report items include the relevant version

This `GEOSVersion()` function is included in php-geos here: https://github.com/libgeos/php-geos/blob/master/geos.c#L44

![Screenshot from 2022-12-05 16-42-31](https://user-images.githubusercontent.com/3116995/205785116-0c9a2f02-aafc-45a1-b909-42cb7957be11.png)
![Screenshot from 2022-12-05 16-42-02](https://user-images.githubusercontent.com/3116995/205785119-7edac7bf-acec-4278-805e-e3e31125774c.png)
