### PR TITLE
Only show the first quantity in log Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ soon as possible.
 
 - [Remove default_measure configuration from quantity type definitions #612](https://github.com/farmOS/farmOS/pull/612)
 - [Shorten name of tests and delivery workflow #617](https://github.com/farmOS/farmOS/pull/617)
+- [Only show the first quantity in log Views #619](https://github.com/farmOS/farmOS/pull/619)
 
 ### Fixed
 

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -543,7 +543,7 @@ display:
           group_column: ''
           group_columns: {  }
           group_rows: true
-          delta_limit: 0
+          delta_limit: 1
           delta_offset: 0
           delta_reversed: false
           delta_first_last: false


### PR DESCRIPTION
This is a very simple change to resolve the issue illustrated in this comment: https://github.com/farmOS/farmOS/issues/497#issuecomment-1240706646

We discussed more elaborate potential fixes for this, but in the interest of getting *something* done before 2.0.0 stable I propose we take this initial small step and open up a follow-up if there is desire.

Another benefit of this is that it will improve performance in lists of logs that have lots of quantities associated with them, by only loading one quantity for each log.