### PR TITLE
Add farmOS API kernel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add farmOS API kernel tests #638](https://github.com/farmOS/farmOS/pull/638)
+
 ### Changed
 
 - [Move land and structure type fields higher up for consistency #632](https://github.com/farmOS/farmOS/pull/632)

--- a/modules/core/api/tests/modules/farm_api_test/config/install/asset.type.test.yml
+++ b/modules/core/api/tests/modules/farm_api_test/config/install/asset.type.test.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+id: test
+label: Test
+description: ''
+workflow: asset_default
+new_revision: true

--- a/modules/core/api/tests/modules/farm_api_test/config/install/log.type.test.yml
+++ b/modules/core/api/tests/modules/farm_api_test/config/install/log.type.test.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+id: test
+label: Test
+description: ''
+name_pattern: 'Test log [log:id]'
+workflow: log_default
+new_revision: true

--- a/modules/core/api/tests/modules/farm_api_test/farm_api_test.info.yml
+++ b/modules/core/api/tests/modules/farm_api_test/farm_api_test.info.yml
@@ -1,0 +1,8 @@
+name: farmOS API Tests
+description: 'Support module for farmOS API testing.'
+type: module
+package: Testing
+core_version_requirement: ^9
+dependencies:
+  - farm:asset
+  - log:log

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -130,6 +130,23 @@ class FarmApiTest extends KernelTestBase {
     $this->assertNotEmpty($data['data']['id']);
     $this->assertEquals($log_type, $data['data']['type']);
     $this->assertEquals($asset_id, $data['data']['relationships']['asset']['data'][0]['id']);
+
+    // Get the log ID.
+    $log_id = $data['data']['id'];
+
+    // Test that the asset and log appear in collection endpoints.
+    $data = $this->apiRequest('/api/asset/test');
+    $this->assertCount(1, $data['data']);
+    $this->assertEquals($asset_id, $data['data'][0]['id']);
+    $data = $this->apiRequest('/api/log/test');
+    $this->assertCount(1, $data['data']);
+    $this->assertEquals($log_id, $data['data'][0]['id']);
+
+    // Test retrieving both asset and log individually by UUID.
+    $data = $this->apiRequest('/api/asset/test/' . $asset_id);
+    $this->assertEquals($asset_id, $data['data']['id']);
+    $data = $this->apiRequest('/api/log/test/' . $log_id);
+    $this->assertEquals($log_id, $data['data']['id']);
   }
 
   /**

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -171,6 +171,14 @@ class FarmApiTest extends KernelTestBase {
     $this->assertEquals($log_id, $data['data']['id']);
     $data = $this->apiRequest('/api/log/test/' . $log_id);
     $this->assertEquals($payload['attributes']['name'], $data['data']['attributes']['name']);
+
+    // Test deleting logs and assets.
+    $this->apiRequest('/api/log/test/' . $log_id, 'DELETE');
+    $data = $this->apiRequest('/api/log/test');
+    $this->assertCount(0, $data['data']);
+    $data = $this->apiRequest('/api/asset/test/' . $asset_id, 'DELETE');
+    $data = $this->apiRequest('/api/asset/test');
+    $this->assertCount(0, $data['data']);
   }
 
   /**
@@ -202,6 +210,7 @@ class FarmApiTest extends KernelTestBase {
       'GET' => Response::HTTP_OK,
       'POST' => Response::HTTP_CREATED,
       'PATCH' => Response::HTTP_OK,
+      'DELETE' => Response::HTTP_NO_CONTENT,
     ];
     $this->assertEquals($expected_response[$method], $response->getStatusCode());
     return Json::decode($response->getContent());

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Drupal\Tests\farm_api\Kernel;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\KernelTests\KernelTestBase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests farmOS API features.
+ *
+ * @group farm
+ */
+class FarmApiTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'farm';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_api',
+    'jsonapi',
+    'jsonapi_extras',
+    'serialization',
+    'simple_oauth',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->installConfig([
+      'jsonapi',
+      'jsonapi_extras',
+      'system',
+    ]);
+
+    // Set the install profile.
+    // This is necessary because farm_api's FarmEntryPoint needs to load the
+    // farm profile information from Drupal's extension list service. During
+    // kernel tests the installProfile property of the ExtensionList class does
+    // not get set automatically.
+    $this->setInstallProfile('farm');
+
+    // Set the site name so that we can check for it in /api meta.farm info.
+    \Drupal::configFactory()->getEditable('system.site')->set('name', 'API Test')->save();
+
+    // Allow JSON:API write operations and change the base path to /api.
+    // These would normally be done by farm_api_install(), which does not run
+    // in Kernel tests (it also does other things we don't need).
+    \Drupal::configFactory()->getEditable('jsonapi.settings')->set('read_only', FALSE)->save();
+    \Drupal::configFactory()->getEditable('jsonapi_extras.settings')->set('path_prefix', 'api')->save();
+  }
+
+  /**
+   * Test common farmOS API requests.
+   */
+  public function testApi() {
+
+    // Test that the API root path is /api and it contains meta.farm info.
+    $data = $this->apiRequest('/api');
+    $this->assertNotEmpty($data['meta']['farm']);
+    $this->assertEquals('API Test', $data['meta']['farm']['name']);
+  }
+
+  /**
+   * Helper function for performing an API request.
+   *
+   * @param string $endpoint
+   *   The API endpoint.
+   * @param string $method
+   *   The request method (eg: GET, POST, PATCH, DELETE).
+   *
+   * @return array
+   *   An array of JSON-decoded data returned by the request.
+   */
+  protected function apiRequest(string $endpoint, string $method = 'GET') {
+    $http_kernel = $this->container->get('http_kernel');
+    $request = Request::create($endpoint, $method);
+    $request->headers->set('Accept', 'application/vnd.api+json');
+    $response = $http_kernel->handle($request);
+    $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+    return Json::decode($response->getContent());
+  }
+
+}

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -30,6 +30,9 @@ class FarmApiTest extends KernelTestBase {
     'consumers',
     'farm_api',
     'farm_api_test',
+    'farm_entity_views',
+    'farm_field',
+    'farm_log_asset',
     'farm_role',
     'farm_role_roles',
     'file',
@@ -42,6 +45,7 @@ class FarmApiTest extends KernelTestBase {
     'state_machine',
     'system',
     'user',
+    'views',
   ];
 
   /**
@@ -53,6 +57,7 @@ class FarmApiTest extends KernelTestBase {
     $this->installEntitySchema('log');
     $this->installConfig([
       'farm_api_test',
+      'farm_entity_views',
       'farm_role_roles',
       'jsonapi',
       'jsonapi_extras',
@@ -110,10 +115,21 @@ class FarmApiTest extends KernelTestBase {
     $log_type = 'log--test';
     $payload = [
       'type' => $log_type,
+      'relationships' => [
+        'asset' => [
+          'data' => [
+            [
+              'id' => $asset_id,
+              'type' => $asset_type,
+            ],
+          ],
+        ],
+      ],
     ];
     $data = $this->apiRequest('/api/log/test', 'POST', $payload);
     $this->assertNotEmpty($data['data']['id']);
     $this->assertEquals($log_type, $data['data']['type']);
+    $this->assertEquals($asset_id, $data['data']['relationships']['asset']['data'][0]['id']);
   }
 
   /**

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -147,6 +147,30 @@ class FarmApiTest extends KernelTestBase {
     $this->assertEquals($asset_id, $data['data']['id']);
     $data = $this->apiRequest('/api/log/test/' . $log_id);
     $this->assertEquals($log_id, $data['data']['id']);
+
+    // Test updating assets and logs.
+    $payload = [
+      'type' => $asset_type,
+      'id' => $asset_id,
+      'attributes' => [
+        'name' => 'Updated asset name',
+      ],
+    ];
+    $data = $this->apiRequest('/api/asset/test/' . $asset_id, 'PATCH', $payload);
+    $this->assertEquals($asset_id, $data['data']['id']);
+    $data = $this->apiRequest('/api/asset/test/' . $asset_id);
+    $this->assertEquals($payload['attributes']['name'], $data['data']['attributes']['name']);
+    $payload = [
+      'type' => $log_type,
+      'id' => $log_id,
+      'attributes' => [
+        'name' => 'Updated log name',
+      ],
+    ];
+    $data = $this->apiRequest('/api/log/test/' . $log_id, 'PATCH', $payload);
+    $this->assertEquals($log_id, $data['data']['id']);
+    $data = $this->apiRequest('/api/log/test/' . $log_id);
+    $this->assertEquals($payload['attributes']['name'], $data['data']['attributes']['name']);
   }
 
   /**
@@ -177,6 +201,7 @@ class FarmApiTest extends KernelTestBase {
     $expected_response = [
       'GET' => Response::HTTP_OK,
       'POST' => Response::HTTP_CREATED,
+      'PATCH' => Response::HTTP_OK,
     ];
     $this->assertEquals($expected_response[$method], $response->getStatusCode());
     return Json::decode($response->getContent());


### PR DESCRIPTION
This adds some basic automated kernel tests to the `farm_api` module. They test the following:

- The root API path is `/api`.
- farmOS meta info is added to `/api` in the `meta.farm` section.
- Creating an asset.
- Creating a log that references the asset.
- Retrieving individual assets and logs.
- Retrieving collections of assets and logs.
- Updating assets and logs.
- Deleting assets and logs.

My motivation for adding these tests started here: https://github.com/farmOS/farmOS/pull/629. I want to be able to test the fix for that issue in a kernel test, but we didn't have any existing API kernel tests, so I figured I would add some basic ones, and then build off of them for the `l10n` tests.