### PR TITLE
Content form and vertical tabs

### DIFF
--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -833,7 +833,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
 
     // Build form and view display settings.
     $field->setDisplayOptions('form', [
-      'type' => 'options_buttons',
+      'type' => 'options_select',
       'weight' => $options['weight']['form'] ?? 0,
     ]);
     $field->setDisplayOptions('view', [

--- a/modules/core/ui/theme/css/toolbar.css
+++ b/modules/core/ui/theme/css/toolbar.css
@@ -3,6 +3,24 @@
  * Styling for farmOS toolbar.
  */
 
+/* Decrease spacing in gin node edit form. */
+/* @todo Move to separate css library. */
+.block-system-main-block > form.gin-node-edit-form {
+  padding: var(--gin-spacing-m);
+}
+.block-system-main-block > form.gin-node-edit-form .form-type--vertical-tabs,
+.block-system-main-block > form.gin-node-edit-form .vertical-tabs {
+  margin-top: 0;
+}
+
+/* Decrease width of vertical tabs in node edit form. */
+form .layout-node-form .vertical-tabs .vertical-tabs__menu {
+  width: 10em;
+}
+form .layout-node-form .vertical-tabs .vertical-tabs__items.vertical-tabs__panes {
+  margin-left: 10em;
+}
+
 /* Add padding to the wrapper around the logo. */
 .toolbar .toolbar-bar #toolbar-item-administration-tray .toolbar-logo {
   padding: .5em !important;

--- a/modules/core/ui/theme/farm_ui_theme.api.php
+++ b/modules/core/ui/theme/farm_ui_theme.api.php
@@ -15,6 +15,27 @@
  */
 
 /**
+ * Specify the field groups to place entity fields in.
+ *
+ * @param string $entity_type
+ *   The entity type.
+ * @param string $bundle
+ *   The bundle.
+ *
+ * @return string[]
+ *   An array keyed by field ID mapping to field group.
+ */
+function hook_farm_ui_theme_field_group_items(string $entity_type, string $bundle) {
+  if ($entity_type == 'asset' && $bundle = 'animal') {
+    return [
+      'nickname' => 'bundle',
+      'sex' => 'bundle',
+    ];
+  }
+  return [];
+}
+
+/**
  * Specify the regions that asset, log, and plan content items should be in.
  *
  * @param string $entity_type

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -25,6 +25,9 @@ function farm_ui_theme_theme($existing, $type, $theme, $path) {
     'page__asset__map_popup' => [
       'base hook' => 'page',
     ],
+    'node_edit_form' => [
+      'render element' => 'form',
+    ],
   ];
 }
 
@@ -45,6 +48,19 @@ function farm_ui_theme_theme_suggestions_menu_local_task(array $variables) {
  */
 function farm_ui_theme_theme_suggestions_menu_local_tasks(array $variables) {
   return ['menu_local_tasks__farm'];
+}
+
+/**
+ * Implements hook_gin_content_form_routes().
+ */
+function farm_ui_theme_gin_content_form_routes() {
+  $routes = [];
+  $entity_types = ['asset', 'log', 'plan'];
+  foreach ($entity_types as $entity_type) {
+    $routes[] = "entity.$entity_type.add_form";
+    $routes[] = "entity.$entity_type.edit_form";
+  }
+  return $routes;
 }
 
 /**

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -48,6 +49,32 @@ function farm_ui_theme_theme_suggestions_menu_local_task(array $variables) {
  */
 function farm_ui_theme_theme_suggestions_menu_local_tasks(array $variables) {
   return ['menu_local_tasks__farm'];
+}
+
+/**
+ * Implements hook_entity_form_display_alter().
+ */
+function farm_ui_theme_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
+
+  // Only alter farm entity types.
+  $entity_types = ['asset', 'log', 'plan'];
+  if (!in_array($context['entity_type'], $entity_types)) {
+    return;
+  }
+
+  // Ask modules for a list of region items.
+  $field_map = \Drupal::moduleHandler()->invokeAll(
+    'farm_ui_theme_field_group_items',
+    [$context['entity_type'], $context['bundle'],
+    ],
+  );
+
+  // Apply the field group mapping if not already specified on the form display.
+  foreach ($field_map as $field_id => $field_group) {
+    if (($renderer = $form_display->getRenderer($field_id)) && !$renderer->getThirdPartySetting('farm_ui_theme', 'field_group', FALSE)) {
+      $renderer->setThirdPartySetting('farm_ui_theme', 'field_group', $field_group);
+    }
+  }
 }
 
 /**

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\farm_ui_theme\Form\GinContentFormBase;
 
 /**
  * Implements hook_theme().
@@ -128,6 +129,25 @@ function farm_ui_theme_gin_content_form_routes() {
     $routes[] = "entity.$entity_type.edit_form";
   }
   return $routes;
+}
+
+/**
+ * Implements hook_entity_type_build().
+ */
+function farm_ui_theme_entity_type_build(array &$entity_types) {
+
+  // Override the default add and edit form class.
+  $target_entity_types = [
+    'asset' => GinContentFormBase::class,
+    'log' => GinContentFormBase::class,
+    'plan' => GinContentFormBase::class,
+  ];
+  foreach ($target_entity_types as $entity_type => $form_class) {
+    if (isset($entity_types[$entity_type])) {
+      $entity_types[$entity_type]->setFormClass('add', $form_class);
+      $entity_types[$entity_type]->setFormClass('edit', $form_class);
+    }
+  }
 }
 
 /**

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -78,6 +78,46 @@ function farm_ui_theme_entity_form_display_alter(EntityFormDisplayInterface $for
 }
 
 /**
+ * Implements hook_farm_ui_theme_field_group_items().
+ */
+function farm_ui_theme_farm_ui_theme_field_group_items(string $entity_type, string $bundle) {
+
+  // Define base fields for asset, log, and plans on behalf of core modules.
+  $fields = [
+    'name' => 'entity',
+    'status' => 'entity',
+    'flag' => 'meta',
+    'file' => 'file',
+    'image' => 'file',
+    'revision' => 'revision',
+    'revision_log_message' => 'revision',
+  ];
+  switch ($entity_type) {
+    case 'asset':
+      $fields['owner'] = 'meta';
+      $fields['intrinsic_geometry'] = 'location';
+      $fields['is_location'] = 'location';
+      $fields['is_fixed'] = 'location';
+      break;
+
+    case 'log':
+      $fields['timestamp'] = 'entity';
+      $fields['category'] = 'meta';
+      $fields['owner'] = 'meta';
+      $fields['geometry'] = 'location';
+      $fields['location'] = 'location';
+      break;
+
+    case 'plan':
+      break;
+
+    default:
+      $fields = [];
+  }
+  return $fields;
+}
+
+/**
  * Implements hook_gin_content_form_routes().
  */
 function farm_ui_theme_gin_content_form_routes() {

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -9,6 +9,7 @@ use Drupal\Core\Block\BlockPluginInterface;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\farm_ui_theme\Form\GinContentFormBase;
+use Drupal\farm_ui_theme\Form\LogForm;
 
 /**
  * Implements hook_theme().
@@ -105,6 +106,7 @@ function farm_ui_theme_farm_ui_theme_field_group_items(string $entity_type, stri
       $fields['timestamp'] = 'entity';
       $fields['category'] = 'meta';
       $fields['owner'] = 'meta';
+      $fields['quantity'] = 'quantity';
       $fields['geometry'] = 'location';
       $fields['location'] = 'location';
       break;
@@ -139,7 +141,7 @@ function farm_ui_theme_entity_type_build(array &$entity_types) {
   // Override the default add and edit form class.
   $target_entity_types = [
     'asset' => GinContentFormBase::class,
-    'log' => GinContentFormBase::class,
+    'log' => LogForm::class,
     'plan' => GinContentFormBase::class,
   ];
   foreach ($target_entity_types as $entity_type => $form_class) {

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -128,6 +128,21 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
       }
     }
 
+    // Add authoring information for existing entities.
+    // @todo Dependency injection.
+    if (!$this->entity->isNew()) {
+      $changed = \Drupal::service('date.formatter')->format($this->entity->getChangedTime(), 'short', '', $this->currentUser()->getTimeZone(), '');
+      $created = \Drupal::service('date.formatter')->format($this->entity->getCreatedTime(), 'short', '', $this->currentUser()->getTimeZone(), '');
+      $form['revision_field_group']['revision_meta'] = [
+        '#theme' => 'item_list',
+        '#items' => [
+          $this->t('Author: @author', ['@author' => $this->entity->getOwner()->getAccountName()]),
+          $this->t('Last saved: @timestamp', ['@timestamp' => $changed]),
+          $this->t('Created: @timestamp', ['@timestamp' => $created]),
+        ],
+      ];
+    }
+
     return $form;
   }
 

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\farm_ui_theme\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element\RenderCallbackInterface;
+
+/**
+ * Entity form for gin content form styling.
+ */
+class GinContentFormBase extends ContentEntityForm implements RenderCallbackInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getNewRevisionDefault() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $status = parent::save($form, $form_state);
+    $entity_type_label = $this->entity->getEntityType()->getSingularLabel();
+    $entity_url = $this->entity->toUrl()->setAbsolute()->toString();
+    $this->messenger()->addMessage($this->t('Saved %entity_type_label: <a href=":url">%label</a>', ['%entity_type_label' => $entity_type_label, ':url' => $entity_url, '%label' => $this->entity->label()]));
+    $form_state->setRedirectUrl($this->entity->toUrl());
+    return $status;
+  }
+
+}

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -19,6 +19,143 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
   }
 
   /**
+   * Function that returns an array of tab definitions to add.
+   *
+   * @return array
+   *   Array of tab definitions keyed by tab id. Each definition should
+   *   provide a location, title and weight.
+   */
+  protected function getFieldGroups() {
+    return [
+      'entity' => [
+        'location' => 'sidebar',
+        'title' => 'Entity',
+        'weight' => -10,
+      ],
+      'bundle' => [
+        'location' => 'main',
+        'title' => 'Bundle',
+        'weight' => 0,
+      ],
+      'info' => [
+        'location' => 'main',
+        'title' => $this->t('Info'),
+        'weight' => 20,
+      ],
+      'meta' => [
+        'location' => 'sidebar',
+        'title' => $this->t('Meta'),
+        'weight' => 40,
+      ],
+      'location' => [
+        'location' => 'main',
+        'title' => $this->t('Location'),
+        'weight' => 60,
+      ],
+      'file' => [
+        'location' => 'main',
+        'title' => $this->t('Files'),
+        'weight' => 80,
+      ],
+      'revision' => [
+        'location' => 'sidebar',
+        'title' => $this->t('Revision information'),
+        'weight' => 100,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    // Add process callback to alter form after GinContentFormHelper.
+    $form['#process'][] = '::processContentForm';
+
+    // @todo Need to add config schema for third party settings.
+    // Only alter the form display if farm_ui_theme.use_field_group is TRUE
+    // or if the form display is new and not saved.
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $form_display */
+    $form_display = $form_state->get('form_display');
+    if (!$form_display || !$form_display->getThirdPartySetting('farm_ui_theme', 'use_field_group', $form_display->isNew())) {
+      return $form;
+    }
+
+    // Add field groups.
+    $field_groups = $this->getFieldGroups();
+    if (!empty($field_groups)) {
+
+      // Disable HTML5 validation on the form element since it does not work
+      // with vertical tabs.
+      $form['#attributes']['novalidate'] = 'novalidate';
+
+      // Vary field group titles based on entity and bundle.
+      if (isset($field_groups['entity'])) {
+        $field_groups['entity']['title'] = $this->entity->getEntityType()->getLabel();
+      }
+      if (isset($field_groups['bundle'])) {
+        $field_groups['bundle']['title'] = $this->entity->type->entity->label();
+      }
+
+      // Create parent for all tabs.
+      $form['tabs'] = [
+        '#type' => 'vertical_tabs',
+        '#default_tab' => 'edit-setup',
+      ];
+
+      // Create tabs.
+      foreach ($field_groups as $tab_id => $tab_info) {
+        $tab_id = "{$tab_id}_field_group";
+        $tab_group = $tab_info['location'] == 'sidebar' ? 'advanced' : 'tabs';
+        $form[$tab_id] = [
+          '#type' => 'details',
+          '#title' => $tab_info['title'],
+          '#group' => $tab_group,
+          '#optional' => TRUE,
+          '#weight' => $tab_info['weight'],
+          '#open' => TRUE,
+        ];
+      }
+
+      // Set field group for each display component.
+      foreach ($form_display->getComponents() as $field_id => $options) {
+        if (isset($form[$field_id]) && $render = $form_display->getRenderer($field_id)) {
+          $tab_id = $render->getThirdPartySetting('farm_ui_theme', 'field_group', 'info');
+          $form[$field_id]['#group'] = "{$tab_id}_field_group";
+        }
+      }
+    }
+
+    return $form;
+  }
+
+  /**
+   * Process function to update form after GinContentFormHelper.
+   *
+   * @param array $form
+   *   The form array to alter.
+   *
+   * @return array
+   *   The form array.
+   *
+   * @see \Drupal\gin\GinContentFormHelper
+   */
+  public function processContentForm(array $form): array {
+
+    // Disable the default meta group provided by Gin.
+    unset($form['meta']);
+
+    // Assign correct status group after GinContentFormHelper.
+    if (isset($form['entity_field_group'])) {
+      $form['status']['#group'] = 'entity_field_group';
+    }
+
+    return $form;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {

--- a/modules/core/ui/theme/src/Form/LogForm.php
+++ b/modules/core/ui/theme/src/Form/LogForm.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\farm_ui_theme\Form;
+
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Element\RenderCallbackInterface;
+
+/**
+ * Log form for gin content form.
+ */
+class LogForm extends GinContentFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getFieldGroups() {
+    return parent::getFieldGroups() + [
+      'quantity' => [
+        'location' => 'main',
+        'title' => $this->t('Quantity'),
+        'weight' => 50,
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
Implements the gin content form and moves fields to vertical tabs within the form and sidebar.

More discussion here: https://farmos.discourse.group/t/ui-improvements-editing-forms/1743?u=paul121

There is one existing issue in Gin that may block this PR: https://www.drupal.org/project/gin/issues/3342164
- Without the node module I found that the Gin content form doesn't work, simply because the `node_edit_form` template isn't registered, even though Gin overrides the template. There is a simple fix that Gin should implement.
- In the meantime @wotnak showed me an even simpler way we can register the `node_edit_form` (see `farm_ui_theme_theme` in this PR)
- However... in the end a warning message is still logged because Gin depends on a Node css/js library that doesn't exist. Despite the error everything still works though, and removing this one line in Gin solves the issue: https://git.drupalcode.org/project/gin/-/blame/8.x-3.x/src/GinContentFormHelper.php#L209