### PR TITLE
Add an Account Admin role with permission to administer users and assign managed roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add an Account Admin role with permission to administer users and assign managed roles #714](https://github.com/farmOS/farmOS/pull/714)
+
 ### Changed
 
 - [Use Gin border radius for the map #710](https://github.com/farmOS/farmOS/pull/710)

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "drupal/log": "^2.0.2",
         "drupal/migrate_plus": "^6.0",
         "drupal/migrate_tools": "^6.0.2",
+        "drupal/role_delegation": "^1.2",
         "drupal/simple_oauth": "5.2.3",
         "drupal/state_machine": "^1.0",
         "drupal/subrequests": "^3.0.3",

--- a/farm.profile
+++ b/farm.profile
@@ -58,6 +58,7 @@ function farm_modules() {
       'farm_import_kml' => t('KML asset importer'),
       'farm_fieldkit' => t('Field Kit integration'),
       'farm_l10n' => t('Translation/localization features'),
+      'farm_role_account_admin' => t('Account Admin role'),
     ],
   ];
 }

--- a/modules/core/role/modules/account_admin/config/install/user.role.farm_account_admin.yml
+++ b/modules/core/role/modules/account_admin/config/install/user.role.farm_account_admin.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_role_account_admin
+  module:
+    - farm_role
+id: farm_account_admin
+label: 'Account Admin'
+weight: 1
+is_admin: false
+permissions:
+  - 'administer farm settings'
+  - 'administer users'
+third_party_settings:
+  farm_role:
+    access:
+      config: true
+      entity:
+        view all: true
+        create all: true
+        update all: true
+        delete all: true

--- a/modules/core/role/modules/account_admin/config/install/user.role.farm_account_admin.yml
+++ b/modules/core/role/modules/account_admin/config/install/user.role.farm_account_admin.yml
@@ -18,7 +18,7 @@ third_party_settings:
     access:
       config: true
       entity:
-        view all: true
-        create all: true
-        update all: true
-        delete all: true
+        view all: false
+        create all: false
+        update all: false
+        delete all: false

--- a/modules/core/role/modules/account_admin/config/schema/farm_role_account_admin.schema.yml
+++ b/modules/core/role/modules/account_admin/config/schema/farm_role_account_admin.schema.yml
@@ -1,0 +1,7 @@
+farm_role_account_admin.settings:
+  type: config_object
+  label: 'farmOS Account Admin Role settings'
+  mapping:
+    allow_peer_role_assignment:
+      type: boolean
+      label: 'Allow users with the Account Admin role to assign/revoke the Account Admin role.'

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.info.yml
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.info.yml
@@ -1,0 +1,9 @@
+name: farmOS Account Admin Role
+description: Provides an Account Admin role for managing users.
+type: module
+package: farmOS
+core_version_requirement: ^9
+dependencies:
+  - farm:farm_role
+  - farm:farm_settings
+  - role_delegation:role_delegation

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.links.task.yml
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.links.task.yml
@@ -1,0 +1,5 @@
+farm_role_account_admin.settings:
+  base_route: farm_settings.settings_page
+  route_name: farm_role_account_admin.settings
+  title: 'Account Admin'
+  weight: 5

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.managed_role_permissions.yml
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.managed_role_permissions.yml
@@ -1,0 +1,3 @@
+farm_role_account_admin:
+  permission_callbacks:
+    - Drupal\farm_role_account_admin\AccountAdminPermissions::permissions

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.module
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.module
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Hooks implemented by the farmOS Account Admin Role module.
+ */
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_access().
+ */
+function farm_role_account_admin_user_access(EntityInterface $entity, $operation, AccountInterface $account) {
+
+  // Only user 1 can access user 1.
+  if ($entity->id() == 1 && $account->id() != 1) {
+    return AccessResult::forbidden();
+  }
+  return AccessResult::neutral();
+}

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.permissions.yml
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.permissions.yml
@@ -1,0 +1,2 @@
+configure account admin role:
+  title: 'Configure Account Admin role'

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.routing.yml
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.routing.yml
@@ -4,4 +4,4 @@ farm_role_account_admin.settings:
     _form: '\Drupal\farm_role_account_admin\Form\AccountAdminSettingsForm'
     _title: 'Account Admin Role settings'
   requirements:
-    _permission: 'administer farm settings'
+    _permission: 'configure account admin role'

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.routing.yml
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.routing.yml
@@ -1,0 +1,7 @@
+farm_role_account_admin.settings:
+  path: 'farm/settings/account-admin'
+  defaults:
+    _form: '\Drupal\farm_role_account_admin\Form\AccountAdminSettingsForm'
+    _title: 'Account Admin Role settings'
+  requirements:
+    _permission: 'administer farm settings'

