### PR TITLE
Update dispatch() argument order for Symfony 5

### DIFF
--- a/modules/core/map/src/Element/FarmMap.php
+++ b/modules/core/map/src/Element/FarmMap.php
@@ -109,7 +109,7 @@ class FarmMap extends RenderElement {
 
     // Create and dispatch a MapRenderEvent.
     $event = new MapRenderEvent($map, $element, $entity_type_manager);
-    \Drupal::service('event_dispatcher')->dispatch(MapRenderEvent::EVENT_NAME, $event);
+    \Drupal::service('event_dispatcher')->dispatch($event, MapRenderEvent::EVENT_NAME);
 
     // Return the element.
     return $event->element;

--- a/modules/core/quantity/quantity.module
+++ b/modules/core/quantity/quantity.module
@@ -125,7 +125,7 @@ function quantity_quantity_presave(QuantityInterface $quantity) {
   // @todo Replace this with core event via https://www.drupal.org/node/2551893.
   $event = new QuantityEvent($quantity);
   $event_dispatcher = \Drupal::service('event_dispatcher');
-  $event_dispatcher->dispatch(QuantityEvent::PRESAVE, $event);
+  $event_dispatcher->dispatch($event, QuantityEvent::PRESAVE);
 }
 
 /**
@@ -137,7 +137,7 @@ function quantity_quantity_delete(QuantityInterface $quantity) {
   // @todo Replace this with core event via https://www.drupal.org/node/2551893.
   $event = new QuantityEvent($quantity);
   $event_dispatcher = \Drupal::service('event_dispatcher');
-  $event_dispatcher->dispatch(QuantityEvent::DELETE, $event);
+  $event_dispatcher->dispatch($event, QuantityEvent::DELETE);
 }
 
 /**


### PR DESCRIPTION
The following deprecation notice appears in tests currently:

```
  2x: Calling the Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch() method with a string event name as the first argument is deprecated in drupal:9.1.0, an Event object will be required instead in drupal:10.0.0. See https://www.drupal.org/node/3154407
    2x in QuickFormTest::testQuickFormSubmission from Drupal\Tests\farm_quick\Kernel
```

This fixes it by swapping the parameters passed to `dispatch()`.

See https://www.drupal.org/node/3154407