### PR TITLE
Fix asset_lookup and term_lookup exception messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- [Fix asset_lookup and term_lookup exception messages #731](https://github.com/farmOS/farmOS/pull/731)
+
 ## [2.2.0] 2023-10-06
 
 This is the second minor release of the farmOS 2.x branch, following

--- a/modules/core/import/modules/csv/src/Plugin/migrate/process/AssetLookup.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/process/AssetLookup.php
@@ -107,7 +107,7 @@ class AssetLookup extends EntityLookup {
 
     // If there are still no results, throw an exception and skip the row.
     if (empty($results)) {
-      throw new MigrateSkipRowException('Asset not found: @asset', ['@asset' => $value]);
+      throw new MigrateSkipRowException('Asset not found: ' . $value);
     }
 
     return $results;

--- a/modules/core/import/modules/csv/src/Plugin/migrate/process/TermLookup.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/process/TermLookup.php
@@ -64,7 +64,7 @@ class TermLookup extends EntityLookup {
 
     // If there are no results, throw an exception and skip the row.
     if (empty($results)) {
-      throw new MigrateSkipRowException('Term not found: @term', ['@term' => $value]);
+      throw new MigrateSkipRowException('Term not found: ' . $value);
     }
 
     return $results;


### PR DESCRIPTION
This was an oversight during #722 development. Initially I was translating these messages with a placeholder, but PHP Codesniffer / PHPStan (can't remember which) told me not to translate them, so I removed the `$this->t()` but forgot to refactor the placeholder bit.