### PR TITLE
Field factory improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add "Speed" to the list of quantity measures #658](https://github.com/farmOS/farmOS/pull/658)
 - [Include Fraction bundle fields in default Views #664](https://github.com/farmOS/farmOS/pull/664)
 - [Allow map to be resized vertically #663](https://github.com/farmOS/farmOS/pull/663)
+- [Add integer, decimal, and email field support to field factory service #666](https://github.com/farmOS/farmOS/pull/666)
 
 ### Changed
 
 - [Do not add birth log mother to animal assets that already have parents #655](https://github.com/farmOS/farmOS/pull/655)
 - [Simplify all map resize logic to use ResizeObserver #662](https://github.com/farmOS/farmOS/pull/662)
 - [Replace all usages of docker-compose with native docker compose #627](https://github.com/farmOS/farmOS/pull/627)
+- [Allow max_length to be overridden on string fields #666](https://github.com/farmOS/farmOS/pull/666)
 
 ### Fixed
 

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -120,6 +120,11 @@ Both methods expect an array of field definition options. These include:
 - `type` (required) - The field data type. Each type may require additional
   options. Supported types include:
     - `boolean` - True/false checkbox.
+    - `decimal` - Decimal number with fixed precision. Additional options:
+        - `precision` (optional) - Total number of digits (including after the
+          decimal point). Defaults to 10.
+        - `scale` (optional) - Number digits to the right of the decimal point.
+          Defaults to 2.
     - `entity_reference` - Reference other entities. Additional options:
         - `target_type` (required) - The entity type to reference (eg: `asset`,
           `log`, `plan`)

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -137,6 +137,7 @@ Both methods expect an array of field definition options. These include:
         - `allowed_values` - An associative array of allowed values.
         - `allowed_values_function` - The name of a function that returns an
           associative array of allowed values.
+    - `string` - Unformatted text field with a maximum length of 255.
     - `string_long` - Unformatted text field of unlimited length.
     - `text_long` - Formatted text field of unlimited length.
     - `timestamp` - Date and time.

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -133,6 +133,9 @@ Both methods expect an array of field definition options. These include:
     - `fraction` - High-precision decimal number storage.
     - `geofield` - Geometry on a map.
     - `image` - Image upload.
+    - `integer` - Integer number. Additional options:
+        - `size` (optional) - The integer database column size (`tiny`,
+          `small`, `medium`, `normal`, or `big`). Defaults to `normal`.
     - `list_string` - Select list with allowed values. Additional options:
         - `allowed_values` - An associative array of allowed values.
         - `allowed_values_function` - The name of a function that returns an

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -137,7 +137,8 @@ Both methods expect an array of field definition options. These include:
         - `allowed_values` - An associative array of allowed values.
         - `allowed_values_function` - The name of a function that returns an
           associative array of allowed values.
-    - `string` - Unformatted text field with a maximum length of 255.
+    - `string` - Unformatted text field of fixed length. Additional options:
+        - 'max_length' - Maximum length. Defaults to 255.
     - `string_long` - Unformatted text field of unlimited length.
     - `text_long` - Formatted text field of unlimited length.
     - `timestamp` - Date and time.

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -125,6 +125,7 @@ Both methods expect an array of field definition options. These include:
           decimal point). Defaults to 10.
         - `scale` (optional) - Number digits to the right of the decimal point.
           Defaults to 2.
+    - `email` - Email field.
     - `entity_reference` - Reference other entities. Additional options:
         - `target_type` (required) - The entity type to reference (eg: `asset`,
           `log`, `plan`)

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -116,6 +116,10 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         $this->modifyBooleanField($field, $options);
         break;
 
+      case 'decimal':
+        $this->modifyDecimalField($field, $options);
+        break;
+
       case 'entity_reference':
         $this->modifyEntityReferenceField($field, $options);
         break;
@@ -232,6 +236,40 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
       ],
       'weight' => $options['weight']['view'] ?? 0,
     ]);
+  }
+
+  /**
+   * Decimal field modifier.
+   *
+   * @param \Drupal\Core\Field\BaseFieldDefinition &$field
+   *   A base field definition object.
+   * @param array $options
+   *   An array of options.
+   */
+  protected function modifyDecimalField(BaseFieldDefinition &$field, array $options = []) {
+
+    // Set the precision and scale, if specified.
+    if (!empty($options['precision'])) {
+      $field->setSetting('precision', $options['precision']);
+    }
+    if (!empty($options['scale'])) {
+      $field->setSetting('scale', $options['scale']);
+    }
+
+    // Build form and view display settings.
+    $field->setDisplayOptions('form', [
+      'type' => 'number',
+      'weight' => $options['weight']['form'] ?? 0,
+    ]);
+    $view_display_options = [
+      'label' => 'inline',
+      'type' => 'number_decimal',
+      'weight' => $options['weight']['view'] ?? 0,
+    ];
+    if (!empty($options['scale'])) {
+      $view_display_options['settings']['scale'] = $options['scale'];
+    }
+    $field->setDisplayOptions('view', $view_display_options);
   }
 
   /**

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -141,6 +141,10 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         $this->modifyIdTagField($field, $options);
         break;
 
+      case 'integer':
+        $this->modifyIntegerField($field, $options);
+        break;
+
       case 'inventory':
         $this->modifyInventoryField($field, $options);
         break;
@@ -694,6 +698,33 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
     $field->setDisplayOptions('view', [
       'label' => 'inline',
       'type' => 'id_tag',
+      'weight' => $options['weight']['view'] ?? 0,
+    ]);
+  }
+
+  /**
+   * Integer field modifier.
+   *
+   * @param \Drupal\Core\Field\BaseFieldDefinition &$field
+   *   A base field definition object.
+   * @param array $options
+   *   An array of options.
+   */
+  protected function modifyIntegerField(BaseFieldDefinition &$field, array $options = []) {
+
+    // Set the size, if specified.
+    if (!empty($options['size'])) {
+      $field->setSetting('size', $options['size']);
+    }
+
+    // Build form and view display settings.
+    $field->setDisplayOptions('form', [
+      'type' => 'number',
+      'weight' => $options['weight']['form'] ?? 0,
+    ]);
+    $field->setDisplayOptions('view', [
+      'label' => 'inline',
+      'type' => 'number_integer',
       'weight' => $options['weight']['view'] ?? 0,
     ]);
   }

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -758,6 +758,11 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
    */
   protected function modifyStringField(BaseFieldDefinition &$field, array $options = []) {
 
+    // Set the maximum length, if specified.
+    if (!empty($options['max_length'])) {
+      $field->setSetting('max_length', $options['max_length']);
+    }
+
     // Build form and view display settings.
     $field->setDisplayOptions('form', [
       'type' => 'string_textfield',

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -758,11 +758,6 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
    */
   protected function modifyStringField(BaseFieldDefinition &$field, array $options = []) {
 
-    // Set default settings.
-    $field->setSetting('max_length', 255);
-    $field->setSetting('is_ascii', FALSE);
-    $field->setSetting('case_sensitive', FALSE);
-
     // Build form and view display settings.
     $field->setDisplayOptions('form', [
       'type' => 'string_textfield',

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -120,6 +120,10 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         $this->modifyDecimalField($field, $options);
         break;
 
+      case 'email':
+        $this->modifyEmailField($field, $options);
+        break;
+
       case 'entity_reference':
         $this->modifyEntityReferenceField($field, $options);
         break;
@@ -270,6 +274,28 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
       $view_display_options['settings']['scale'] = $options['scale'];
     }
     $field->setDisplayOptions('view', $view_display_options);
+  }
+
+  /**
+   * Email field modifier.
+   *
+   * @param \Drupal\Core\Field\BaseFieldDefinition &$field
+   *   A base field definition object.
+   * @param array $options
+   *   An array of options.
+   */
+  protected function modifyEmailField(BaseFieldDefinition &$field, array $options = []) {
+
+    // Build form and view display settings.
+    $field->setDisplayOptions('form', [
+      'type' => 'email_default',
+      'weight' => $options['weight']['form'] ?? 0,
+    ]);
+    $field->setDisplayOptions('view', [
+      'label' => 'inline',
+      'type' => 'email_mailto',
+      'weight' => $options['weight']['view'] ?? 0,
+    ]);
   }
 
   /**


### PR DESCRIPTION
This PR includes a number of improvements to the `farm_field.factory` service. It adds `decimal`, `integer`, and `email` field type support. It adds missing documentation for the `string` type and allows `max_length` to be overridden. It also cleans up some of the default configuration for `string` and `string_long` fields.