### PR TITLE
Fix farm_log_asset_names_summary() $cutoff parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix bulk move/group action log names when unsetting location/group #669](https://github.com/farmOS/farmOS/pull/669)
+- [Fix farm_log_asset_names_summary() $cutoff parameter #674](https://github.com/farmOS/farmOS/pull/674)
 
 ### Security
 

--- a/modules/core/log/farm_log.module
+++ b/modules/core/log/farm_log.module
@@ -63,10 +63,9 @@ function farm_log_entity_prepare_form(EntityInterface $entity, $operation, FormS
  *   An array of assets.
  * @param int $cutoff
  *   The number of asset names to include before summarizing the rest.
- *   If the number of assets exceeds the cutoff, only the first asset's
- *   name will be included, and the rest will be summarized as "(+ X more)".
- *   If the number of assets is less than or equal to the cutoff, or if the
- *   cutoff is 0, all asset names will be included.
+ *   If the number of assets exceeds the cutoff, the rest will be summarized
+ *   as "(+X more)". If the number of assets is less than or equal to the
+ *   cutoff, or if the cutoff is 0, all asset names will be included.
  *
  * @return string
  *   Returns a string summarizing the assets.
@@ -77,12 +76,13 @@ function farm_log_asset_names_summary(array $assets, $cutoff = 3) {
   foreach ($assets as $asset) {
     $names[] = $asset->label();
   }
-  $count = count($names);
-  if ($cutoff == 0 || count($names) <= $cutoff) {
-    $output = implode(', ', $names);
+  if ($cutoff != 0) {
+    array_splice($names, $cutoff);
   }
-  else {
-    $output = $names[0] . ' (+' . ($count - 1) . ' ' . t('more') . ')';
+  $output = implode(', ', $names);
+  $diff = count($assets) - count($names);
+  if ($diff > 0) {
+    $output .= ' (+' . $diff . ' ' . t('more') . ')';
   }
   return $output;
 }


### PR DESCRIPTION
There is a bug in the way the `$cutoff` parameter of the `farm_log_asset_names_summary()` function works.

https://github.com/farmOS/farmOS/blob/2b3bb21683396fc0b5ec0cd2f5107dc4e4e4d16a/modules/core/log/farm_log.module#L74

It works as expected if the `$cutoff` is `0` (all names are included), or `1` (only the first name is included). Everything else is treated as if `$cutoff` is `1` (only the first name is included).