### PR TITLE
Update Drupal core to 9.5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Update Drupal core to 9.5.x](https://github.com/farmOS/farmOS/pull/621)
+
 ## [2.0.0-rc1] 2022-12-15
 
 PHP 8+ is now the recommended minimum version requirement for farmOS. The

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-12-09/2339235-9.3.x-76.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
-                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2021-09-13/drupal-2909128.patch"
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2022-12-16/drupal-2909128-9.5.x-74.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.2",
-        "drupal/core": "9.4.9",
+        "drupal/core": "9.5.0",
         "drupal/config_update": "^1.7",
         "drupal/consumers": "^1.15",
         "drupal/csv_serialization": "^2.0",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "9.4.9"
+        "drupal/core-composer-scaffold": "9.5.0"
     },
     "require-dev": {
         "behat/mink": "^1.10",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Inherit from the Drupal 9 image on Docker Hub.
-FROM drupal:9.4
+FROM drupal:9.5
 
 # Set the farmOS and composer project repository URLs and versions.
 ARG FARMOS_REPO=https://github.com/farmOS/farmOS.git


### PR DESCRIPTION
Drupal 9.5.0 was released yesterday: https://www.drupal.org/project/drupal/releases/9.5.0

> This is the **final minor version (feature release) of Drupal 9** and is ready for use on production sites.