### PR TITLE
TypeError when adding email delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ soon as possible.
 - [Correct CSS classname for priority flag #609](https://github.com/farmOS/farmOS/pull/609)
 - [Fix user admin permissions form alter for managed roles #610](https://github.com/farmOS/farmOS/pull/610)
 - [Fix migration of lab field to taxonomy terms #611](https://github.com/farmOS/farmOS/pull/611)
+- [Fix TypeError when adding email delivery #616](https://github.com/farmOS/farmOS/pull/616)
 
 ## [2.0.0-beta8.1] 2022-11-26
 

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
@@ -77,7 +77,7 @@ class Email extends NotificationDeliveryBase implements ContainerFactoryPluginIn
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
 
     // Convert array of emails into a single text area.
-    $emails = $this->configuration['email'];
+    $emails = $this->configuration['email'] ?? [];
     $default = implode(PHP_EOL, $emails);
     $form['email'] = [
       '#type' => 'textarea',


### PR DESCRIPTION
When adding an email delivery to a data stream notification I'm receiving the following errors. The second error prevents from adding an email delivery and creating the notification:

> Warning: Undefined array key "email" in Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\Email->buildConfigurationForm() (line 80 of /var/www/html/web/profiles/farm/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php)

> TypeError: implode(): Argument #1 ($pieces) must be of type array, string given in implode() (line 81 of /var/www/html/web/profiles/farm/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php)

Earlier when testing #613 on a Tugboat demo site w/PHP 7.4 I did not encounter this error. It seems that this is new behavior for internal functions in PHP 8: https://php.watch/versions/8.0/internal-function-exceptions