### PR TITLE
Do not add birth log mother to animal assets that already have parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Add "Speed" to the list of quantity measures #658](https://github.com/farmOS/farmOS/pull/658)
 
+### Changed
+
+- [Do not add birth log mother to animal assets that already have parents #655](https://github.com/farmOS/farmOS/pull/655)
+
 ### Fixed
 
 - [Fix quick form toolbar menu links #657](https://github.com/farmOS/farmOS/pull/657)

--- a/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
@@ -93,22 +93,11 @@ class LogEventSubscriber implements EventSubscriberInterface {
         $save = TRUE;
       }
 
-      // If a mother is specified, make sure that it is linked as one of the
-      // child's parents.
+      // If a mother is specified, and the child does not have any parents,
+      // add the mother to the child's parent reference field.
       if (!empty($mother)) {
-
-        // Iterate through the child's parents to see if the mother is linked.
-        $mother_linked = FALSE;
         $parents = $child->get('parent')->referencedEntities();
-        foreach ($parents as $parent) {
-          if ($parent->id() == $mother->id()) {
-            $mother_linked = TRUE;
-            break;
-          }
-        }
-
-        // Link to the mother, if not already.
-        if (!$mother_linked) {
+        if (empty($parents)) {
           $args = [
             ':mother_url' => $mother->toUrl()->toString(),
             '%mother_name' => $mother->label(),


### PR DESCRIPTION
During the construction of the Birth quick form (PR incoming), I ran into an issue with our current logic that automatically copies the `mother` of a `birth` log to the `parent` field of referenced `animal` assets when the birth log is saved.

Basically, the current logic iterates over the parents referenced in the animal asset, checks to see if the `mother` is present, and if not, it adds it.

I'm proposing that we change the logic so that it ONLY adds the `mother` if NO parents are already specified.

The thinking here is: if a user has already defined parents on the asset, we shouldn't be changing them at all.

In practice, this was necessary for the birth quick form, because that form provides the ability to specify both the "birth mother" and the "genetic mother". ONLY the "genetic mother" should be saved to the child's `parent` field... but because of the logic we have in the `farm_birth` module it was also adding the "birth mother" after the `birth` log was saved (which happens after the child asset is created and `parent` is set to the "genetic mother").

I decided to open this as a standalone PR ahead of the Birth quick form PR to keep things isolated.