### PR TITLE
Remove time service from planting quick form

### DIFF
--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -29,6 +29,8 @@ use Psr\Container\ContainerInterface;
  *     "create plant asset",
  *   }
  * )
+ *
+ * @internal
  */
 class Planting extends QuickFormBase {
 

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\farm_quick_planting\Plugin\QuickForm;
 
-use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -67,13 +66,6 @@ class Planting extends QuickFormBase {
   protected $state;
 
   /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -92,17 +84,14 @@ class Planting extends QuickFormBase {
    *   The state service.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   Current user object.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, StateInterface $state, AccountInterface $current_user, TimeInterface $time) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, StateInterface $state, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
     $this->messenger = $messenger;
     $this->entityTypeManager = $entity_type_manager;
     $this->moduleHandler = $module_handler;
     $this->state = $state;
     $this->currentUser = $current_user;
-    $this->time = $time;
   }
 
   /**
@@ -118,7 +107,6 @@ class Planting extends QuickFormBase {
       $container->get('module_handler'),
       $container->get('state'),
       $container->get('current_user'),
-      $container->get('datetime.time'),
     );
   }
 


### PR DESCRIPTION
#635 changed the way that `#default_value` was populated for the date fields in the Planting quick form. The `time.datetime` service is no longer used. This PR removes it from the Planting quick form class's injected dependencies.

I opened this as a follow-up because there could be an argument that changing this class's signature is a breaking change. If someone were extending this quick form to create their own, they might need to update their class signature accordingly, otherwise an error would occur.

This is a very small one - and probably a very small chance of any issue. But it brings up a broader question, perhaps, about what we consider breaking. Curious to hear thoughts on this, and whether or not we should merge this.