### PR TITLE
Allow setting time in bulk actions and quick forms via datetime element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Move land and structure type fields higher up for consistency #632](https://github.com/farmOS/farmOS/pull/632)
+- [Change asset action date pickers to use HTML5 calendar widgets #630](https://github.com/farmOS/farmOS/pull/630)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Move land and structure type fields higher up for consistency #632](https://github.com/farmOS/farmOS/pull/632)
 - [Change asset action date pickers to use HTML5 calendar widgets #630](https://github.com/farmOS/farmOS/pull/630)
+- [Allow setting time in bulk actions and quick forms via datetime element #635](https://github.com/farmOS/farmOS/pull/635)
 
 ### Fixed
 

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -135,11 +135,10 @@ class AssetGroupActionForm extends ConfirmFormBase {
         ->toString());
     }
 
-    $date = new DrupalDateTime();
     $form['date'] = [
-      '#type' => 'date',
+      '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => date('Y-m-d', $date->getTimestamp()),
+      '#default_value' => new DrupalDateTime('midnight'),
       '#required' => TRUE,
     ];
 
@@ -207,7 +206,7 @@ class AssetGroupActionForm extends ConfirmFormBase {
       $log = Log::create([
         'name' => $log_name,
         'type' => 'observation',
-        'timestamp' => strtotime($form_state->getValue('date')),
+        'timestamp' => $form_state->getValue('date')->getTimestamp(),
         'asset' => $accessible_entities,
         'is_group_assignment' => TRUE,
         'group' => $groups,

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -135,12 +135,11 @@ class AssetGroupActionForm extends ConfirmFormBase {
         ->toString());
     }
 
+    $date = new DrupalDateTime();
     $form['date'] = [
-      '#type' => 'datelist',
+      '#type' => 'date',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime(),
-      '#date_part_order' => ['year', 'month', 'day'],
-      '#date_year_range' => '-15:+15',
+      '#default_value' => date('Y-m-d', $date->getTimestamp()),
       '#required' => TRUE,
     ];
 
@@ -197,8 +196,6 @@ class AssetGroupActionForm extends ConfirmFormBase {
         $groups = $this->entityTypeManager->getStorage('asset')->loadMultiple($group_ids);
       }
 
-      /** @var \Drupal\Core\Datetime\DrupalDateTime $date */
-      $date = $form_state->getValue('date');
       $done = (bool) $form_state->getValue('done', FALSE);
 
       // Generate a name for the log.
@@ -210,7 +207,7 @@ class AssetGroupActionForm extends ConfirmFormBase {
       $log = Log::create([
         'name' => $log_name,
         'type' => 'observation',
-        'timestamp' => $date->getTimestamp(),
+        'timestamp' => strtotime($form_state->getValue('date')),
         'asset' => $accessible_entities,
         'is_group_assignment' => TRUE,
         'group' => $groups,

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -166,11 +166,10 @@ class AssetMoveActionForm extends ConfirmFormBase {
         ->toString());
     }
 
-    $date = new DrupalDateTime();
     $form['date'] = [
-      '#type' => 'date',
+      '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => date('Y-m-d', $date->getTimestamp()),
+      '#default_value' => new DrupalDateTime('midnight'),
       '#required' => TRUE,
     ];
 
@@ -237,7 +236,7 @@ class AssetMoveActionForm extends ConfirmFormBase {
       $log = Log::create([
         'name' => $log_name,
         'type' => 'activity',
-        'timestamp' => strtotime($form_state->getValue('date')),
+        'timestamp' => $form_state->getValue('date')->getTimestamp(),
         'asset' => $accessible_entities,
         'is_movement' => TRUE,
         'location' => $locations,

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -166,12 +166,11 @@ class AssetMoveActionForm extends ConfirmFormBase {
         ->toString());
     }
 
+    $date = new DrupalDateTime();
     $form['date'] = [
-      '#type' => 'datelist',
+      '#type' => 'date',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime(),
-      '#date_part_order' => ['year', 'month', 'day'],
-      '#date_year_range' => '-15:+15',
+      '#default_value' => date('Y-m-d', $date->getTimestamp()),
       '#required' => TRUE,
     ];
 
@@ -227,8 +226,6 @@ class AssetMoveActionForm extends ConfirmFormBase {
         $locations = $this->entityTypeManager->getStorage('asset')->loadMultiple($location_ids);
       }
 
-      /** @var \Drupal\Core\Datetime\DrupalDateTime $date */
-      $date = $form_state->getValue('date');
       $done = (bool) $form_state->getValue('done', FALSE);
 
       // Generate a name for the log.
@@ -240,7 +237,7 @@ class AssetMoveActionForm extends ConfirmFormBase {
       $log = Log::create([
         'name' => $log_name,
         'type' => 'activity',
-        'timestamp' => $date->getTimestamp(),
+        'timestamp' => strtotime($form_state->getValue('date')),
         'asset' => $accessible_entities,
         'is_movement' => TRUE,
         'location' => $locations,

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -3,6 +3,7 @@
 namespace Drupal\farm_quick_planting\Plugin\QuickForm;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -339,9 +340,9 @@ class Planting extends QuickFormBase {
     // Create log fields.
     $field_info = [
       'date' => [
-        '#type' => 'date',
+        '#type' => 'datetime',
         '#title' => $this->t('Date'),
-        '#default_value' => date('Y-m-d', $this->time->getRequestTime()),
+        '#default_value' => new DrupalDateTime('midnight'),
         '#required' => TRUE,
       ],
       'done' => [
@@ -554,7 +555,7 @@ class Planting extends QuickFormBase {
       $this->createLog([
         'type' => $log_type,
         'name' => $log_name,
-        'timestamp' => strtotime($log_values['date']),
+        'timestamp' => $log_values['date']->getTimestamp(),
         'asset' => $plant_asset,
         'quantity' => [$this->prepareQuantity($log_values['quantity'])],
         'location' => $log_values['location'] ?? NULL,

--- a/modules/quick/planting/tests/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/Kernel/QuickPlantingTest.php
@@ -100,6 +100,7 @@ class QuickPlantingTest extends KernelTestBase {
       'farm_quantity_standard',
       'farm_seeding',
       'farm_transplanting',
+      'system',
     ]);
   }
 
@@ -240,7 +241,10 @@ class QuickPlantingTest extends KernelTestBase {
       ],
       'seeding' => [
         'type' => 'seeding',
-        'date' => '2022-05-15',
+        'date' => [
+          'date' => '2022-05-15',
+          'time' => '00:00:00',
+        ],
         'location' => $land1->label(),
         'quantity' => [
           'measure' => 'weight',
@@ -292,21 +296,30 @@ class QuickPlantingTest extends KernelTestBase {
       ],
       'seeding' => [
         'type' => 'seeding',
-        'date' => '2022-05-15',
+        'date' => [
+          'date' => '2022-05-15',
+          'time' => '00:00:00',
+        ],
         'location' => $land1->label(),
         'notes' => [],
         'done' => TRUE,
       ],
       'transplanting' => [
         'type' => 'transplanting',
-        'date' => '2022-06-15',
+        'date' => [
+          'date' => '2022-06-15',
+          'time' => '00:00:00',
+        ],
         'location' => $land2->label(),
         'notes' => [],
         'done' => FALSE,
       ],
       'harvest' => [
         'type' => 'harvest',
-        'date' => '2022-07-15',
+        'date' => [
+          'date' => '2022-07-15',
+          'time' => '00:00:00',
+        ],
         'notes' => [],
         'done' => FALSE,
       ],


### PR DESCRIPTION
This changes the form element in our asset bulk action forms and in the planting quick form to use `datetime` instead of `date`, thus making it possible to set the time.

This is a follow-up to #630, and so it includes the commit from that PR which will be merged separately. This PR only adds one additional commit on top. Together they address #509 (and also bring the Planting quick form into consistency).

This is the same approach I am proposing in the Log module here: https://www.drupal.org/project/log/issues/3336721