### PR TITLE
Issue #3359452: Deprecate farm_log_asset_names_summary()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - [QuickFormInterface::getId() is replaced by QuickFormInterface::getQuickId()](https://www.drupal.org/node/3379686)
+- [Issue #3359452: Deprecate farm_log_asset_names_summary()](https://www.drupal.org/project/farm/issues/3359452)
 
 ### Fixed
 

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -199,7 +199,9 @@ class AssetGroupActionForm extends ConfirmFormBase {
       $done = (bool) $form_state->getValue('done', FALSE);
 
       // Generate a name for the log.
+      // @phpstan-ignore-next-line
       $asset_names = farm_log_asset_names_summary($accessible_entities);
+      // @phpstan-ignore-next-line
       $group_names = farm_log_asset_names_summary($groups);
       $log_name = $this->t('Clear group membership of @assets', ['@assets' => Markup::create($asset_names)]);
       if (!empty($group_names)) {

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -229,7 +229,9 @@ class AssetMoveActionForm extends ConfirmFormBase {
       $done = (bool) $form_state->getValue('done', FALSE);
 
       // Generate a name for the log.
+      // @phpstan-ignore-next-line
       $asset_names = farm_log_asset_names_summary($accessible_entities);
+      // @phpstan-ignore-next-line
       $location_names = farm_log_asset_names_summary($locations);
       $log_name = $this->t('Clear location of @assets', ['@assets' => Markup::create($asset_names)]);
       if (!empty($location_names)) {

--- a/modules/core/log/farm_log.module
+++ b/modules/core/log/farm_log.module
@@ -69,6 +69,10 @@ function farm_log_entity_prepare_form(EntityInterface $entity, $operation, FormS
  *
  * @return string
  *   Returns a string summarizing the assets.
+ *
+ * @deprecated in farm:2.2.0 and is removed from farm:3.0.0. Use
+ *   QuickStringTrait::entityLabelsSummary() instead.
+ * @see https://www.drupal.org/node/3359456
  */
 function farm_log_asset_names_summary(array $assets, $cutoff = 3) {
   /** @var \Drupal\asset\Entity\AssetInterface[] $assets */


### PR DESCRIPTION
See https://www.drupal.org/project/farm/issues/3359452

Originally discussed here, and ultimately decided to split it out to a separate PR: https://github.com/farmOS/farmOS/pull/671