### PR TITLE
Fix quick form toolbar menu links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Add "Speed" to the list of quantity measures #658](https://github.com/farmOS/farmOS/pull/658)
 
+### Fixed
+
+- [Fix quick form toolbar menu links #657](https://github.com/farmOS/farmOS/pull/657)
+
 ## [2.0.3] 2023-03-15
 
 ### Added

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
@@ -61,7 +61,7 @@ class QuickFormMenuLink extends DeriverBase implements ContainerDeriverInterface
       $route_id = 'farm.quick.' . $quick_form['id'];
       $links[$route_id] = [
         'title' => $quick_form['label'],
-        'parent' => 'farm.quick',
+        'parent' => 'farm.quick:farm.quick',
         'route_name' => $route_id,
       ] + $base_plugin_definition;
     }


### PR DESCRIPTION
When the `farm_quick` module is enabled, it adds a "Quick forms" top-level menu item to the toolbar. Hovering over this menu item does not display a list of available quick forms, however (eg: like the "Records" menu shows "Assets", "Logs", etc on hover).

The reason these aren't showing up is because we are incorrectly setting the `parent` of the individual quick form menu items:

https://github.com/farmOS/farmOS/blob/4ec1709a7bddf15875721c52888914c775963f2a/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php#L64

It *looks* like we're doing it correctly, but because this is a "derived" menu item, we need to also include the deriving menu item ID as a prefix, as defined in `farm_quick.links.menu.yml`: 

https://github.com/farmOS/farmOS/blob/4ec1709a7bddf15875721c52888914c775963f2a/modules/core/quick/farm_quick.links.menu.yml#L1

So the `parent` actually needs to be: `farm.quick:farm.quick`.