### PR TITLE
Validate quantity entities created by create_quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Misc quick form code and documentation improvements #703](https://github.com/farmOS/farmOS/pull/703)
 
+### Fixed
+
+- [Validate quantity entities created by create_quantity #721](https://github.com/farmOS/farmOS/pull/721)
+
 ## [2.1.3] 2023-09-20
 
 ### Changed


### PR DESCRIPTION
It is currently possible for a migration to create an invalid quantity entity because the `create_quantity` process plugin does not run `$entity->validate()` to check for constraint violations before saving it.

This PR adds a simple check before the entity gets saved, and throws a `MigrateSkipRowException` with the property path and violation message in the same pattern as core migrate.