### PR TITLE
Change asset action date pickers to use HTML5 calendar widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Move land and structure type fields higher up for consistency #632](https://github.com/farmOS/farmOS/pull/632)
+- [Change asset action date pickers to use HTML5 calendar widgets #630](https://github.com/farmOS/farmOS/pull/630)
 
 ### Fixed
 

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -135,12 +135,11 @@ class AssetGroupActionForm extends ConfirmFormBase {
         ->toString());
     }
 
+    $date = new DrupalDateTime();
     $form['date'] = [
-      '#type' => 'datelist',
+      '#type' => 'date',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime(),
-      '#date_part_order' => ['year', 'month', 'day'],
-      '#date_year_range' => '-15:+15',
+      '#default_value' => date('Y-m-d', $date->getTimestamp()),
       '#required' => TRUE,
     ];
 
@@ -197,8 +196,6 @@ class AssetGroupActionForm extends ConfirmFormBase {
         $groups = $this->entityTypeManager->getStorage('asset')->loadMultiple($group_ids);
       }
 
-      /** @var \Drupal\Core\Datetime\DrupalDateTime $date */
-      $date = $form_state->getValue('date');
       $done = (bool) $form_state->getValue('done', FALSE);
 
       // Generate a name for the log.
@@ -210,7 +207,7 @@ class AssetGroupActionForm extends ConfirmFormBase {
       $log = Log::create([
         'name' => $log_name,
         'type' => 'observation',
-        'timestamp' => $date->getTimestamp(),
+        'timestamp' => strtotime($form_state->getValue('date')),
         'asset' => $accessible_entities,
         'is_group_assignment' => TRUE,
         'group' => $groups,

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -166,12 +166,11 @@ class AssetMoveActionForm extends ConfirmFormBase {
         ->toString());
     }
 
+    $date = new DrupalDateTime();
     $form['date'] = [
-      '#type' => 'datelist',
+      '#type' => 'date',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime(),
-      '#date_part_order' => ['year', 'month', 'day'],
-      '#date_year_range' => '-15:+15',
+      '#default_value' => date('Y-m-d', $date->getTimestamp()),
       '#required' => TRUE,
     ];
 
@@ -227,8 +226,6 @@ class AssetMoveActionForm extends ConfirmFormBase {
         $locations = $this->entityTypeManager->getStorage('asset')->loadMultiple($location_ids);
       }
 
-      /** @var \Drupal\Core\Datetime\DrupalDateTime $date */
-      $date = $form_state->getValue('date');
       $done = (bool) $form_state->getValue('done', FALSE);
 
       // Generate a name for the log.
@@ -240,7 +237,7 @@ class AssetMoveActionForm extends ConfirmFormBase {
       $log = Log::create([
         'name' => $log_name,
         'type' => 'activity',
-        'timestamp' => $date->getTimestamp(),
+        'timestamp' => strtotime($form_state->getValue('date')),
         'asset' => $accessible_entities,
         'is_movement' => TRUE,
         'location' => $locations,


### PR DESCRIPTION
Fixes #509 - this changes the date picker in the "move asset" and "group asset" panels to use the calendar selector widget from the browser.  This makes these panels more consistent with date selection in other areas of the UI.