### PR TITLE
Move land and structure type fields higher up for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Move land and structure type fields higher up for consistency #632](https://github.com/farmOS/farmOS/pull/632)
+
 ### Fixed
 
 - [Add folder creation and clear caches to Configure private filesystem in the Hosting and Environment docs #628](https://github.com/farmOS/farmOS/pull/628)

--- a/modules/asset/land/src/Plugin/Asset/AssetType/Land.php
+++ b/modules/asset/land/src/Plugin/Asset/AssetType/Land.php
@@ -27,7 +27,7 @@ class Land extends FarmAssetType {
       'allowed_values_function' => 'farm_land_type_field_allowed_values',
       'required' => TRUE,
       'weight' => [
-        'form' => -50,
+        'form' => -90,
         'view' => -50,
       ],
     ];

--- a/modules/asset/structure/src/Plugin/Asset/AssetType/Structure.php
+++ b/modules/asset/structure/src/Plugin/Asset/AssetType/Structure.php
@@ -27,7 +27,7 @@ class Structure extends FarmAssetType {
       'allowed_values_function' => 'farm_structure_type_field_allowed_values',
       'required' => TRUE,
       'weight' => [
-        'form' => -50,
+        'form' => -90,
         'view' => -50,
       ],
     ];


### PR DESCRIPTION
Currently the land and structure type field come after status, flags and owners. This is different than animal and plant assets whose type field comes immediately after the asset name. Since the land and structure type are required fields it seems more appropriate to have them included higher in the form.