### PR TITLE
Fix hideable boolean settings form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Fix composer.json version constraints for migrate_plus and migrate_tools #702](https://github.com/farmOS/farmOS/pull/702)
 - [Fix birth log quick form apostrophe becomes &#039; #698](https://github.com/farmOS/farmOS/issues/698)
 - [Exclude block.block.gin_content from farm_update #715](https://github.com/farmOS/farmOS/pull/715)
+- [Fix hideable boolean settings form #718](https://github.com/farmOS/farmOS/pull/718)
 
 ## [2.1.2] 2023-07-18
 

--- a/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
+++ b/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
@@ -44,13 +44,11 @@ class HideableBoolean extends BooleanFormatter {
       '#type' => 'checkbox',
       '#title' => $this->t('Hide if TRUE'),
       '#default_value' => $this->getSetting('hide_if_true'),
-      '#return_value' => TRUE,
     ];
     $form['hide_if_false'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Hide if FALSE'),
       '#default_value' => $this->getSetting('hide_if_false'),
-      '#return_value' => TRUE,
     ];
 
     return $form;


### PR DESCRIPTION
I'm using the `hideable_boolean` formatter on a boolean field but the settings form does not allow turning either value "on", both values are always unchecked and saved as `FALSE` to the display configuration. Removing these `#return_value` lines solves the problem and the form behaves as expected.

I'm not quite sure why we (I think it was me) included `#return_value`... I did a little searching and seems it is used in `Checkbox::processCheckbox` but don't quite understand why we would set it here. It seems to be for internal use only. https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Render%21Element%21Checkbox.php/function/Checkbox%3A%3AprocessCheckbox/8.2.x

![Screenshot from 2023-09-06 11-03-50](https://github.com/farmOS/farmOS/assets/3116995/790a5ed1-4a5d-4e6a-830b-4eada8e88d47)
