### PR TITLE
Use a single process for MariaDB tests

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -95,7 +95,7 @@ jobs:
             processes: auto
           - dbms: mariadb
             DB_URL: mysql://farm:farm@db/farm
-            processes: auto
+            processes: 1
           - dbms: sqlite
             DB_URL: sqlite://localhost/sites/default/files/db.sqlite
             processes: 1


### PR DESCRIPTION
MariaDB tests fail a large percentage of the time in GitHub Actions with the following error:

```
Failed to run installer database tasks: Failed to connect to your database server. The server reports the following message: SQLSTATE[HY000] [2002] Connection refused.
- Is the database server running?
- Does the database exist or does the database user have sufficient privileges to create the database?
- Have you entered the correct database name?
- Have you entered the correct username and password?
- Have you entered the correct database hostname and port number?
```