### PR TITLE
Breadcrumb improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Convert geometry values to WKT in GeofieldWidget #640](https://github.com/farmOS/farmOS/pull/640)
 - [Fix map ui being unreadable on dark mode #642](https://github.com/farmOS/farmOS/pull/642)
+- [Implement FarmBreadcrumbBuilder::applies() to only affect desired routes](https://github.com/farmOS/farmOS/pull/644)
 
 ## [2.0.1] 2023-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Add farmOS API kernel tests #638](https://github.com/farmOS/farmOS/pull/638)
+- [Add breadcrumb on canonical user page to people page](https://github.com/farmOS/farmOS/pull/644)
 
 ### Changed
 

--- a/modules/core/ui/breadcrumb/src/Breadcrumb/FarmBreadcrumbBuilder.php
+++ b/modules/core/ui/breadcrumb/src/Breadcrumb/FarmBreadcrumbBuilder.php
@@ -22,6 +22,7 @@ class FarmBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
       'entity.asset.canonical',
       'entity.log.canonical',
       'entity.plan.canonical',
+      'entity.user.canonical',
     ];
     return in_array($route_match->getRouteName(), $routes);
   }
@@ -65,6 +66,11 @@ class FarmBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
         $breadcrumb->addCacheableDependency($plan);
         $breadcrumb->addLink(Link::createFromRoute($this->t('Plans'), 'view.farm_plan.page'));
         $breadcrumb->addLink(Link::createFromRoute($plan->getBundleLabel(), 'view.farm_plan.page_type', ['arg_0' => $plan->bundle()]));
+        break;
+
+      // User pages.
+      case 'entity.user.canonical':
+        $breadcrumb->addLink(Link::createFromRoute($this->t('People'), 'view.farm_people.page'));
         break;
     }
 

--- a/modules/core/ui/breadcrumb/src/Breadcrumb/FarmBreadcrumbBuilder.php
+++ b/modules/core/ui/breadcrumb/src/Breadcrumb/FarmBreadcrumbBuilder.php
@@ -17,6 +17,18 @@ class FarmBreadcrumbBuilder extends PathBasedBreadcrumbBuilder {
   /**
    * {@inheritdoc}
    */
+  public function applies(RouteMatchInterface $route_match) {
+    $routes = [
+      'entity.asset.canonical',
+      'entity.log.canonical',
+      'entity.plan.canonical',
+    ];
+    return in_array($route_match->getRouteName(), $routes);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function build(RouteMatchInterface $route_match) {
     $breadcrumb = parent::build($route_match);
 


### PR DESCRIPTION
We should be implementing `FarmBreadcrumbBuilder::applies()` - it defaults to TRUE which means we may be building breadcrumbs for all routes! Since we inherit the default `PathBasedBreadcrumbBuilder` this probably isn't causing any issues. However I think this could cause issues if another breadcrumb builder was trying to do something on another route and had a lower priority.

Also adding a simple "People" breadcrumb on user pages:

![Screenshot from 2023-02-24 17-10-51](https://user-images.githubusercontent.com/3116995/221327724-734a8dee-34d0-4a07-acda-e5c5b3e03c2e.png)
