### PR TITLE
Refresh map edit layer when WKT is pasted into data input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Refresh map edit layer when WKT is pasted into data input field #670](https://github.com/farmOS/farmOS/pull/670)
+
 ### Changed
 
 - Update farmOS-map to [v2.2.0](https://github.com/farmOS/farmOS-map/releases/tag/v2.2.0)

--- a/modules/core/map/js/farmOS.map.behaviors.input.js
+++ b/modules/core/map/js/farmOS.map.behaviors.input.js
@@ -1,10 +1,38 @@
 (function () {
   farmOS.map.behaviors.input = {
     attach: function (instance) {
+
+      // Get the data input form element.
+      var input = instance.map.getTargetElement().parentElement.querySelector('[data-map-geometry-field]')
+
+      // When features change in the edit layer, write WKT to the input form element.
       instance.editAttached && instance.editAttached.then(() => {
         instance.edit.wktOn('featurechange', function(wkt) {
-          instance.map.getTargetElement().parentElement.querySelector('[data-map-geometry-field]').value = wkt;
+          if (input.value !== wkt) {
+            input.value = wkt;
+          }
         });
+      });
+
+      // Add an event listener to the input element, which will attempt to
+      // import new WKT when it changes.
+      input.addEventListener('input', (e) => {
+
+        // If the value is empty, only clear features from the layer.
+        if (!input.value) {
+          instance.edit.layer.getSource().clear();
+          return;
+        }
+
+        // Clear features from the layer.
+        instance.edit.layer.getSource().clear();
+
+        // Read features from WKT and add them to the layer.
+        var features = instance.readFeatures('wkt', input.value);
+        instance.edit.layer.getSource().addFeatures(features);
+
+        // Zoom to the layer.
+        instance.zoomToLayer(instance.edit.layer);
       });
     },
 


### PR DESCRIPTION
This adds a bit of logic to our farmOS-map `input` behavior, which is used in all maps that have the `edit` behavior enabled (eg: `farm_map_input` form elements, including our `geofield` widget). It allows you to paste WKT into the `textarea` below the map, replacing the geometry in the editable layer.