### PR TITLE
Fix type error when un-assigning asset from group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Add folder creation and clear caches to Configure private filesystem in the Hosting and Environment docs #628](https://github.com/farmOS/farmOS/pull/628)
 - [Issue #3336698: Add "project: farm" to farm.info.yml to fix drupal.org usage statistics](https://www.drupal.org/project/farm/issues/3336698)
+- [Fix type error when un-assigning asset from group #631](https://github.com/farmOS/farmOS/pull/631)
 
 ## [2.0.0] 2023-01-01
 

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -192,7 +192,7 @@ class AssetGroupActionForm extends ConfirmFormBase {
 
       // Load group assets.
       $groups = [];
-      $group_ids = array_column($form_state->getValue('group', []), 'target_id');
+      $group_ids = array_column($form_state->getValue('group', []) ?? [], 'target_id');
       if (!empty($group_ids)) {
         $groups = $this->entityTypeManager->getStorage('asset')->loadMultiple($group_ids);
       }


### PR DESCRIPTION
Submitting the group asset action form without a group yields the following error:

> Message TypeError: array_column(): Argument 1 ($array) must be of type array, null given in array_column() (line 195 of /var/www/html/web/profiles/farm/modules/asset/group/src/Form/AssetGroupActionForm.php)

One fix is to use the null coalescing operator to return an empty array when the form value is null.

We made this change in the move action form as well: https://github.com/farmOS/farmOS/commit/6d13a732d704c0312f4106871948af724ed4931d