### PR TITLE
Update softprops/action-gh-release to 1.15

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Create artifact
         run: cd /tmp && tar -czf farmOS-${FARMOS_VERSION}.tar.gz farmOS
       - name: Create GitHub release
-        uses: softprops/action-gh-release@6034af24fba4e5a8e975aaa6056554efe4c794d0 #0.1.13
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 #0.1.15
         with:
           body: |
             For full release notes, see [CHANGELOG.md](https://github.com/farmOS/farmOS/blob/${{ env.FARMOS_VERSION }}/CHANGELOG.md).


### PR DESCRIPTION
Update softprops/action-gh-release to 1.15: https://github.com/softprops/action-gh-release/releases/tag/v0.1.15

- It uses the `set-output` command and will stop running starting June 1 2023: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Also fixes the Node.js version warning.

![Screenshot from 2023-03-16 08-21-04](https://user-images.githubusercontent.com/3116995/225664104-cd1ffd5a-5b12-4aab-b2da-efdfcf72ee7c.png)
