### PR TITLE
Update composer.md guide to capture locked farmOS version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Update composer.md guide to capture locked farmOS version #697](https://github.com/farmOS/farmOS/pull/697)
+
 ### Fixed
 
 - [Leaving empty the Parent field in the Assign Parent For This Asset form leads to unexpected error #683](https://github.com/farmOS/farmOS/issues/683)

--- a/docs/hosting/composer.md
+++ b/docs/hosting/composer.md
@@ -213,6 +213,9 @@ Example `Dockerfile`:
 # Inherit from the upsteam farmOS 2.x image.
 FROM farmos/farmos:2.x
 
+# Install `jq` to help in extracting the farmOS version below.
+RUN apt-get update && apt-get install -y jq
+
 # Create a fresh /var/farmOS directory.
 RUN rm -r /var/farmOS && mkdir /var/farmOS
 
@@ -223,6 +226,11 @@ COPY composer.lock /var/farmOS/composer.lock
 # Build the farmOS codebase with Composer as the www-data user in /var/farmOS
 # with the --no-dev flag.
 RUN (cd /var/farmOS; composer install --no-dev)
+
+# Set the version in farm.info.yml to match the version locked by Composer.
+# This is optional but is useful because the version will appear as the
+# "Installation Profile" version at `/admin/reports/status` in farmOS.
+RUN sed -i "s|version: 2.x|version: $(jq -r '.packages[] | select(.name == "farmos/farmos").version' /var/farmOS/composer.lock)|g" /var/farmOS/web/profiles/farm/farm.info.yml
 
 # Copy the farmOS codebase into /opt/drupal.
 RUN rm -r /opt/drupal && cp -rp /var/farmOS /opt/drupal


### PR DESCRIPTION
Having the version appear in the status report can be really helpful for debugging and improves the overall polish of these instructions IMHO :)