### PR TITLE
Add QuickStringTrait::entityLabelsSummary() and deprecate farm_log_asset_names_summary()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Add QuickStringTrait::assetNamesSummary() and deprecate farm_log_asset_names_summary() #671](https://github.com/farmOS/farmOS/pull/671)
+
 ### Fixed
 
 - [Fix bulk move/group action log names when unsetting location/group #669](https://github.com/farmOS/farmOS/pull/669)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Add QuickStringTrait::assetNamesSummary() and deprecate farm_log_asset_names_summary() #671](https://github.com/farmOS/farmOS/pull/671)
+- [Add QuickStringTrait::entityLabelsSummary() and deprecate farm_log_asset_names_summary() #671](https://github.com/farmOS/farmOS/pull/671)
 
 ### Fixed
 

--- a/docs/development/module/quick.md
+++ b/docs/development/module/quick.md
@@ -149,10 +149,10 @@ Available traits and the methods that they provide include:
     Expects a keyed array of strings to concatenate together, along with an
     optional array of keys that should be prioritized in case the full string
     won't fit.
-  - `assetNamesSummary($assets, $cutoff)` - Generate a summary of asset names
-    for use in a log name. Example: "Asset 1, Asset 2, Asset 3 (+ 15 more)".
-    Note that this does NOT sanitize the asset names. It is the responsibility
-    of downstream code to do so, if it is printing the text to the page.
+  - `entityLabelsSummary($entities, $cutoff)` - Generate a summary of entity
+    labels. Example: "Asset 1, Asset 2, Asset 3 (+ 15 more)". Note that this
+    does NOT sanitize the entity labels. It is the responsibility of downstream
+    code to do so, if it is printing text to the page.
 - `QuickTermTrait`
   - `createTerm($values)` - Creates and returns a new term entity from an array
     of values.

--- a/docs/development/module/quick.md
+++ b/docs/development/module/quick.md
@@ -149,6 +149,10 @@ Available traits and the methods that they provide include:
     Expects a keyed array of strings to concatenate together, along with an
     optional array of keys that should be prioritized in case the full string
     won't fit.
+  - `assetNamesSummary($assets, $cutoff)` - Generate a summary of asset names
+    for use in a log name. Example: "Asset 1, Asset 2, Asset 3 (+ 15 more)".
+    Note that this does NOT sanitize the asset names. It is the responsibility
+    of downstream code to do so, if it is printing the text to the page.
 - `QuickTermTrait`
   - `createTerm($values)` - Creates and returns a new term entity from an array
     of values.

--- a/modules/core/log/farm_log.module
+++ b/modules/core/log/farm_log.module
@@ -70,6 +70,9 @@ function farm_log_entity_prepare_form(EntityInterface $entity, $operation, FormS
  *
  * @return string
  *   Returns a string summarizing the assets.
+ *
+ * @deprecated in farmOS:2.x and is removed from farmOS:3.x. Use
+ * \Drupal\farm_quick\Traits\QuickStringTrait::assetNamesSummary() instead.
  */
 function farm_log_asset_names_summary(array $assets, $cutoff = 3) {
   /** @var \Drupal\asset\Entity\AssetInterface[] $assets */

--- a/modules/core/log/farm_log.module
+++ b/modules/core/log/farm_log.module
@@ -72,7 +72,7 @@ function farm_log_entity_prepare_form(EntityInterface $entity, $operation, FormS
  *   Returns a string summarizing the assets.
  *
  * @deprecated in farmOS:2.x and is removed from farmOS:3.x. Use
- * \Drupal\farm_quick\Traits\QuickStringTrait::assetNamesSummary() instead.
+ * \Drupal\farm_quick\Traits\QuickStringTrait::entityLabelsSummary() instead.
  */
 function farm_log_asset_names_summary(array $assets, $cutoff = 3) {
   /** @var \Drupal\asset\Entity\AssetInterface[] $assets */

--- a/modules/core/log/farm_log.module
+++ b/modules/core/log/farm_log.module
@@ -77,12 +77,13 @@ function farm_log_asset_names_summary(array $assets, $cutoff = 3) {
   foreach ($assets as $asset) {
     $names[] = $asset->label();
   }
-  $count = count($names);
-  if ($cutoff == 0 || count($names) <= $cutoff) {
-    $output = implode(', ', $names);
+  if ($cutoff != 0) {
+    array_splice($names, $cutoff);
   }
-  else {
-    $output = $names[0] . ' (+' . ($count - 1) . ' ' . t('more') . ')';
+  $output = implode(', ', $names);
+  $diff = count($assets) - count($names);
+  if ($diff > 0) {
+    $output .= ' (+ ' . $diff . ' ' . t('more') . ')';
   }
   return $output;
 }

--- a/modules/core/quick/farm_quick.info.yml
+++ b/modules/core/quick/farm_quick.info.yml
@@ -6,7 +6,6 @@ core_version_requirement: ^9
 dependencies:
   - drupal:taxonomy
   - farm:asset
-  - farm:farm_log
   - farm:farm_log_quantity
   - farm:quantity
   - log:log

--- a/modules/core/quick/farm_quick.info.yml
+++ b/modules/core/quick/farm_quick.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^9
 dependencies:
   - drupal:taxonomy
   - farm:asset
+  - farm:farm_log
   - farm:farm_log_quantity
   - farm:quantity
   - log:log

--- a/modules/core/quick/src/Traits/QuickStringTrait.php
+++ b/modules/core/quick/src/Traits/QuickStringTrait.php
@@ -131,4 +131,27 @@ trait QuickStringTrait {
     return $this->trimString($priority_string, $max_length);
   }
 
+  /**
+   * Generate a summary of asset names for use in a log name.
+   *
+   * Note that this does NOT sanitize the asset names. It is the responsibility
+   * of downstream code to do so, if it is printing the text to the page.
+   *
+   * @param \Drupal\asset\Entity\AssetInterface[] $assets
+   *   An array of assets.
+   * @param int $cutoff
+   *   The number of asset names to include before summarizing the rest.
+   *   If the number of assets exceeds the cutoff, only the first asset's
+   *   name will be included, and the rest will be summarized as "(+ X more)".
+   *   If the number of assets is less than or equal to the cutoff, or if the
+   *   cutoff is 0, all asset names will be included.
+   *
+   * @return string
+   *   Returns a string summarizing the assets.
+   */
+  function assetNamesSummary(array $assets, $cutoff = 3) {
+    // @todo Move logic from farm_log_asset_names_summary() into here.
+    return farm_log_asset_names_summary($assets, $cutoff);
+  }
+
 }

--- a/modules/core/quick/src/Traits/QuickStringTrait.php
+++ b/modules/core/quick/src/Traits/QuickStringTrait.php
@@ -149,7 +149,7 @@ trait QuickStringTrait {
    * @return string
    *   Returns a string summarizing the assets.
    */
-  function assetNamesSummary(array $assets, $cutoff = 3) {
+  protected function assetNamesSummary(array $assets, $cutoff = 3) {
     // @todo Move logic from farm_log_asset_names_summary() into here.
     return farm_log_asset_names_summary($assets, $cutoff);
   }

--- a/modules/core/quick/src/Traits/QuickStringTrait.php
+++ b/modules/core/quick/src/Traits/QuickStringTrait.php
@@ -132,26 +132,38 @@ trait QuickStringTrait {
   }
 
   /**
-   * Generate a summary of asset names for use in a log name.
+   * Generate a summary of entity labels.
    *
-   * Note that this does NOT sanitize the asset names. It is the responsibility
-   * of downstream code to do so, if it is printing the text to the page.
+   * Note that this does NOT sanitize the entity labels. It is the
+   * responsibility of downstream code to do so, if it is printing text to the
+   * page.
    *
-   * @param \Drupal\asset\Entity\AssetInterface[] $assets
-   *   An array of assets.
+   * @param array $entities
+   *   An array of entities.
    * @param int $cutoff
-   *   The number of asset names to include before summarizing the rest.
-   *   If the number of assets exceeds the cutoff, only the first asset's
-   *   name will be included, and the rest will be summarized as "(+ X more)".
-   *   If the number of assets is less than or equal to the cutoff, or if the
-   *   cutoff is 0, all asset names will be included.
+   *   The number of entity labels to include before summarizing the rest.
+   *   If the number of entities exceeds the cutoff, only the first entity's
+   *   label will be included, and the rest will be summarized as "(+ X more)".
+   *   If the number of entities is less than or equal to the cutoff, or if the
+   *   cutoff is 0, all entity labels will be included.
    *
    * @return string
-   *   Returns a string summarizing the assets.
+   *   Returns a string summarizing the entity labels.
    */
-  protected function assetNamesSummary(array $assets, $cutoff = 3) {
-    // @todo Move logic from farm_log_asset_names_summary() into here.
-    return farm_log_asset_names_summary($assets, $cutoff);
+  protected function entityLabelsSummary(array $entities, $cutoff = 3) {
+    $names = [];
+    foreach ($entities as $entity) {
+      $names[] = $entity->label();
+    }
+    if ($cutoff != 0) {
+      array_splice($names, $cutoff);
+    }
+    $output = implode(', ', $names);
+    $diff = count($entities) - count($names);
+    if ($diff > 0) {
+      $output .= ' (+ ' . $diff . ' ' . t('more') . ')';
+    }
+    return $output;
   }
 
 }

--- a/modules/core/quick/tests/src/Kernel/QuickStringTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickStringTest.php
@@ -88,9 +88,9 @@ class QuickStringTest extends KernelTestBase {
   }
 
   /**
-   * Test assetNamesSummary() method.
+   * Test entityLabelsSummary() method.
    */
-  public function testAssetNamesSummary() {
+  public function testEntityLabelsSummary() {
 
     // Create a test asset type.
     $asset_type = AssetType::create([
@@ -114,12 +114,12 @@ class QuickStringTest extends KernelTestBase {
 
     // Test default with a cutoff of 3.
     $expected = $assets[0]->label() . ', ' . $assets[1]->label() . ', ' . $assets[2]->label() . ' (+ 7 more)';
-    $name_summary = $this->assetNamesSummary($assets);
+    $name_summary = $this->entityLabelsSummary($assets);
     $this->assertEquals($expected, $name_summary);
 
     // Test with a cutoff of 1.
     $expected = $assets[0]->label() . ' (+ 9 more)';
-    $name_summary = $this->assetNamesSummary($assets, 1);
+    $name_summary = $this->entityLabelsSummary($assets, 1);
     $this->assertEquals($expected, $name_summary);
 
     // Test with a cutoff of 0.
@@ -128,7 +128,7 @@ class QuickStringTest extends KernelTestBase {
       $labels[] = $asset->label();
     }
     $expected = implode(', ', $labels);
-    $name_summary = $this->assetNamesSummary($assets, 0);
+    $name_summary = $this->entityLabelsSummary($assets, 0);
     $this->assertEquals($expected, $name_summary);
   }
 

--- a/modules/core/quick/tests/src/Kernel/QuickStringTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickStringTest.php
@@ -122,7 +122,7 @@ class QuickStringTest extends KernelTestBase {
     $name_summary = $this->assetNamesSummary($assets, 1);
     $this->assertEquals($expected, $name_summary);
 
-    // Test default with a cutoff of 0.
+    // Test with a cutoff of 0.
     $labels = [];
     foreach ($assets as $asset) {
       $labels[] = $asset->label();

--- a/modules/core/quick/tests/src/Kernel/QuickStringTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickStringTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\farm_quick\Kernel;
 
+use Drupal\asset\Entity\Asset;
+use Drupal\asset\Entity\AssetType;
 use Drupal\farm_quick\Traits\QuickStringTrait;
 use Drupal\KernelTests\KernelTestBase;
 
@@ -18,8 +20,21 @@ class QuickStringTest extends KernelTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'asset',
+    // @todo Remove this dependency in farmOS 3.x.
+    'farm_log',
     'farm_quick',
+    'state_machine',
+    'user',
   ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('asset');
+  }
 
   /**
    * Test trimString() method.
@@ -70,6 +85,51 @@ class QuickStringTest extends KernelTestBase {
     $priority_keys = ['foo', 'baz'];
     $name = $this->prioritizedString($parts, $priority_keys, 10);
     $this->assertEquals('Foo B… Baz', $name);
+  }
+
+  /**
+   * Test assetNamesSummary() method.
+   */
+  public function testAssetNamesSummary() {
+
+    // Create a test asset type.
+    $asset_type = AssetType::create([
+      'id' => 'test',
+      'label' => 'Test',
+      'workflow' => 'asset_default',
+    ]);
+    $asset_type->save();
+
+    // Create 10 assets with randomly generated names.
+    $assets = [];
+    for ($i = 0; $i < 10; $i++) {
+      $asset = Asset::create([
+        'name' => $this->randomString(),
+        'type' => 'test',
+        'status' => 'active',
+      ]);
+      $asset->save();
+      $assets[] = $asset;
+    }
+
+    // Test default with a cutoff of 3.
+    $expected = $assets[0]->label() . ', ' . $assets[1]->label() . ', ' . $assets[2]->label() . ' (+ 7 more)';
+    $name_summary = $this->assetNamesSummary($assets);
+    $this->assertEquals($expected, $name_summary);
+
+    // Test with a cutoff of 1.
+    $expected = $assets[0]->label() . ' (+ 9 more)';
+    $name_summary = $this->assetNamesSummary($assets, 1);
+    $this->assertEquals($expected, $name_summary);
+
+    // Test default with a cutoff of 0.
+    $labels = [];
+    foreach ($assets as $asset) {
+      $labels[] = $asset->label();
+    }
+    $expected = implode(', ', $labels);
+    $name_summary = $this->assetNamesSummary($assets, 0);
+    $this->assertEquals($expected, $name_summary);
   }
 
 }


### PR DESCRIPTION
Opening this PR to start a discussion...

Currently the `farm_log_asset_names_summary()` function is only used in the `AssetMoveActionForm` and `AssetGroupActionForm` classes.

If we were to make both of those into quick forms instead, and redirect to them with assets prepopulated from the bulk action (via https://farmos.org/development/module/quick/#quick-form-actions), we could further unify helper functions like this one into quick form traits. And those bulk actions can delegate to more generally useful quick forms.

This PR doesn't do any of that, but could be a first step in that direction.