### PR TITLE
Wrap all entity labels with Markup::create() in translated log names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix composer.json version constraints for migrate_plus and migrate_tools #702](https://github.com/farmOS/farmOS/pull/702)
+- [Fix birth log quick form apostrophe becomes &#039; #698](https://github.com/farmOS/farmOS/issues/698)
 
 ## [2.1.2] 2023-07-18
 

--- a/modules/asset/group/src/Form/AssetGroupActionForm.php
+++ b/modules/asset/group/src/Form/AssetGroupActionForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
@@ -200,9 +201,9 @@ class AssetGroupActionForm extends ConfirmFormBase {
       // Generate a name for the log.
       $asset_names = farm_log_asset_names_summary($accessible_entities);
       $group_names = farm_log_asset_names_summary($groups);
-      $log_name = $this->t('Clear group membership of @assets', ['@assets' => $asset_names]);
+      $log_name = $this->t('Clear group membership of @assets', ['@assets' => Markup::create($asset_names)]);
       if (!empty($group_names)) {
-        $log_name = $this->t('Group @assets into @groups', ['@assets' => $asset_names, '@groups' => $group_names]);
+        $log_name = $this->t('Group @assets into @groups', ['@assets' => Markup::create($asset_names), '@groups' => Markup::create($group_names)]);
       }
 
       // Create the log.

--- a/modules/core/location/src/Form/AssetMoveActionForm.php
+++ b/modules/core/location/src/Form/AssetMoveActionForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
@@ -230,9 +231,9 @@ class AssetMoveActionForm extends ConfirmFormBase {
       // Generate a name for the log.
       $asset_names = farm_log_asset_names_summary($accessible_entities);
       $location_names = farm_log_asset_names_summary($locations);
-      $log_name = $this->t('Clear location of @assets', ['@assets' => $asset_names]);
+      $log_name = $this->t('Clear location of @assets', ['@assets' => Markup::create($asset_names)]);
       if (!empty($location_names)) {
-        $log_name = $this->t('Move @assets to @locations', ['@assets' => $asset_names, '@locations' => $location_names]);
+        $log_name = $this->t('Move @assets to @locations', ['@assets' => Markup::create($asset_names), '@locations' => Markup::create($location_names)]);
       }
 
       // Create the log.

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\farm_group\GroupMembershipInterface;
 use Drupal\farm_location\AssetLocationInterface;
@@ -443,7 +444,7 @@ class Birth extends QuickFormBase {
         $this->createLog([
           'type' => 'observation',
           'timestamp' => $birthdate->getTimestamp(),
-          'name' => $this->t('Weight of @asset is @weight @units', ['@asset' => $asset->label(), '@weight' => $child['weight'], '@units' => $this->birthWeightUnits()]),
+          'name' => $this->t('Weight of @asset is @weight @units', ['@asset' => Markup::create($asset->label()), '@weight' => $child['weight'], '@units' => $this->birthWeightUnits()]),
           'asset' => [$asset],
           'quantity' => [
             [
@@ -473,7 +474,7 @@ class Birth extends QuickFormBase {
     foreach ($children as $child) {
       $child_names[] = $child->label();
     }
-    $birth_log_values['name'] = $this->t('Birth: @children', ['@children' => $this->trimString(implode(', ', $child_names), 180)]);
+    $birth_log_values['name'] = $this->t('Birth: @children', ['@children' => Markup::create($this->trimString(implode(', ', $child_names), 180))]);
 
     // If the birth mother has a location (at the time of birth), use the birth
     // log to set the location of the children.

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -470,11 +470,7 @@ class Birth extends QuickFormBase {
     ];
 
     // Generate the birth log name.
-    $child_names = [];
-    foreach ($children as $child) {
-      $child_names[] = $child->label();
-    }
-    $birth_log_values['name'] = $this->t('Birth: @children', ['@children' => Markup::create($this->trimString(implode(', ', $child_names), 180))]);
+    $birth_log_values['name'] = $this->t('Birth: @children', ['@children' => Markup::create($this->entityLabelsSummary($children))]);
 
     // If the birth mother has a location (at the time of birth), use the birth
     // log to set the location of the children.

--- a/modules/quick/birth/tests/Kernel/QuickBirthTest.php
+++ b/modules/quick/birth/tests/Kernel/QuickBirthTest.php
@@ -156,7 +156,7 @@ class QuickBirthTest extends QuickFormTestBase {
       'child_count' => 2,
       'children' => [
         [
-          'name' => 'Child 1',
+          'name' => "Suzie's child",
           'tag' => [
             'id' => '123',
             'type' => 'ear_tag',
@@ -200,7 +200,7 @@ class QuickBirthTest extends QuickFormTestBase {
 
     // Confirm that the first child animal asset contains all the expected data.
     $child1 = $assets[6];
-    $this->assertEquals('Child 1', $child1->label());
+    $this->assertEquals("Suzie's child", $child1->label());
     $this->assertEquals($breed2->id(), $child1->get('animal_type')->target_id);
     $this->assertEquals($today->getTimestamp(), $child1->get('birthdate')->value);
     $this->assertEquals('F', $child1->get('sex')->value);
@@ -239,7 +239,7 @@ class QuickBirthTest extends QuickFormTestBase {
     $weight_log = $logs[2];
     $this->assertEquals('observation', $weight_log->bundle());
     $this->assertEquals($today->getTimestamp(), $weight_log->get('timestamp')->value);
-    $this->assertEquals('Weight of Child 1 is 10 kg', $weight_log->label());
+    $this->assertEquals("Weight of Suzie's child is 10 kg", $weight_log->label());
     $this->assertEquals($child1->id(), $weight_log->get('asset')->referencedEntities()[0]->id());
     $this->assertEquals('weight', $weight_log->get('quantity')->referencedEntities()[0]->get('measure')->value);
     $this->assertEquals('10', $weight_log->get('quantity')->referencedEntities()[0]->get('value')[0]->get('decimal')->getValue());
@@ -250,7 +250,7 @@ class QuickBirthTest extends QuickFormTestBase {
     $birth_log = $logs[3];
     $this->assertEquals('birth', $birth_log->bundle());
     $this->assertEquals($today->getTimestamp(), $birth_log->get('timestamp')->value);
-    $this->assertEquals('Birth: Child 1, Child 2', $birth_log->label());
+    $this->assertEquals("Birth: Suzie's child, Child 2", $birth_log->label());
     $this->assertEquals($child1->id(), $birth_log->get('asset')->referencedEntities()[0]->id());
     $this->assertEquals($child2->id(), $birth_log->get('asset')->referencedEntities()[1]->id());
     $this->assertEquals($birth_mother->id(), $birth_log->get('mother')->referencedEntities()[0]->id());

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\farm_location\AssetLocationInterface;
@@ -314,9 +315,9 @@ class Movement extends QuickFormBase implements QuickFormInterface {
     // Generate a name for the log.
     $asset_names = $this->entityLabelsSummary($assets);
     $location_names = $this->entityLabelsSummary($locations);
-    $log['name'] = $this->t('Clear location of @assets', ['@assets' => $asset_names]);
+    $log['name'] = $this->t('Clear location of @assets', ['@assets' => Markup::create($asset_names)]);
     if (!empty($location_names)) {
-      $log['name'] = $this->t('Move @assets to @locations', ['@assets' => $asset_names, '@locations' => $location_names]);
+      $log['name'] = $this->t('Move @assets to @locations', ['@assets' => Markup::create($asset_names), '@locations' => Markup::create($location_names)]);
     }
 
     // Create the log.

--- a/modules/quick/movement/tests/Kernel/QuickMovementTest.php
+++ b/modules/quick/movement/tests/Kernel/QuickMovementTest.php
@@ -58,7 +58,7 @@ class QuickMovementTest extends QuickFormTestBase {
     ]);
     $equipment1->save();
     $equipment2 = Asset::create([
-      'name' => 'Combine',
+      'name' => "Mike's Combine",
       'type' => 'equipment',
       'status' => 'active',
     ]);
@@ -116,7 +116,7 @@ class QuickMovementTest extends QuickFormTestBase {
     $log = $logs[1];
     $this->assertEquals('activity', $log->bundle());
     $this->assertEquals($today->getTimestamp(), $log->get('timestamp')->value);
-    $this->assertEquals('Move Tractor, Combine to Field A, Field B', $log->label());
+    $this->assertEquals("Move Tractor, Mike's Combine to Field A, Field B", $log->label());
     $this->assertEquals($equipment1->id(), $log->get('asset')->referencedEntities()[0]->id());
     $this->assertEquals($equipment2->id(), $log->get('asset')->referencedEntities()[1]->id());
     $this->assertEquals($location1->id(), $log->get('location')->referencedEntities()[0]->id());

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -7,6 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
@@ -516,15 +517,15 @@ class Planting extends QuickFormBase {
       // Name the log based on the type and asset.
       switch ($log_type) {
         case 'seeding':
-          $log_name = $this->t('Seed @asset', ['@asset' => $plant_asset->label()]);
+          $log_name = $this->t('Seed @asset', ['@asset' => Markup::create($plant_asset->label())]);
           break;
 
         case 'transplanting':
-          $log_name = $this->t('Transplant @asset', ['@asset' => $plant_asset->label()]);
+          $log_name = $this->t('Transplant @asset', ['@asset' => Markup::create($plant_asset->label())]);
           break;
 
         case 'harvest':
-          $log_name = $this->t('Harvest @asset', ['@asset' => $plant_asset->label()]);
+          $log_name = $this->t('Harvest @asset', ['@asset' => Markup::create($plant_asset->label())]);
           break;
       }
 

--- a/modules/quick/planting/tests/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/Kernel/QuickPlantingTest.php
@@ -64,7 +64,7 @@ class QuickPlantingTest extends QuickFormTestBase {
     ]);
     $season->save();
     $crop = Term::create([
-      'name' => 'Rice',
+      'name' => "Jacob's Cattle Bean",
       'vid' => 'plant_type',
     ]);
     $crop->save();
@@ -84,7 +84,7 @@ class QuickPlantingTest extends QuickFormTestBase {
     // Check that the asset's fields were populated correctly.
     $asset = $assets[1];
     $this->assertEquals('plant', $asset->bundle());
-    $this->assertEquals('2022 Rice', $asset->label());
+    $this->assertEquals("2022 Jacob's Cattle Bean", $asset->label());
     $this->assertEquals('active', $asset->get('status')->value);
     $this->assertEquals($season->id(), $asset->get('season')->referencedEntities()[0]->id());
     $this->assertEquals($crop->id(), $asset->get('plant_type')->referencedEntities()[0]->id());
@@ -123,7 +123,7 @@ class QuickPlantingTest extends QuickFormTestBase {
     $this->assertEquals($crop2->id(), $asset->get('plant_type')->referencedEntities()[1]->id());
 
     // Test overriding the plant name.
-    $custom_name = 'Rice of the 2022 season';
+    $custom_name = "Jacob's Cattle Bean of the 2022 season";
     $this->submitQuickForm([
       'seasons' => [['target_id' => $season->id()]],
       'crops' => [


### PR DESCRIPTION
Fixes https://github.com/farmOS/farmOS/issues/698 (and similar issues in other quick forms and bulk actions).