### PR TITLE
Fix enable/disable buttons on data stream notifications page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ soon as possible.
 - [Fix user admin permissions form alter for managed roles #610](https://github.com/farmOS/farmOS/pull/610)
 - [Fix migration of lab field to taxonomy terms #611](https://github.com/farmOS/farmOS/pull/611)
 - [Fix TypeError when adding email delivery #616](https://github.com/farmOS/farmOS/pull/616)
+- [Fix enable/disable buttons on data stream notifications page #613](https://github.com/farmOS/farmOS/pull/613)
 
 ## [2.0.0-beta8.1] 2022-11-26
 

--- a/modules/core/data_stream/modules/notification/data_stream_notification.routing.yml
+++ b/modules/core/data_stream/modules/notification/data_stream_notification.routing.yml
@@ -4,7 +4,7 @@ entity.data_stream_notification.enable:
     _controller: '\Drupal\data_stream_notification\Controller\NotificationUIController::ajaxOperation'
     op: enable
   requirements:
-    _entity_access: data_stream_notification.edit
+    _entity_access: data_stream_notification.update
     _csrf_token: 'TRUE'
 
 entity.data_stream_notification.disable:
@@ -13,5 +13,5 @@ entity.data_stream_notification.disable:
     _controller: '\Drupal\data_stream_notification\Controller\NotificationUIController::ajaxOperation'
     op: disable
   requirements:
-    _entity_access: data_stream_notification.edit
+    _entity_access: data_stream_notification.update
     _csrf_token: 'TRUE'


### PR DESCRIPTION
Closes #613 

The correct `entity_access` permission operation is `update` not `edit`