### PR TITLE
Improve asset bundle logic in ID tag widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Leaving empty the Parent field in the Assign Parent For This Asset form leads to unexpected error #683](https://github.com/farmOS/farmOS/issues/683)
 - [Correct namespace for MigrateToolsCommands #700](https://github.com/farmOS/farmOS/pull/700)
+- [Improve asset bundle logic in ID tag widget #699](https://github.com/farmOS/farmOS/pull/699)
 
 ## [2.1.1] 2023-05-23
 

--- a/modules/core/id_tag/src/Plugin/Field/FieldWidget/IdTagWidget.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldWidget/IdTagWidget.php
@@ -36,7 +36,7 @@ class IdTagWidget extends WidgetBase {
     $tag_type = $items[$delta]->type ?? NULL;
 
     // Get the current asset bundle.
-    $bundle = $form_state->getStorage()['form_display']->get('bundle');
+    $bundle = $items->getParent()->getEntity()->bundle();
 
     // Load allowed tag types.
     $tag_types = farm_id_tag_type_options($bundle);


### PR DESCRIPTION
This fixes a bug where assets cannot be used in an inline entity form because the ID Tag widget assumes it is being used in the context of an entity form_display:

> Warning: Undefined array key "form_display" in Drupal\farm_id_tag\Plugin\Field\FieldWidget\IdTagWidget->formElement() (line 39 of /var/www/html/web/profiles/farm/modules/core/id_tag/src/Plugin/Field/FieldWidget/IdTagWidget.php)

Inline entity forms and likely other entity forms may not use the form_display key in form storage so using the entity from the FieldItemList is more robust.