### PR TITLE
Changes modules directory so mounted modules are recognized

### DIFF
--- a/docs/development/module/index.md
+++ b/docs/development/module/index.md
@@ -10,7 +10,7 @@ detailed documentation of Drupal development more generally, refer to the
 
 Modules should be placed in the `sites/all/modules` directory of the server's
 document root. If you are using the farmOS Docker image, this will be:
-`/var/opt/drupal/web/sites/all/modules`
+`/opt/drupal/web/sites/all/modules`
 
 A good practice is to download farmOS-specific modules into `modules/farm` to
 keep them separate. You may also consider creating a `modules/custom` directory


### PR DESCRIPTION
Documentation indicated that modules should be added to `/var/opt/drupal/web/sites/all/modules` within the -dev container. However, modules mounted into that location were not recognized by drupal. This PR changes the directory for modules to be `/opt/drupal/web/sites/all/modules`. When modules are mounted into the container in this directory they are recognized by drupal.