### PR TITLE
Shorten name of tests and delivery workflow

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -1,4 +1,4 @@
-name: Run tests and delivery workflow
+name: Tests and delivery
 on:
   schedule:
     - cron: '0 8 * * *' # Run at 8AM UTC.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ soon as possible.
 ### Changed
 
 - [Remove default_measure configuration from quantity type definitions #612](https://github.com/farmOS/farmOS/pull/612)
+- [Shorten name of tests and delivery workflow #617](https://github.com/farmOS/farmOS/pull/617)
 
 ### Fixed
 


### PR DESCRIPTION
This should make it easier to read the results of individual jobs in this workflow. See screenshot. With a shorter workflow name the individual job names should appear without being cut off :-)

![Screenshot from 2022-12-06 10-06-02](https://user-images.githubusercontent.com/3116995/205991415-11a77ca0-b2f3-4b81-b7db-9dab2b7d4dea.png)
