### PR TITLE
Correct link to CSV module docs

### DIFF
--- a/docs/guide/import.md
+++ b/docs/guide/import.md
@@ -12,8 +12,8 @@ You can also see a list of all records that were created by each importer,
 and easily review/modify/delete them after import.
 
 farmOS also provides a framework for developing more specialized importers with
-custom CSV column headers. See [CSV importers](/development/csv) in the farmOS
-Development Guide for more information.
+custom CSV column headers. See [CSV importers](/development/module/csv) in the
+farmOS Development Guide for more information.
 
 ## Geometry
 


### PR DESCRIPTION
Broken link in the CSV section on this page: https://farmos.org/guide/import/

> See [CSV importers](https://farmos.org/development/csv) in the farmOS Development Guide for more information.