### PR TITLE
Remove classy from term tasks test

### DIFF
--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -29,11 +29,6 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
   /**
    * {@inheritdoc}
    */
-  protected $defaultTheme = 'classy';
-
-  /**
-   * {@inheritdoc}
-   */
   protected static $modules = [
     'block',
     'farm_plant',
@@ -109,9 +104,8 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
       return $result;
     };
 
-    $primary_tab_links = $get_array_of_link_text_by_url($this->xpath('//*[contains(@class, :class)]//a', [
-      ':class' => 'tabs primary',
-    ]));
+    // Select links from the first ul inside layout-container.
+    $primary_tab_links = $get_array_of_link_text_by_url($this->xpath('(//div[@class="layout-container"]//ul)[1]/li/a'));
 
     $assert_has_link = function ($elements, $url, $label) {
       $this->assertArrayHasKey($url, $elements, "No link exists with url '$url' among: " . print_r($elements, TRUE));
@@ -124,9 +118,8 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
     $this->drupalGet("$fava_term_url/assets/all");
     $this->assertSession()->statusCodeEquals(200);
 
-    $secondary_tab_links = $get_array_of_link_text_by_url($this->xpath('//*[contains(@class, :class)]//a', [
-      ':class' => 'tabs secondary',
-    ]));
+    // Select links from the second ul inside layout-container.
+    $secondary_tab_links = $get_array_of_link_text_by_url($this->xpath('(//div[@class="layout-container"]//ul)[2]/li/a'));
 
     $this->assertCount(3, $secondary_tab_links, 'Only 3 secondary tabs appear.');
 


### PR DESCRIPTION
Classy is now deprecated and will be removed from D10. This will default to using the `stark` base theme.

This ends up using the `menu-local-tasks` template from the core `system` theme: https://git.drupalcode.org/project/drupal/-/blob/9.5.8/core/modules/system/templates/menu-local-tasks.html.twig

Updating the logic to select links as either from the 1st or 2nd `ul` to determine primary/secondary works.