--- a/modules/core/role/modules/account_admin/src/AccountAdminPermissions.php
+++ b/modules/core/role/modules/account_admin/src/AccountAdminPermissions.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\farm_role_account_admin;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\farm_role\ManagedRolePermissionsManagerInterface;
+use Drupal\user\RoleInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Add permissions to the Account Admin role.
+ */
+class AccountAdminPermissions implements ContainerInjectionInterface {
+
+  /**
+   * The managed role permissions manager.
+   *
+   * @var \Drupal\farm_role\ManagedRolePermissionsManagerInterface
+   */
+  protected $managedRolePermissionsManager;
+
+  /**
+   * Constructs an AccountAdminPermissions object.
+   *
+   * @param \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_permissions_manager
+   *   The managed role permissions manager.
+   */
+  public function __construct(ManagedRolePermissionsManagerInterface $managed_role_permissions_manager) {
+    $this->managedRolePermissionsManager = $managed_role_permissions_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('plugin.manager.managed_role_permissions'),
+    );
+  }
+
+  /**
+   * Add permissions to default farmOS roles.
+   *
+   * @param \Drupal\user\RoleInterface $role
+   *   The role to add permissions to.
+   *
+   * @return array
+   *   An array of permission strings.
+   */
+  public function permissions(RoleInterface $role) {
+    $perms = [];
+
+    // Add permissions to the farm_account_admin role.
+    if ($role->id() == 'farm_account_admin') {
+
+      // Grant the ability to assign managed farmOS roles.
+      $roles = $this->managedRolePermissionsManager->getMangedRoles();
+      foreach ($roles as $role) {
+        $perms[] = 'assign ' . $role->id() . ' role';
+      }
+    }
+
+    return $perms;
+  }
+
+}

--- a/modules/core/role/modules/account_admin/src/AccountAdminPermissions.php
+++ b/modules/core/role/modules/account_admin/src/AccountAdminPermissions.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\farm_role_account_admin;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\farm_role\ManagedRolePermissionsManagerInterface;
 use Drupal\user\RoleInterface;
