### PR TITLE
Use access content permission in farm_ui_views test

### DIFF
--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -45,7 +45,7 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
     $this->drupalPlaceBlock('local_tasks_block');
 
     // Create/login a user with permission to access taxonomy pages and assets.
-    $this->user = $this->createUser(['administer taxonomy', 'view any asset']);
+    $this->user = $this->createUser(['access content', 'view any asset']);
     $this->drupalLogin($this->user);
 
     $entity_type_manager = $this->container->get('entity_type.manager');


### PR DESCRIPTION
The administer taxonomy permission should not be used in tests because we do not grant the permission to standard farmOS roles. Taxonomy terms can be viewed with the access content permission.

https://github.com/farmOS/farmOS/blob/a1b315c9026e1dca54d31fb1a20e69c4e3eb59e8/modules/core/role/src/ManagedRolePermissionsManager.php#L290-L293