### PR TITLE
Add a Group membership assignment quick form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add a Group membership assignment quick form #723](https://github.com/farmOS/farmOS/pull/723)
+
 ## [2.1.3] 2023-09-20
 
 ### Changed

--- a/modules/quick/group/farm_quick_group.info.yml
+++ b/modules/quick/group/farm_quick_group.info.yml
@@ -1,0 +1,9 @@
+name: Group Quick Form
+description: Provides a quick form for recording asset group membership changes.
+type: module
+package: farmOS Quick Forms
+core_version_requirement: ^9
+dependencies:
+  - farm:farm_group
+  - farm:farm_observation
+  - farm:farm_quick

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Drupal\farm_quick_group\Plugin\QuickForm;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\farm_group\GroupMembershipInterface;
+use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
+use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
+use Drupal\farm_quick\Traits\QuickFormElementsTrait;
+use Drupal\farm_quick\Traits\QuickLogTrait;
+use Drupal\farm_quick\Traits\QuickStringTrait;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Group quick form.
+ *
+ * @QuickForm(
+ *   id = "group",
+ *   label = @Translation("Group membership"),
+ *   description = @Translation("Record asset group membership changes."),
+ *   helpText = @Translation("Use this form to assign assets to a group. A new observation log will be created to record the group membership change."),
+ *   permissions = {
+ *     "create observation log",
+ *   }
+ * )
+ */
+class Group extends QuickFormBase implements QuickFormInterface {
+
+  use QuickLogTrait;
+  use QuickFormElementsTrait;
+  use QuickStringTrait;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Group membership service.
+   *
+   * @var \Drupal\farm_group\GroupMembershipInterface
+   */
+  protected $groupMembership;
+
+  /**
+   * Current user object.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a QuickFormBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
+   *   Group membership service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, GroupMembershipInterface $group_membership, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
+    $this->messenger = $messenger;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->groupMembership = $group_membership;
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('messenger'),
+      $container->get('entity_type.manager'),
+      $container->get('group.membership'),
+      $container->get('current_user'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, string $id = NULL) {
+
+    // Date.
+    $form['date'] = [
+      '#type' => 'datetime',
+      '#title' => $this->t('Date'),
+      '#default_value' => new DrupalDateTime('midnight', $this->currentUser->getTimeZone()),
+      '#required' => TRUE,
+    ];
+
+    // Assets.
+    $form['asset'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Assets'),
+      '#description' => $this->t('Which assets are changing group membership?'),
+      '#target_type' => 'asset',
+      '#selection_settings' => [
+        'sort' => [
+          'field' => 'status',
+          'direction' => 'ASC',
+        ],
+      ],
+      '#maxlength' => 1024,
+      '#tags' => TRUE,
+      '#required' => TRUE,
+    ];
+
+    // Groups.
+    $form['group'] = [
+      '#type' => 'entity_autocomplete',
+      '#title' => $this->t('Groups'),
+      '#description' => $this->t('The groups to assign the assets to. Leave blank to un-assign assets from all groups.'),
+      '#target_type' => 'asset',
+      '#selection_handler' => 'views',
+      '#selection_settings' => [
+        'view' => [
+          'view_name' => 'farm_group_reference',
+          'display_name' => 'entity_reference',
+          'arguments' => [],
+        ],
+        'match_operator' => 'CONTAINS',
+      ],
+      '#maxlength' => 1024,
+      '#tags' => TRUE,
+    ];
+
+    // Notes.
+    $form['notes'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Notes'),
+    ];
+    $form['notes']['notes'] = [
+      '#type' => 'text_format',
+      '#title' => $this->t('Notes'),
+      '#title_display' => 'invisible',
+      '#format' => 'default',
+    ];
+
+    // Done.
+    $form['done'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Completed'),
+      '#default_value' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Draft a group membership observation log from the user-submitted data.
+    $timestamp = $form_state->getValue('date')->getTimestamp();
+    $status = $form_state->getValue('done') ? 'done' : 'pending';
+    $log = [
+      'type' => 'observation',
+      'timestamp' => $timestamp,
+      'asset' => $form_state->getValue('asset'),
+      'group' => $form_state->getValue('group'),
+      'notes' => $form_state->getValue('notes'),
+      'status' => $status,
+      'is_group_assignment' => TRUE,
+    ];
+
+    // Load assets and groups.
+    $assets = $this->loadEntityAutocompleteAssets($form_state->getValue('asset'));
+    $groups = $this->loadEntityAutocompleteAssets($form_state->getValue('group'));
+
+    // Generate a name for the log.
+    $asset_names = $this->entityLabelsSummary($assets);
+    $group_names = $this->entityLabelsSummary($groups);
+    $log['name'] = $this->t('Clear group membership of @assets', ['@assets' => Markup::create($asset_names)]);
+    if (!empty($group_names)) {
+      $log['name'] = $this->t('Group @assets into @groups', ['@assets' => Markup::create($asset_names), '@groups' => Markup::create($group_names)]);
+    }
+
+    // Create the log.
+    $this->createLog($log);
+  }
+
+  /**
+   * Load assets from entity_autocomplete values.
+   *
+   * @param array|null $values
+   *   The value from $form_state->getValue().
+   *
+   * @return \Drupal\asset\Entity\AssetInterface[]
+   *   Returns an array of assets.
+   */
+  protected function loadEntityAutocompleteAssets($values) {
+    $entities = [];
+    if (empty($values)) {
+      return $entities;
+    }
+    foreach ($values as $value) {
+      if ($value instanceof EntityInterface) {
+        $entities[] = $value;
+      }
+      elseif (!empty($value['target_id'])) {
+        $entities[] = $this->entityTypeManager->getStorage('asset')->load($value['target_id']);
+      }
+    }
+    return $entities;
+  }
+
+}

