### PR TITLE
Respect user timezone in midnight default datetime values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix quick form toolbar menu links #657](https://github.com/farmOS/farmOS/pull/657)
+- [Respect user timezone in midnight default datetime values #665](https://github.com/farmOS/farmOS/pull/665)
 
 ## [2.0.3] 2023-03-15
 

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -138,7 +138,7 @@ class AssetGroupActionForm extends ConfirmFormBase {
     $form['date'] = [
       '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime('midnight'),
+      '#default_value' => new DrupalDateTime('midnight', $this->user->getTimeZone()),
       '#required' => TRUE,
     ];
 

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -169,7 +169,7 @@ class AssetMoveActionForm extends ConfirmFormBase {
     $form['date'] = [
       '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime('midnight'),
+      '#default_value' => new DrupalDateTime('midnight', $this->user->getTimeZone()),
       '#required' => TRUE,
     ];
 

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -332,7 +332,7 @@ class Planting extends QuickFormBase {
       'date' => [
         '#type' => 'datetime',
         '#title' => $this->t('Date'),
-        '#default_value' => new DrupalDateTime('midnight'),
+        '#default_value' => new DrupalDateTime('midnight', $this->currentUser->getTimeZone()),
         '#required' => TRUE,
       ],
       'done' => [


### PR DESCRIPTION
https://github.com/farmOS/farmOS/pull/635 changed some of our date form elements to `datetime` with `'#default_value' => new DrupalDateTime('midnight')`.

I discovered an issue with this: `new DrupalDateTime('midnight')` defaults to a timezone of `UTC`, which can lead the default date to be different than the user's current date.

For example, in the Eastern timezone (UTC-4), if I open the Planting quick form at 9 pm Eastern, it will show *tomorrow's* date as the default value. This could easily go unnoticed, leading to incorrect planting dates.

The solution to this is to pass the user's timezone into the `DrupalDateTime` constructor as a second parameter.