### PR TITLE
Patch Drupal core to fix Issue #3266341

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Convert geometry values to WKT in GeofieldWidget #640](https://github.com/farmOS/farmOS/pull/640)
 - [Fix map ui being unreadable on dark mode #642](https://github.com/farmOS/farmOS/pull/642)
+- Patch Drupal core to fix [Issue #3266341: Views pagers do math on disparate data types, resulting in type errors in PHP 8](https://www.drupal.org/project/drupal/issues/3266341)
 
 ## [2.0.1] 2023-02-08
 

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,8 @@
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-12-09/2339235-9.3.x-76.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
-                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2022-12-16/drupal-2909128-9.5.x-74.patch"
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2022-12-16/drupal-2909128-9.5.x-74.patch",
+                "Issue #3266341: Views pagers do math on disparate data types, resulting in type errors in PHP 8": "https://www.drupal.org/files/issues/2022-09-23/3266341-26.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"


### PR DESCRIPTION
[Issue #32663341](https://www.drupal.org/project/drupal/issues/3266341): Views pagers do math on disparate data types, resulting in type errors in PHP 8

The result of this Drupal core issue for farmOS is that we cannot use the "Items per page = All" filter in our asset/log record views. I tested the patch and it fixes this issue for us: https://www.drupal.org/project/farm/issues/3344865