--- a/modules/quick/group/tests/Kernel/QuickGroupTest.php
+++ b/modules/quick/group/tests/Kernel/QuickGroupTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\farm_quick_group\Kernel;
+
+use Drupal\asset\Entity\Asset;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
+
+/**
+ * Tests for farmOS group quick form.
+ *
+ * @group farm
+ */
+class QuickGroupTest extends QuickFormTestBase {
+
+  /**
+   * Quick form ID.
+   *
+   * @var string
+   */
+  protected $quickFormId = 'group';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_equipment',
+    'farm_group',
+    'farm_observation',
+    'farm_quick_group',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installConfig([
+      'farm_equipment',
+      'farm_group',
+      'farm_observation',
+    ]);
+  }
+
+  /**
+   * Test group quick form submission.
+   */
+  public function testQuickGroup() {
+
+    // Get today's date.
+    $today = new DrupalDateTime('midnight');
+
+    // Create two equipment assets and two group assets.
+    $equipment1 = Asset::create([
+      'name' => 'Tractor',
+      'type' => 'equipment',
+      'status' => 'active',
+    ]);
+    $equipment1->save();
+    $equipment2 = Asset::create([
+      'name' => "Mike's Combine",
+      'type' => 'equipment',
+      'status' => 'active',
+    ]);
+    $equipment2->save();
+    $group1 = Asset::create([
+      'name' => 'Group 1',
+      'type' => 'group',
+      'status' => 'active',
+    ]);
+    $group1->save();
+    $group2 = Asset::create([
+      'name' => 'Group 2',
+      'type' => 'group',
+      'status' => 'active',
+    ]);
+    $group2->save();
+
+    // Programmatically submit the group quick form.
+    $form_values = [
+      'date' => [
+        'date' => $today->format('Y-m-d'),
+        'time' => $today->format('H:i:s'),
+      ],
+      'asset' => [
+        ['target_id' => $equipment1->id()],
+        ['target_id' => $equipment2->id()],
+      ],
+      'group' => [
+        ['target_id' => $group1->id()],
+        ['target_id' => $group2->id()],
+      ],
+      'notes' => [
+        'value' => 'Lorem ipsum',
+        'format' => 'default',
+      ],
+      'done' => TRUE,
+    ];
+    $this->submitQuickForm($form_values);
+
+    // Load logs.
+    $logs = $this->logStorage->loadMultiple();
+
+    // Confirm that one log exists.
+    $this->assertCount(1, $logs);
+
+    // Check that the observation log's fields were populated correctly.
+    $log = $logs[1];
+    $this->assertEquals('observation', $log->bundle());
+    $this->assertEquals($today->getTimestamp(), $log->get('timestamp')->value);
+    $this->assertEquals("Group Tractor, Mike's Combine into Group 1, Group 2", $log->label());
+    $this->assertEquals($equipment1->id(), $log->get('asset')->referencedEntities()[0]->id());
+    $this->assertEquals($equipment2->id(), $log->get('asset')->referencedEntities()[1]->id());
+    $this->assertEquals($group1->id(), $log->get('group')->referencedEntities()[0]->id());
+    $this->assertEquals($group2->id(), $log->get('group')->referencedEntities()[1]->id());
+    $this->assertEquals('Lorem ipsum', $log->get('notes')->value);
+    $this->assertEquals('done', $log->get('status')->value);
+  }
+
+}


### PR DESCRIPTION
This adds a simple Group Membership quick form. It is basically a copy+paste of the existing Movement quick form, with the geometry/map stuff removed. Other than that all the code and tests are essentially the same.

The motivation for this is twofold:

1) Make it easier to assign group membership (and easier to find than the current bulk action).
2) Prepare to replace the existing Group and Move bulk actions with ones that redirect to the Move and Group quick forms.

I've already started on the refactoring necessary for (2), so we should be able to merge #676 ahead of v2.2.0 and then finish that up before 3.0.0.