### PR TITLE
Remove line breaks and whitespace from log CSV quantity cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Prevent circular asset location #568](https://github.com/farmOS/farmOS/pull/568)
 - [Prevent circular group membership #562](https://github.com/farmOS/farmOS/pull/562)
 - [Issue #3328419: Uninstalling farm_ui_views module breaks site](https://www.drupal.org/project/farm/issues/3328419)
+- [Remove line breaks and whitespace from log CSV quantity cells #622](https://github.com/farmOS/farmOS/pull/622)
 
 ## [2.0.0-rc1] 2022-12-15
 

--- a/modules/core/quantity/config/install/core.entity_view_mode.quantity.plain_text.yml
+++ b/modules/core/quantity/config/install/core.entity_view_mode.quantity.plain_text.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - quantity
+  module:
+    - quantity
+id: quantity.plain_text
+label: Plain text
+targetEntityType: quantity
+cache: false

--- a/modules/core/quantity/quantity.post_update.php
+++ b/modules/core/quantity/quantity.post_update.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the quantity module.
+ */
+
+use Drupal\Core\Entity\Entity\EntityViewMode;
+
+/**
+ * Create plain text view mode for quantities.
+ */
+function quantity_post_update_plain_text_view_mode(&$sandbox) {
+  $view_mode = EntityViewMode::create([
+    'id' => 'quantity.plain_text',
+    'label' => 'Plain text',
+    'targetEntityType' => 'quantity',
+    'cache' => FALSE,
+    'dependencies' => [
+      'enforced' => [
+        'module' => [
+          'quantity',
+        ],
+      ],
+      'module' => [
+        'quantity',
+      ],
+    ],
+  ]);
+  $view_mode->save();
+}

--- a/modules/core/quantity/src/Entity/Quantity.php
+++ b/modules/core/quantity/src/Entity/Quantity.php
@@ -30,7 +30,7 @@ use Drupal\user\EntityOwnerTrait;
  *     "inline_form" = "\Drupal\quantity\Form\QuantityInlineForm",
  *     "list_builder" = "\Drupal\quantity\QuantityListBuilder",
  *     "permission_provider" = "\Drupal\entity\UncacheableEntityPermissionProvider",
- *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
+ *     "view_builder" = "Drupal\quantity\QuantityViewBuilder",
  *     "views_data" = "Drupal\quantity\QuantityViewsData",
  *     "form" = {
  *       "default" = "Drupal\Core\Entity\ContentEntityForm",

--- a/modules/core/quantity/src/QuantityViewBuilder.php
+++ b/modules/core/quantity/src/QuantityViewBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\quantity;
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityViewBuilder;
+use Drupal\Core\Security\TrustedCallbackInterface;
+
+/**
+ * Quantity entity view builder.
+ */
+class QuantityViewBuilder extends EntityViewBuilder implements TrustedCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function view(EntityInterface $entity, $view_mode = 'full', $langcode = NULL) {
+    $build = parent::view($entity, $view_mode, $langcode);
+
+    // If the view mode is plain_text, add a post render callback to strip tags
+    // and whitespace.
+    if ($view_mode == 'plain_text') {
+      $build['#post_render'][] = [$this, 'plainText'];
+    }
+
+    return $build;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return array_merge(parent::trustedCallbacks(), ['plainText']);
+  }
+
+  /**
+   * Strips HTML, newlines, and whitespace from rendered entity.
+   *
+   * @param string $value
+   *   A string of rendered content for the Quantity entity.
+   *
+   * @return string
+   *   The updated content.
+   */
+  public static function plainText(string $value) {
+    $value = Html::decodeEntities($value);
+    $value = strip_tags($value);
+    $value = trim($value);
+    $value = preg_replace('/\s+/', ' ', $value);
+    return $value;
+  }
+
+}

--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -67,6 +67,12 @@ function farm_ui_views_views_pre_view(ViewExecutable $view, $display_id, array &
     }
   }
 
+  // If this is a log "CSV export" display, set the Quantity view mode to
+  // "Plain text" to strip out tags and whitespace.
+  if ($view->id() == 'farm_log' && $display_id == 'csv') {
+    $view->setHandlerOption('csv', 'field', 'quantity_target_id', 'settings', ['view_mode' => 'plain_text']);
+  }
+
   // Remove the asset and location filters from the log page_asset display.
   // @todo Make the AssetOrLocationArgument compatible with these filters.
   if ($view->id() == 'farm_log' && $display_id == 'page_asset') {


### PR DESCRIPTION
Fixes https://github.com/farmOS/farmOS/issues/497

I took the approach described in this comment: https://www.drupal.org/project/csv_serialization/issues/2914214#comment-12575679

I decided to add this to a new `farm_csv` module, similar to our existing `farm_kml` module. This module uses a `ServiceModifierInterface` class to override the class used for the CSV encoder provided by `csv_serialization` with our own `FarmCsvEncoder`, which extends from the original and simply performs some extra formatting via the `formatValue()` method.