### PR TITLE
Create a QuickFormTestBase class that other quick form tests can extend from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Document building farmOS with Composer #648](https://github.com/farmOS/farmOS/pull/648)
+- [Create a QuickFormTestBase class that other quick form tests can extend from #650](https://github.com/farmOS/farmOS/pull/650)
 
 ### Fixed
 

--- a/modules/core/quick/tests/src/Kernel/QuickFormTestBase.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTestBase.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\Tests\farm_quick\Kernel;
+
+use Drupal\Core\Form\FormState;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Base class that modules can use to test their quick forms.
+ *
+ * @group farm
+ *
+ * @internal
+ */
+abstract class QuickFormTestBase extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * Quick form ID.
+   *
+   * @var string
+   */
+  protected $quickFormId;
+
+  /**
+   * Asset entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $assetStorage;
+
+  /**
+   * Log entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $logStorage;
+
+  /**
+   * Taxonomy term entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $termStorage;
+
+  /**
+   * Quantity entity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $quantityStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'asset',
+    'entity',
+    'entity_reference_revisions',
+    'farm_entity',
+    'farm_entity_fields',
+    'farm_field',
+    'farm_format',
+    'farm_location',
+    'farm_log',
+    'farm_log_asset',
+    'farm_log_quantity',
+    'farm_map',
+    'farm_quick',
+    'file',
+    'filter',
+    'fraction',
+    'geofield',
+    'image',
+    'log',
+    'options',
+    'quantity',
+    'rest',
+    'serialization',
+    'state_machine',
+    'system',
+    'taxonomy',
+    'text',
+    'user',
+    'views',
+    'views_geojson',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->setUpCurrentUser([], [], TRUE);
+    $this->assetStorage = \Drupal::entityTypeManager()->getStorage('asset');
+    $this->logStorage = \Drupal::entityTypeManager()->getStorage('log');
+    $this->termStorage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+    $this->quantityStorage = \Drupal::entityTypeManager()->getStorage('quantity');
+    $this->installEntitySchema('asset');
+    $this->installEntitySchema('log');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('quantity');
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('user_role');
+    $this->installConfig([
+      'farm_format',
+      'farm_location',
+      'system',
+    ]);
+  }
+
+  /**
+   * Helper function for performing a quick form submission.
+   *
+   * @param array $values
+   *   The values to submit.
+   */
+  protected function submitQuickForm(array $values = []) {
+    $form_arg = '\Drupal\farm_quick\Form\QuickForm';
+    $form_state = (new FormState())->setValues($values);
+    \Drupal::formBuilder()->submitForm($form_arg, $form_state, $this->quickFormId);
+  }
+
+}

--- a/modules/quick/planting/tests/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/Kernel/QuickPlantingTest.php
@@ -3,78 +3,37 @@
 namespace Drupal\Tests\farm_quick_planting\Kernel;
 
 use Drupal\asset\Entity\Asset;
-use Drupal\Core\Form\FormState;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\taxonomy\Entity\Term;
-use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 
 /**
  * Tests for farmOS planting quick form.
  *
  * @group farm
  */
-class QuickPlantingTest extends KernelTestBase {
-
-  use UserCreationTrait;
+class QuickPlantingTest extends QuickFormTestBase {
 
   /**
-   * Asset entity storage.
+   * Quick form ID.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var string
    */
-  protected $assetStorage;
-
-  /**
-   * Log entity storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $logStorage;
+  protected $quickFormId = 'planting';
 
   /**
    * {@inheritdoc}
    */
   protected static $modules = [
-    'asset',
-    'entity',
-    'entity_reference_revisions',
-    'farm_entity',
-    'farm_entity_fields',
-    'farm_field',
-    'farm_format',
     'farm_harvest',
     'farm_land',
-    'farm_location',
-    'farm_log',
-    'farm_log_asset',
-    'farm_log_quantity',
-    'farm_map',
     'farm_plant',
     'farm_plant_type',
     'farm_quantity_standard',
-    'farm_quick',
     'farm_quick_planting',
     'farm_season',
     'farm_seeding',
     'farm_transplanting',
     'farm_unit',
-    'file',
-    'filter',
-    'fraction',
-    'geofield',
-    'image',
-    'log',
-    'options',
-    'quantity',
-    'rest',
-    'serialization',
-    'state_machine',
-    'system',
-    'taxonomy',
-    'text',
-    'user',
-    'views',
-    'views_geojson',
   ];
 
   /**
@@ -82,20 +41,9 @@ class QuickPlantingTest extends KernelTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->setUpCurrentUser([], [], TRUE);
-    $this->assetStorage = \Drupal::entityTypeManager()->getStorage('asset');
-    $this->logStorage = \Drupal::entityTypeManager()->getStorage('log');
-    $this->installEntitySchema('asset');
-    $this->installEntitySchema('log');
-    $this->installEntitySchema('taxonomy_term');
-    $this->installEntitySchema('quantity');
-    $this->installEntitySchema('user');
-    $this->installEntitySchema('user_role');
     $this->installConfig([
-      'farm_format',
       'farm_harvest',
       'farm_land',
-      'farm_location',
       'farm_plant',
       'farm_quantity_standard',
       'farm_seeding',
@@ -340,18 +288,6 @@ class QuickPlantingTest extends KernelTestBase {
     $this->assertEquals('pending', $log->get('status')->value);
     $log = $logs[4];
     $this->assertEquals('pending', $log->get('status')->value);
-  }
-
-  /**
-   * Helper function for performing a planting quick form submission.
-   *
-   * @param array $values
-   *   The values to submit.
-   */
-  protected function submitQuickForm(array $values = []) {
-    $form_arg = '\Drupal\farm_quick\Form\QuickForm';
-    $form_state = (new FormState())->setValues($values);
-    \Drupal::formBuilder()->submitForm($form_arg, $form_state, 'planting');
   }
 
 }


### PR DESCRIPTION
I made this last year when I was starting work on a v2 Birth quick form. Dusting that stuff off again now, and figured that this commit could be merged by itself first.

The idea is that it provides a base class for modules to use so they can write their own quick form kernel tests without replicating a whole bunch of boilerplate stuff. I figure we can add more to it over time too to make quick form testing more standardized.

This also refactors the Planting quick form test to use the new base class.