### PR TITLE
Exclude block.block.gin_content from farm_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix composer.json version constraints for migrate_plus and migrate_tools #702](https://github.com/farmOS/farmOS/pull/702)
 - [Fix birth log quick form apostrophe becomes &#039; #698](https://github.com/farmOS/farmOS/issues/698)
+- [Exclude block.block.gin_content from farm_update #715](https://github.com/farmOS/farmOS/pull/715)
 
 ## [2.1.2] 2023-07-18
 

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -221,8 +221,10 @@ function farm_ui_theme_farm_ui_theme_region_items(string $entity_type) {
  */
 function farm_ui_theme_farm_update_exclude_config() {
 
-  // Exclude config that we have overridden in hook_install().
+  // Exclude config that we have overridden in hook_install() or the
+  // farm_ui_theme.overrider service.
   return [
     'block.block.gin_local_actions',
+    'block.block.gin_content',
   ];
 }


### PR DESCRIPTION
This fixes an issue I've encountered where the block layout can be configured (specifically the "Content" region) and be left in a "broken state" where the "Powered by farmOS" block is positioned *above* the main content. Also according to the comment in `farm_ui_theme_farm_update_exclude_config` I think this should have already been excluded :-)

This isn't a normal thing users will experience but is a concern for UI development because it leaves things in a "broken" state... For me, I was playing with adding a new block to the top of "Content" region. After I removed the block and tried to "reset" to normal things worked fine. BUT *after clearing the cache* my development instance was left with "Powered by farmOS" at the top each page (above "Main page content". There does not appear to be any way to fix this via the UI.