### PR TITLE
Allow map to be resized vertically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Add "Speed" to the list of quantity measures #658](https://github.com/farmOS/farmOS/pull/658)
 - [Include Fraction bundle fields in default Views #664](https://github.com/farmOS/farmOS/pull/664)
+- [Allow map to be resized vertically #663](https://github.com/farmOS/farmOS/pull/663)
 
 ### Changed
 

--- a/modules/core/map/css/farm_map.css
+++ b/modules/core/map/css/farm_map.css
@@ -1,5 +1,7 @@
 .farm-map {
   height: 400px;
+  resize: vertical;
+  overflow: hidden;
 }
 
 /* Inline labels cause the map to cover other fields. */


### PR DESCRIPTION
Simple change allows the map to be resized vertically! `resize: vertical` adds a little drag icon to the bottom right corner of the map the same thing that is usually in a text area. `overflow: hidden` prevents scroll bars from appearing around the map.

As is this would be a simple change that allows all maps to be resized. Some questions:
- Should this be configurable?
- Should we also allow resizing horizontally?
- Should this be implemented in a map behavior?
- ...

This is dependent on #662 for proper resizing logic