### PR TITLE
Fix bulk move/group action log names when unsetting location/group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix bulk move/group action log names when unsetting location/group #669](https://github.com/farmOS/farmOS/pull/669)
+
 ## [2.0.4] 2023-04-03
 
 ### Added

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -200,7 +200,10 @@ class AssetGroupActionForm extends ConfirmFormBase {
       // Generate a name for the log.
       $asset_names = farm_log_asset_names_summary($accessible_entities);
       $group_names = farm_log_asset_names_summary($groups);
-      $log_name = $this->t('Group @assets into @groups', ['@assets' => $asset_names, '@groups' => $group_names]);
+      $log_name = $this->t('Clear group membership of @assets', ['@assets' => $asset_names]);
+      if (!empty($group_names)) {
+        $log_name = $this->t('Group @assets into @groups', ['@assets' => $asset_names, '@groups' => $group_names]);
+      }
 
       // Create the log.
       $log = Log::create([

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -230,7 +230,10 @@ class AssetMoveActionForm extends ConfirmFormBase {
       // Generate a name for the log.
       $asset_names = farm_log_asset_names_summary($accessible_entities);
       $location_names = farm_log_asset_names_summary($locations);
-      $log_name = $this->t('Move @assets to @locations', ['@assets' => $asset_names, '@locations' => $location_names]);
+      $log_name = $this->t('Clear location of @assets', ['@assets' => $asset_names]);
+      if (!empty($location_names)) {
+        $log_name = $this->t('Move @assets to @locations', ['@assets' => $asset_names, '@locations' => $location_names]);
+      }
 
       // Create the log.
       $log = Log::create([


### PR DESCRIPTION
If you use the bulk actions for "Move assets" or "Group assets", but you leave the "Location" or "Group" fields blank (which means you intend to unset the location / group of the assets), the logs that are created have an auto-generated name that doesn't make sense.

For example:

"Move Tractor to "

"Group Tractor into "

This is because the log name patterns are simply:

`Move @assets to @locations`

`Group @assets into @groups`

This PR fixes this by checking if `@locations` / `@groups` is empty, and offering a different pattern if it is:

`Clear location of @assets`

`Clear group membership of @assets`