### PR TITLE
Standardize all taxonomy bundle labels to be singular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Simplify all map resize logic to use ResizeObserver #662](https://github.com/farmOS/farmOS/pull/662)
 - [Replace all usages of docker-compose with native docker compose #627](https://github.com/farmOS/farmOS/pull/627)
 - [Allow max_length to be overridden on string fields #666](https://github.com/farmOS/farmOS/pull/666)
+- [Standardize all taxonomy bundle labels to be singular #661](https://github.com/farmOS/farmOS/pull/661)
 
 ### Fixed
 

--- a/modules/taxonomy/animal_type/config/install/taxonomy.vocabulary.animal_type.yml
+++ b/modules/taxonomy/animal_type/config/install/taxonomy.vocabulary.animal_type.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_animal_type
-name: Animal types
+name: Animal type
 vid: animal_type
 description: 'A list of animal species/breeds.'
 weight: 0

--- a/modules/taxonomy/lab/config/install/taxonomy.vocabulary.lab.yml
+++ b/modules/taxonomy/lab/config/install/taxonomy.vocabulary.lab.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_lab
-name: Labs
+name: Lab
 vid: lab
 description: 'A list of labs.'
 weight: 0

--- a/modules/taxonomy/log_category/config/install/taxonomy.vocabulary.log_category.yml
+++ b/modules/taxonomy/log_category/config/install/taxonomy.vocabulary.log_category.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_log_category
-name: Log categories
+name: Log category
 vid: log_category
 description: 'A list of log categories.'
 weight: 0

--- a/modules/taxonomy/material_type/config/install/taxonomy.vocabulary.material_type.yml
+++ b/modules/taxonomy/material_type/config/install/taxonomy.vocabulary.material_type.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_material_type
-name: Material types
+name: Material type
 vid: material_type
 description: 'A list of material types.'
 weight: 0

--- a/modules/taxonomy/plant_type/config/install/taxonomy.vocabulary.plant_type.yml
+++ b/modules/taxonomy/plant_type/config/install/taxonomy.vocabulary.plant_type.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_plant_type
-name: Plant types
+name: Plant type
 vid: plant_type
 description: 'A list of crops/varieties.'
 weight: 0

--- a/modules/taxonomy/season/config/install/taxonomy.vocabulary.season.yml
+++ b/modules/taxonomy/season/config/install/taxonomy.vocabulary.season.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_season
-name: Seasons
+name: Season
 vid: season
 description: 'A list of seasons.'
 weight: 0

--- a/modules/taxonomy/test_method/config/install/taxonomy.vocabulary.test_method.yml
+++ b/modules/taxonomy/test_method/config/install/taxonomy.vocabulary.test_method.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_test_method
-name: Test methods
+name: Test method
 vid: test_method
 description: 'A list of test methods.'
 weight: 0

--- a/modules/taxonomy/unit/config/install/taxonomy.vocabulary.unit.yml
+++ b/modules/taxonomy/unit/config/install/taxonomy.vocabulary.unit.yml
@@ -4,7 +4,7 @@ dependencies:
   enforced:
     module:
       - farm_unit
-name: Units
+name: Unit
 vid: unit
 description: 'A list of units for measurement purposes.'
 weight: 0


### PR DESCRIPTION
Assets, logs and quantities all use a singular form for their bundle label. With the exception of "Crop Family", all of our taxonomy terms use a plural label for their bundle. It would be nice to standardize on singular forms for the bundle labels.

My primary motivation for this change is to support #634 where we use the bundle label as the label for the Primary task tab above View, Edit, and Revisions secondary task tabs. Compare the following: Log categories vs singular Plant example. This PR would change "Log categories" to "Log category".

I believe the only other impact of this change is the Taxonomy structure page using singular forms. I believe this is more consistent with how we list singular asset/log types under the "Records" menu.

![Screenshot from 2023-03-21 13-38-33](https://user-images.githubusercontent.com/3116995/226736385-45f15c99-50cf-4970-bcf8-412c789cb9bc.png)

![Screenshot from 2023-03-21 13-39-09](https://user-images.githubusercontent.com/3116995/226736410-3d83c5c8-71db-47eb-9aec-4fac02f0a4a0.png)

