### PR TITLE
Add and standardize cacheability of index pages

### DIFF
--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -113,10 +113,14 @@ class CsvImportController extends ControllerBase {
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
     ];
     $tree = $this->menuLinkTree->transform($tree, $manipulators);
+
+    // Start cacheability with migrate_plus migration config entity list tag.
     $tree_access_cacheability = new CacheableMetadata();
+    $tree_access_cacheability->addCacheTags($this->entityTypeManager()->getStorage('migration')->getEntityType()->getListCacheTags());
+
     $links = [];
     foreach ($tree as $element) {
-      $tree_access_cacheability = $tree_access_cacheability->merge(CacheableMetadata::createFromObject($element->access));
+      $tree_access_cacheability->addCacheableDependency($element->access);
 
       // Only render accessible links.
       if (!$element->access->isAllowed()) {
@@ -145,6 +149,7 @@ class CsvImportController extends ControllerBase {
         '#markup' => $this->t('You do not have any importers.'),
       ];
     }
+    $tree_access_cacheability->applyTo($output);
     return $output;
   }
 

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -118,27 +118,21 @@ class CsvImportController extends ControllerBase {
     $tree_access_cacheability = new CacheableMetadata();
     $tree_access_cacheability->addCacheTags($this->entityTypeManager()->getStorage('migration')->getEntityType()->getListCacheTags());
 
-    $links = [];
+    // Build items for each csv importer.
+    $items = [];
     foreach ($tree as $element) {
       $tree_access_cacheability->addCacheableDependency($element->access);
-
-      // Only render accessible links.
-      if (!$element->access->isAllowed()) {
-        continue;
-      }
-
-      // Include the link.
-      $links[] = $element->link;
-    }
-    if (!empty($links)) {
-      $items = [];
-      foreach ($links as $link) {
+      if ($element->access->isAllowed()) {
         $items[] = [
-          'title' => $link->getTitle(),
-          'description' => $link->getDescription(),
-          'url' => $link->getUrlObject(),
+          'title' => $element->link->getTitle(),
+          'description' => $element->link->getDescription(),
+          'url' => $element->link->getUrlObject(),
         ];
       }
+    }
+
+    // Render items.
+    if (!empty($items)) {
       $output = [
         '#theme' => 'admin_block_content',
         '#content' => $items,

--- a/modules/core/import/src/Controller/ImportController.php
+++ b/modules/core/import/src/Controller/ImportController.php
@@ -59,10 +59,13 @@ class ImportController extends ControllerBase {
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],
     ];
     $tree = $this->menuLinkTree->transform($tree, $manipulators);
+
+    // Start cacheability for indexer list.
     $tree_access_cacheability = new CacheableMetadata();
+
     $links = [];
     foreach ($tree as $element) {
-      $tree_access_cacheability = $tree_access_cacheability->merge(CacheableMetadata::createFromObject($element->access));
+      $tree_access_cacheability->addCacheableDependency($element->access);
 
       // Only render accessible links.
       if (!$element->access->isAllowed()) {
@@ -91,6 +94,7 @@ class ImportController extends ControllerBase {
         '#markup' => $this->t('You do not have any importers.'),
       ];
     }
+    $tree_access_cacheability->applyTo($output);
     return $output;
   }
 

--- a/modules/core/import/src/Controller/ImportController.php
+++ b/modules/core/import/src/Controller/ImportController.php
@@ -63,27 +63,21 @@ class ImportController extends ControllerBase {
     // Start cacheability for indexer list.
     $tree_access_cacheability = new CacheableMetadata();
 
-    $links = [];
+    // Build list item for each importer.
+    $items = [];
     foreach ($tree as $element) {
       $tree_access_cacheability->addCacheableDependency($element->access);
-
-      // Only render accessible links.
-      if (!$element->access->isAllowed()) {
-        continue;
-      }
-
-      // Include the link.
-      $links[] = $element->link;
-    }
-    if (!empty($links)) {
-      $items = [];
-      foreach ($links as $link) {
+      if ($element->access->isAllowed()) {
         $items[] = [
-          'title' => $link->getTitle(),
-          'description' => $link->getDescription(),
-          'url' => $link->getUrlObject(),
+          'title' => $element->link->getTitle(),
+          'description' => $element->link->getDescription(),
+          'url' => $element->link->getUrlObject(),
         ];
       }
+    }
+
+    // Render items.
+    if (!empty($items)) {
       $output = [
         '#theme' => 'admin_block_content',
         '#content' => $items,

--- a/modules/core/quick/src/Controller/QuickFormController.php
+++ b/modules/core/quick/src/Controller/QuickFormController.php
@@ -59,9 +59,9 @@ class QuickFormController extends ControllerBase {
     $quick_forms = $this->quickFormInstanceManager->getInstances();
     $items = [];
     foreach ($quick_forms as $id => $quick_form) {
+      $cacheability->addCacheableDependency($quick_form);
       $url = Url::fromRoute('farm.quick.' . $id);
       if ($url->access()) {
-        $cacheability->addCacheableDependency($quick_form);
         $items[] = [
           'title' => $quick_form->getLabel(),
           'description' => $quick_form->getDescription(),
@@ -69,6 +69,8 @@ class QuickFormController extends ControllerBase {
         ];
       }
     }
+
+    // Render items.
     if (!empty($items)) {
       $output = [
         '#theme' => 'admin_block_content',


### PR DESCRIPTION
This fixes the CSV import index so the cacheability reflects changes to the `migration` config entity list.

It also standardized how we build these index controllers. We do nearly the same thing in 5 different places but all are slightly different :-)