### PR TITLE
Convert geometry values to WKT in GeofieldWidget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Convert geometry values to WKT in GeofieldWidget #640](https://github.com/farmOS/farmOS/pull/640)
+
 ## [2.0.1] 2023-02-08
 
 ### Added

--- a/modules/core/map/config/schema/farm_map.schema.yml
+++ b/modules/core/map/config/schema/farm_map.schema.yml
@@ -67,7 +67,10 @@ field.widget.settings.farm_map_geofield:
   type: mapping
   label: 'Farm map geofield settings'
   mapping:
-    geocode_file_field:
+    display_raw_geometry:
+      type: boolean
+      label: 'Whether or not to display the raw geometry field underneath map.'
+    populate_file_field:
       type: string
       label: 'The name of the file field to geocode into the geofield.'
 block.settings.map_block:

--- a/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
+++ b/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
@@ -203,6 +203,16 @@ class GeofieldWidget extends GeofieldBaseWidget {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
+    foreach ($values as $delta => $value) {
+      $values[$delta]['value'] = $this->geofieldBackendValue($value['value']);
+    }
+    return $values;
+  }
+
+  /**
    * Submit function to parse geometries from uploaded files.
    *
    * @param array $form

--- a/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
+++ b/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\Tests\farm_map\Functional;
+
+use Drupal\Core\Entity\Entity\EntityFormDisplay;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\Tests\field\Functional\FieldTestBase;
+
+/**
+ * Tests the farmOS Geofield widget.
+ *
+ * @group farm
+ */
+class GeofieldWidgetTest extends FieldTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_map',
+    'geofield',
+    'entity_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'farm';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * A field storage with cardinality 1 to use in this test class.
+   *
+   * @var \Drupal\field\Entity\FieldStorageConfig
+   */
+  protected $fieldStorage;
+
+  /**
+   * A Field to use in this test class.
+   *
+   * @var \Drupal\field\Entity\FieldConfig
+   */
+  protected $field;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->fieldStorage = FieldStorageConfig::create([
+      'field_name' => 'geofield_field',
+      'entity_type' => 'entity_test',
+      'type' => 'geofield',
+      'settings' => [
+        'backend' => 'geofield_backend_default',
+      ],
+    ]);
+    $this->fieldStorage->save();
+
+    $this->field = FieldConfig::create([
+      'field_storage' => $this->fieldStorage,
+      'bundle' => 'entity_test',
+      'settings' => [
+        'backend' => 'geofield_backend_default',
+      ],
+    ]);
+    $this->field->save();
+
+    // Create a web user.
+    $this->drupalLogin($this->drupalCreateUser(['view test entity', 'administer entity_test content']));
+  }
+
+  /**
+   * Test the farmOS Geofield widget.
+   */
+  public function testGeofieldWidget() {
+    EntityFormDisplay::load('entity_test.entity_test.default')
+      ->setComponent($this->fieldStorage->getName(), [
+        'type' => 'farm_map_geofield',
+      ])
+      ->save();
+
+    // Create an entity.
+    $entity = EntityTest::create([
+      'user_id' => 1,
+      'name' => $this->randomMachineName(),
+    ]);
+    $entity->save();
+
+    // With no field data, no buttons are checked.
+    $this->drupalGet('entity_test/manage/' . $entity->id() . '/edit');
+    $this->assertSession()->pageTextContains('geofield_field');
+
+    // Test a valid WKT value.
+    $edit = [
+      'name[0][value]' => 'Arnedo',
+      'geofield_field[0][value]' => 'POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))',
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertFieldValues($entity, 'geofield_field', ['POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))']);
+  }
+
+}

--- a/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
+++ b/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
@@ -105,6 +105,31 @@ class GeofieldWidgetTest extends FieldTestBase {
     ];
     $this->submitForm($edit, 'Save');
     $this->assertFieldValues($entity, 'geofield_field', ['POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))']);
+
+    // Test a valid GeoJSON value.
+    $edit = [
+      'name[0][value]' => 'Dinagat Islands',
+      'geofield_field[0][value]' => '{
+  "type": "Feature",
+  "geometry": {
+    "type": "Point",
+    "coordinates": [125.6, 10.1]
+  },
+  "properties": {
+    "name": "Dinagat Islands"
+  }
+}',
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertFieldValues($entity, 'geofield_field', ['POINT (125.6 10.1)']);
+
+    // Test a valid WKB value.
+    $edit = [
+      'name[0][value]' => 'Arnedo',
+      'geofield_field[0][value]' => '0101000020E6100000705F07CE19D100C0865AD3BCE31C4540',
+    ];
+    $this->submitForm($edit, 'Save');
+    $this->assertFieldValues($entity, 'geofield_field', ['POINT (-2.1021 42.2257)']);
   }
 
 }


### PR DESCRIPTION
Fixes #639  - see that issue for full context and decision process.

Note that this includes two additional commits ahead of the final directly relevant commit:

> Fix config schema for field.widget.settings.farm_map_geofield.

This fixes an outdated setting name in `farm_map.schemal.yml` and adds a missing one. This was discovered when I was writing an automated test.

> Add an automated test for the farmOS Geofield widget. 

This adds an automated functional test for our custom Geofield widget. This is copied and minimally modified from the upstream Geofield module's widget tests. Note that this commit ONLY tests WKT data. The next (and final) commit adds tests for GeoJSON and WKB (also copied from upstream module's test) and fixes the bug described in #639 