### PR TITLE
Update Drupal core to 9.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Replace all usages of docker-compose with native docker compose #627](https://github.com/farmOS/farmOS/pull/627)
 - [Allow max_length to be overridden on string fields #666](https://github.com/farmOS/farmOS/pull/666)
 - [Standardize all taxonomy bundle labels to be singular #661](https://github.com/farmOS/farmOS/pull/661)
+- [Update Drupal core to 9.5.7 #667](https://github.com/farmOS/farmOS/pull/667)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -57,8 +57,7 @@
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2021-12-09/2339235-9.3.x-76.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
-                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2022-12-16/drupal-2909128-9.5.x-74.patch",
-                "Issue #3266341: Views pagers do math on disparate data types, resulting in type errors in PHP 8": "https://www.drupal.org/files/issues/2022-09-23/3266341-26.patch"
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2022-12-16/drupal-2909128-9.5.x-74.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.2",
-        "drupal/core": "9.5.5",
+        "drupal/core": "9.5.7",
         "drupal/config_update": "^1.7",
         "drupal/consumers": "^1.15",
         "drupal/csv_serialization": "^2.0",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "9.5.5"
+        "drupal/core-composer-scaffold": "9.5.7"
     },
     "require-dev": {
         "behat/mink": "^1.10",

--- a/modules/core/settings/src/Form/FarmSettingsModulesForm.php
+++ b/modules/core/settings/src/Form/FarmSettingsModulesForm.php
@@ -137,13 +137,6 @@ class FarmSettingsModulesForm extends FormBase {
       foreach ($options['disabled'] as $name) {
         $form[$type]['modules'][$name]['#disabled'] = TRUE;
       }
-
-      // Disable the submit button until an uninstalled module is checked.
-      $uninstalled = array_diff(array_keys($options['options']), $options['default']);
-      foreach ($uninstalled as $module_name) {
-        $name = $type . "[modules][$module_name]";
-        $form['actions']['submit']['#states']['disabled'][":input[name=\"$name\"]"] = ['checked' => FALSE];
-      }
     }
     return $form;
   }

--- a/modules/core/settings/tests/src/Functional/ModulesFormTest.php
+++ b/modules/core/settings/tests/src/Functional/ModulesFormTest.php
@@ -52,9 +52,6 @@ class ModulesFormTest extends WebDriverTestBase {
     // Request the module settings page.
     $this->drupalGet('farm/settings/modules');
 
-    // Assert that the install button is disabled.
-    $this->assertInstallButtonState(TRUE);
-
     // Assert that installed modules are checked and disabled.
     foreach (['farm_land', 'farm_observation'] as $module) {
       $this->assertModuleCheckboxState('core', $module, TRUE, TRUE);
@@ -101,19 +98,6 @@ class ModulesFormTest extends WebDriverTestBase {
   }
 
   /**
-   * Helper function to assert the state of the install modules button.
-   *
-   * @param bool $disabled
-   *   Boolean if the checkbox should be disabled. Defaults to FALSE.
-   */
-  protected function assertInstallButtonState(bool $disabled = FALSE) {
-    $page = $this->getSession()->getPage();
-    $button = $page->findButton('install-modules');
-    $this->assertNotEmpty($button, "The install modules button exists.");
-    $this->assertEquals($disabled, $button->hasAttribute('disabled'));
-  }
-
-  /**
    * Helper function to test installing a list of modules.
    *
    * @param array $modules
@@ -136,9 +120,6 @@ class ModulesFormTest extends WebDriverTestBase {
         $this->assertModuleCheckboxState($type, $module_name, TRUE, FALSE);
       }
     }
-
-    // Assert the install button becomes enabled.
-    $this->assertInstallButtonState(FALSE);
 
     // Submit the form.
     $page->pressButton('install-modules');


### PR DESCRIPTION
This required two additional changes, which are documented here for future reference:

- The patch for [Issue #3266341](https://www.drupal.org/project/drupal/issues/3266341) was merged upstream, so we can remove it from our `composer.json`.
- Core [Issue #994360](https://www.drupal.org/project/drupal/issues/994360) breaks the `#states` logic of the farmOS modules form submit button, so we decided to just remove that logic and the associated test. See chat log: https://irc.farmos.org/bot/log/farmOS/2023-04-03