### PR TITLE
Remove field links from asset entity browser view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update farmOS-map to [v2.2.1](https://github.com/farmOS/farmOS-map/releases/tag/v2.2.1)
+- [Remove field links from asset entity browser view #673](https://github.com/farmOS/farmOS/pull/673)
 
 ### Fixed
 

--- a/modules/core/ui/views/config/install/views.view.farm_asset.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_asset.yml
@@ -1388,7 +1388,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1517,7 +1517,7 @@ display:
           click_sort_column: target_id
           type: entity_reference_label
           settings:
-            link: true
+            link: false
           group_column: target_id
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
Our asset entity browser opens a table view of assets. Clicking on links within this table opens the link within the same entity browser modal and leaves the user without any clear way to "go back" to the entity browser and select assets.

Removing links from the asset name and current location columns is a simple fix that prevents this from happening.


![Screenshot from 2023-05-09 13-56-52](https://github.com/farmOS/farmOS/assets/3116995/f1780351-e408-452f-9e0d-b2d1aa96c799)

![Screenshot from 2023-05-09 13-57-04](https://github.com/farmOS/farmOS/assets/3116995/3f2a078a-18c3-490b-b624-1fe263f78be4)
