### PR TITLE
Fix undeclared dependency on farm_group in birth quick form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix undeclared dependency on farm_group in birth quick form #682](https://github.com/farmOS/farmOS/pull/682)
+
 ## [2.1.0] 2023-05-19
 
 This is the first minor release of the farmOS 2.x branch, following

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -9,7 +9,6 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\farm_group\GroupMembershipInterface;
 use Drupal\farm_location\AssetLocationInterface;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickAssetTrait;
@@ -67,13 +66,6 @@ class Birth extends QuickFormBase {
   protected $assetLocation;
 
   /**
-   * Group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface
-   */
-  protected $groupMembership;
-
-  /**
    * Current user object.
    *
    * @var \Drupal\Core\Session\AccountInterface
@@ -99,18 +91,15 @@ class Birth extends QuickFormBase {
    *   The config factory service.
    * @param \Drupal\farm_location\AssetLocationInterface $asset_location
    *   Asset location service.
-   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
-   *   Group membership service.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, GroupMembershipInterface $group_membership, AccountInterface $current_user) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
     $this->entityTypeManager = $entity_type_manager;
     $this->moduleHandler = $module_handler;
     $this->configFactory = $config_factory;
     $this->assetLocation = $asset_location;
-    $this->groupMembership = $group_membership;
     $this->currentUser = $current_user;
   }
 
@@ -127,7 +116,6 @@ class Birth extends QuickFormBase {
       $container->get('module_handler'),
       $container->get('config.factory'),
       $container->get('asset.location'),
-      $container->get('group.membership'),
       $container->get('current_user'),
     );
   }
@@ -492,7 +480,8 @@ class Birth extends QuickFormBase {
         $group = [$this->entityTypeManager->getStorage('asset')->load($group)];
       }
       if (empty($group)) {
-        $group = $this->groupMembership->getGroup($birth_mother, $birthdate->getTimestamp());
+        // @phpstan-ignore-next-line
+        $group = \Drupal::service('group.membership')->getGroup($birth_mother, $birthdate->getTimestamp());
       }
       if (!empty($group)) {
         $birth_log_values['group'] = $group;


### PR DESCRIPTION
Discovered a bug with the new birth quick form today. It is supposed to optionally add support for Group Membership, but if the `farm_group` module is not enabled the following error occurs and it is impossible to open the quick form (or even the `/quick` index page):

```
Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException: You have requested a non-existent service "group.membership". in Drupal\Component\DependencyInjection\Container->get() (line 157 of /opt/drupal/web/core/lib/Drupal/Component/DependencyInjection/Container.php).
```

This is because the birth quick form tries to inject the `group.membership` service as a dependency.

This PR fixes the issue by removing the injected dependency and using `\Drupal::service('group.membership')` instead.

A `// @phpstan-ignore-next-line` is added above this line to allow PHPStan tests to pass.