### PR TITLE
Fix Quick form actions cause RouteNotFoundException: Route farm.quick.[id] does not exist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix asset_lookup and term_lookup exception messages #731](https://github.com/farmOS/farmOS/pull/731)
 - [Prevent saving invalid ID tag types #725](https://github.com/farmOS/farmOS/issues/725)
+- [Quick form actions cause RouteNotFoundException: Route farm.quick.[id] does not exist. #727](https://github.com/farmOS/farmOS/issues/727)
 
 ## [2.2.0] 2023-10-06
 

--- a/modules/core/quick/farm_quick.links.task.yml
+++ b/modules/core/quick/farm_quick.links.task.yml
@@ -1,9 +1,2 @@
-farm_quick.quick_form:
-  title: Quick Form
-  route_name: farm_quick.quick_form
-  base_route: farm_quick.quick_form
-
-farm_quick.configure:
-  title: Configure
-  route_name: farm_quick.configure
-  base_route: farm_quick.quick_form
+farm.quick:
+  deriver: Drupal\farm_quick\Plugin\Derivative\QuickFormTaskLink

--- a/modules/core/quick/farm_quick.module
+++ b/modules/core/quick/farm_quick.module
@@ -20,9 +20,12 @@ function farm_quick_help($route_name, RouteMatchInterface $route_match) {
   }
 
   // Load help text for individual quick forms.
-  if ($route_name == 'farm_quick.quick_form') {
-    if (($quick_form_id = $route_match->getParameter('quick_form')) && $quick_form = \Drupal::service('quick_form.instance_manager')->getInstance($quick_form_id)) {
-      if ($help_text = $quick_form->getHelpText()) {
+  if (strpos($route_name, 'farm.quick.') === 0) {
+    $quick_form_id = $route_match->getParameter('id');
+    if ($route_name == 'farm.quick.' . $quick_form_id) {
+      $quick_form = \Drupal::service('quick_form.instance_manager')->getInstance($quick_form_id);
+      $help_text = $quick_form->getHelpText();
+      if (!empty($help_text)) {
         $output .= '<p>' . $help_text . '</p>';
       }
     }

--- a/modules/core/quick/farm_quick.routing.yml
+++ b/modules/core/quick/farm_quick.routing.yml
@@ -6,18 +6,6 @@ farm.quick:
   requirements:
     _permission: 'view quick_form'
 
-farm_quick.quick_form:
-  path: /quick/{quick_form}
-  defaults:
-    _form: \Drupal\farm_quick\Form\QuickForm
-    _title_callback: \Drupal\farm_quick\Form\QuickForm::getTitle
-  requirements:
-    _custom_access: \Drupal\farm_quick\Form\QuickForm::access
-  options:
-    parameters:
-      quick_form:
-        type: string
-
 farm_quick.configure:
   path: /quick/{quick_form}/configure
   defaults:
@@ -29,3 +17,6 @@ farm_quick.configure:
     parameters:
       quick_form:
         type: string
+
+route_callbacks:
+  - '\Drupal\farm_quick\Routing\QuickFormRoutes::routes'

--- a/modules/core/quick/src/Controller/QuickFormController.php
+++ b/modules/core/quick/src/Controller/QuickFormController.php
@@ -59,7 +59,7 @@ class QuickFormController extends ControllerBase {
     $quick_forms = $this->quickFormInstanceManager->getInstances();
     $items = [];
     foreach ($quick_forms as $id => $quick_form) {
-      $url = Url::fromRoute('farm_quick.quick_form', ['quick_form' => $id]);
+      $url = Url::fromRoute('farm.quick.' . $id);
       if ($url->access()) {
         $cacheability->addCacheableDependency($quick_form);
         $items[] = [

--- a/modules/core/quick/src/Entity/QuickFormInstance.php
+++ b/modules/core/quick/src/Entity/QuickFormInstance.php
@@ -175,4 +175,20 @@ class QuickFormInstance extends ConfigEntityBase implements QuickFormInstanceInt
     }
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function postSave(EntityStorageInterface $storage, $update = TRUE) {
+    parent::postSave($storage, $update);
+    \Drupal::service('router.builder')->setRebuildNeeded();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function postDelete(EntityStorageInterface $storage, array $entities) {
+    parent::postDelete($storage, $entities);
+    \Drupal::service('router.builder')->setRebuildNeeded();
+  }
+
 }

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -62,7 +62,7 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
    */
   public function getFormId() {
     $form_id = $this->getBaseFormId();
-    $id = $this->getRouteMatch()->getParameter('quick_form');
+    $id = $this->getRouteMatch()->getParameter('id');
     if (!is_null($id)) {
       $form_id .= '_' . $this->quickFormInstanceManager->getInstance($id)->getPlugin()->getFormId();
     }
@@ -72,14 +72,14 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
   /**
    * Get the title of the quick form.
    *
-   * @param string $quick_form
+   * @param string $id
    *   The quick form ID.
    *
    * @return string
    *   Quick form title.
    */
-  public function getTitle(string $quick_form) {
-    return $this->quickFormInstanceManager->getInstance($quick_form)->getLabel();
+  public function getTitle(string $id) {
+    return $this->quickFormInstanceManager->getInstance($id)->getLabel();
   }
 
   /**
@@ -87,14 +87,14 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
    *
    * @param \Drupal\Core\Session\AccountInterface $account
    *   Run access checks for this account.
-   * @param string $quick_form
+   * @param string $id
    *   The quick form ID.
    *
    * @return \Drupal\Core\Access\AccessResultInterface
    *   The access result.
    */
-  public function access(AccountInterface $account, string $quick_form) {
-    if ($quick_form = $this->quickFormInstanceManager->getInstance($quick_form)) {
+  public function access(AccountInterface $account, string $id) {
+    if ($quick_form = $this->quickFormInstanceManager->getInstance($id)) {
       return $quick_form->getPlugin()->access($account);
     }
 
@@ -105,13 +105,13 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $quick_form = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $id = NULL) {
 
     // Save the quick form ID.
-    $this->quickFormId = $quick_form;
+    $this->quickFormId = $id;
 
     // Load the quick form.
-    $form = $this->quickFormInstanceManager->getInstance($quick_form)->getPlugin()->buildForm($form, $form_state);
+    $form = $this->quickFormInstanceManager->getInstance($id)->getPlugin()->buildForm($form, $form_state);
 
     // Add a submit button, if one wasn't provided.
     if (empty($form['actions']['submit'])) {

--- a/modules/core/quick/src/Routing/QuickFormRoutes.php
+++ b/modules/core/quick/src/Routing/QuickFormRoutes.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Drupal\farm_quick\Routing;
+
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\farm_quick\Form\QuickForm;
+use Drupal\farm_quick\QuickFormInstanceManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Defines quick form routes.
+ */
+class QuickFormRoutes implements ContainerInjectionInterface {
+
+  /**
+   * The quick form instance manager.
+   *
+   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
+   */
+  protected $quickFormInstanceManager;
+
+  /**
+   * Constructs a QuickFormRoutes object.
+   *
+   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
+   *   The quick form instance manager.
+   */
+  public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
+    $this->quickFormInstanceManager = $quick_form_instance_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('quick_form.instance_manager'),
+    );
+  }
+
+  /**
+   * Provides routes for quick forms.
+   *
+   * @return \Symfony\Component\Routing\RouteCollection
+   *   Returns a route collection.
+   */
+  public function routes(): RouteCollection {
+    $route_collection = new RouteCollection();
+    /** @var \Drupal\farm_quick\Entity\QuickFormInstanceInterface[] $quick_forms */
+    $quick_forms = $this->quickFormInstanceManager->getInstances();
+    foreach ($quick_forms as $id => $quick_form) {
+
+      // Build a route for the quick form.
+      $route = new Route(
+        "/quick/$id",
+        [
+          '_form' => QuickForm::class,
+          '_title_callback' => QuickForm::class . '::getTitle',
+          'id' => $id,
+        ],
+        [
+          '_custom_access' => QuickForm::class . '::access',
+        ],
+      );
+      $route_collection->add("farm.quick.$id", $route);
+    }
+    return $route_collection;
+  }
+
+}

--- a/modules/core/quick/tests/src/Functional/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Functional/QuickFormTest.php
@@ -146,6 +146,9 @@ class QuickFormTest extends FarmBrowserTestBase {
     ]);
     $config_entity->save();
 
+    // Rebuild routes.
+    \Drupal::service('router.builder')->rebuildIfNeeded();
+
     // Go to the quick form index and confirm that the requires_entity_test
     // quick form item is visible.
     $this->drupalGet('quick');
@@ -157,6 +160,15 @@ class QuickFormTest extends FarmBrowserTestBase {
     $this->drupalGet('quick/requires_entity_test');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains($this->t('Test field'));
+
+    // Delete the config entity and confirm that it is removed.
+    $config_entity->delete();
+    \Drupal::service('router.builder')->rebuildIfNeeded();
+    $this->drupalGet('quick');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextNotContains($this->t('Test requiresEntity quick form'));
+    $this->drupalGet('quick/requires_entity_test');
+    $this->assertSession()->statusCodeEquals(404);
   }
 
 }


### PR DESCRIPTION
Fixes #727

This reverts https://github.com/farmOS/farmOS/commit/3505e80124a2fe365eab5510fd2585f9ead9e69d and adds an event subscriber to rebuild quick form routes when quick form config entities are saved.