@@ -20,13 +21,23 @@ class AccountAdminPermissions implements ContainerInjectionInterface {
   protected $managedRolePermissionsManager;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
    * Constructs an AccountAdminPermissions object.
    *
    * @param \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_permissions_manager
    *   The managed role permissions manager.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory service.
    */
-  public function __construct(ManagedRolePermissionsManagerInterface $managed_role_permissions_manager) {
+  public function __construct(ManagedRolePermissionsManagerInterface $managed_role_permissions_manager, ConfigFactoryInterface $config_factory) {
     $this->managedRolePermissionsManager = $managed_role_permissions_manager;
+    $this->configFactory = $config_factory;
   }
 
   /**
@@ -35,6 +46,7 @@ class AccountAdminPermissions implements ContainerInjectionInterface {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('plugin.manager.managed_role_permissions'),
+      $container->get('config.factory'),
     );
   }
 
@@ -53,9 +65,20 @@ class AccountAdminPermissions implements ContainerInjectionInterface {
     // Add permissions to the farm_account_admin role.
     if ($role->id() == 'farm_account_admin') {
 
+      // Load the module settings.
+      $settings = $this->configFactory->get('farm_role_account_admin.settings');
+
       // Grant the ability to assign managed farmOS roles.
       $roles = $this->managedRolePermissionsManager->getMangedRoles();
       foreach ($roles as $role) {
+
+        // Do not allow assigning the "Account Admin" role if
+        // allow_peer_role_assignment is disabled.
+        if ($role->id() == 'farm_account_admin' && !$settings->get('allow_peer_role_assignment', FALSE)) {
+          continue;
+        }
+
+        // Add permission to assign the role.
         $perms[] = 'assign ' . $role->id() . ' role';
       }
     }

--- a/modules/core/role/modules/account_admin/src/Form/AccountAdminSettingsForm.php
+++ b/modules/core/role/modules/account_admin/src/Form/AccountAdminSettingsForm.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\farm_role_account_admin\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides a settings form for the Account Admin Role module.
+ */
+class AccountAdminSettingsForm extends ConfigFormbase {
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'farm_role_account_admin.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_role_account_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateinterface $form_state) {
+    $config = $this->config(static::SETTINGS);
+
+    $form['allow_peer_role_assignment'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Allow peer role assignment'),
+      '#description' => $this->t('Allow users with the Account Admin role to assign/revoke the Account Admin role.'),
+      '#default_value' => $config->get('allow_peer_role_assignment'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->configFactory->getEditable(static::SETTINGS)
+      ->set('allow_peer_role_assignment', $form_state->getValue('allow_peer_role_assignment'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/core/role/modules/account_admin/src/Form/AccountAdminSettingsForm.php
+++ b/modules/core/role/modules/account_admin/src/Form/AccountAdminSettingsForm.php
@@ -2,8 +2,11 @@
 
 namespace Drupal\farm_role_account_admin\Form;
 
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a settings form for the Account Admin Role module.
@@ -16,6 +19,36 @@ class AccountAdminSettingsForm extends ConfigFormbase {
    * @var string
    */
   const SETTINGS = 'farm_role_account_admin.settings';
+
+  /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
+   * Constructs a \Drupal\system\ConfigFormBase object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
+   *   The cache tags invalidator.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+    $this->setConfigFactory($config_factory);
+    $this->cacheTagsInvalidator = $cache_tags_invalidator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('cache_tags.invalidator'),
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -56,6 +89,9 @@ class AccountAdminSettingsForm extends ConfigFormbase {
     $this->configFactory->getEditable(static::SETTINGS)
       ->set('allow_peer_role_assignment', $form_state->getValue('allow_peer_role_assignment'))
       ->save();
+
+    // Invalidate the user_role:farm_account_admin cache tag.
+    $this->cacheTagsInvalidator->invalidateTags(['user_role:farm_account_admin']);
 
     parent::submitForm($form, $form_state);
   }

--- a/modules/core/role/modules/account_admin/tests/src/Functional/UserAccessTest.php
+++ b/modules/core/role/modules/account_admin/tests/src/Functional/UserAccessTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\Tests\farm_role_account_admin\Functional;
+
+use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+
+/**
+ * Tests access to user 1.
+ *
+ * @group farm
+ */
+class UserAccessTest extends FarmBrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_role_account_admin',
+  ];
+
+  /**
+   * Test user 1 access.
+   */
+  public function testUser1Access() {
+
+    // Create and login a user with farm_account_admin role.
+    $user = $this->createUser();
+    $user->addRole('farm_account_admin');
+    $user->save();
+    $this->drupalLogin($user);
+
+    // Confirm that the user cannot access user 1.
+    $this->drupalGet('user/1');
+    $this->assertSession()->statusCodeEquals(403);
+    $this->drupalGet('user/1/edit');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+}

--- a/modules/core/role/modules/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
+++ b/modules/core/role/modules/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\Tests\farm_role_account_admin\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Tests for Account Admin role permissions.
+ *
+ * @group farm
+ */
+class AccountAdminPermissionsTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_role',
+    'farm_role_account_admin',
+    'farm_role_roles',
+    'farm_settings',
+    'role_delegation',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp():void {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installSchema('system', ['sequences']);
+    $this->installConfig(['farm_role_account_admin', 'farm_role_roles']);
+  }
+
+  /**
+   * Test that the Account Admin role gets appropriate permissions.
+   */
+  public function testAccountAdminPermissions() {
+
+    // Create a user.
+    $user = $this->setUpCurrentUser([], [], FALSE);
+
+    // List Account Admin permissions.
+    $account_admin_permissions = [
+      'administer farm settings',
+      'administer users',
+      'assign farm_account_admin role',
+      'assign farm_manager role',
+      'assign farm_worker role',
+      'assign farm_viewer role',
+    ];
+
+    // Ensure the user does not have permissions.
+    foreach ($account_admin_permissions as $permission) {
+      $this->assertFalse($user->hasPermission($permission));
+    }
+
+    // Add Account Admin role.
+    $user->addRole('farm_account_admin');
+
+    // Ensure the user has permissions.
+    foreach ($account_admin_permissions as $permission) {
+      $this->assertTrue($user->hasPermission($permission));
+    }
+  }
+
+}

--- a/modules/core/role/modules/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
+++ b/modules/core/role/modules/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
@@ -49,7 +49,6 @@ class AccountAdminPermissionsTest extends KernelTestBase {
     $account_admin_permissions = [
       'administer farm settings',
       'administer users',
-      'assign farm_account_admin role',
       'assign farm_manager role',
       'assign farm_worker role',
       'assign farm_viewer role',
@@ -67,6 +66,23 @@ class AccountAdminPermissionsTest extends KernelTestBase {
     foreach ($account_admin_permissions as $permission) {
       $this->assertTrue($user->hasPermission($permission));
     }
+
+    // Ensure the user does not have the "assign farm_account_admin role"
+    // permission.
+    $this->assertFalse($user->hasPermission('assign farm_account_admin role'));
+
+    // Enable the allow_peer_role_assignment setting.
+    $settings = \Drupal::configFactory()->getEditable('farm_role_account_admin.settings');
+    $settings->set('allow_peer_role_assignment', TRUE);
+    $settings->save();
+
+    // Rebuild the container so the configuration change takes effect.
+    $kernel = \Drupal::service('kernel');
+    $kernel->invalidateContainer();
+    $kernel->rebuildContainer();
+
+    // Ensure the user has the "assign farm_account_admin role" permission.
+    $this->assertTrue($user->hasPermission('assign farm_account_admin role'));
   }
 
 }


### PR DESCRIPTION
For consideration: this PR adds a new "Account Admin" role (`farm_account_admin`) to the "farmOS Default Roles" module (`farm_role_roles`) which grants the following permissions:

- `administer farm settings`
- `administer users`
- `assign [role_id] role` (for each of the "managed" farmOS roles)

This is a role that I currently provide on Farmier-hosted farmOS instances, so I thought it might be worth contributing back to core if it is generally useful.

This is helpful in cases where you want to designate certain users as "Account Admins" without giving them full Drupal admin access. Currently, the role with the highest level of permissions in farmOS is "Manager", but they do not have the ability to create new users, edit existing users, or assign roles. On a default farmOS installation on the Drupal admin (uid 1) can do that. This provides a role specifically for that purpose.