### PR TITLE
Correct namespace for MigrateToolsCommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Leaving empty the Parent field in the Assign Parent For This Asset form leads to unexpected error #683](https://github.com/farmOS/farmOS/issues/683)
+- [Correct namespace for MigrateToolsCommands #700](https://github.com/farmOS/farmOS/pull/700)
 
 ## [2.1.1] 2023-05-23
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "drupal/jsonapi_extras": "^3.15",
         "drupal/jsonapi_schema": "1.0-beta2",
         "drupal/log": "^2.0.2",
-        "drupal/migrate_plus": "^6.0",
+        "drupal/migrate_plus": "^6.0.2",
         "drupal/migrate_tools": "^6.0",
         "drupal/simple_oauth": "5.2.3",
         "drupal/state_machine": "^1.0",

--- a/modules/core/migrate/src/Commands/FarmMigrateCommands.php
+++ b/modules/core/migrate/src/Commands/FarmMigrateCommands.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\farm_migrate\Commands;
 
-use Drupal\migrate_tools\Commands\MigrateToolsCommands;
+use Drupal\migrate_tools\Drush\MigrateToolsCommands;
 
 /**
  * Farm Migrate Drush commands.


### PR DESCRIPTION
This changed in the 6.0.2 release of migrate_tools to support Drush 12: https://www.drupal.org/node/3372643
This commit: https://git.drupalcode.org/project/migrate_tools/-/commit/748cc794a163bf5259a07eaefbcb635bc99df589

Currently if someone installs farmOS 2.1.1 with migrate_tools 6.0.2 our migration commands will not work. We had already been using migrate_tools ^6.0 so I think we only need to update our dependency version to ^6.0.2 and use the new namespace for `MigrateToolsCommands`. This will then be fixed in the next release of farmOS.

Also notable the Drush 12 release notes: https://github.com/drush-ops/drush/releases/tag/12.0.0

> Compatible with Drupal 10+.
Existing commands should run without modification unless you are doing something exotic.
Changing commands to use [PHP Attributes](https://www.drush.org/11.x/commands/#attributes-or-annotations) and [static create() factory](https://www.drush.org/11.x/dependency-injection/#create-method) may be done at your leisure, before Drupal 13.

So I don't think we need to make changes to our migrate commands for Drush 12. Also Drush 12 only works with D10+ so not a concern yet.