### PR TITLE
Fix planting quick form creating empty quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix planting quick form creating empty quantities #737](https://github.com/farmOS/farmOS/pull/737)
+
 ## [2.2.1] 2023-10-09
 
 ### Fixed

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -562,14 +562,14 @@ class Planting extends QuickFormBase {
    * @param array $values
    *   Quantity field values from the form.
    *
-   * @return array
-   *   Returns an array to pass into createLog() or createQuantity().
+   * @return array|null
+   *   Returns an array for createQuantity() or NULL if no quantity value.
    */
   protected function prepareQuantity(array $values) {
 
     // If there is no value, return an empty array.
     if (empty($values['value'])) {
-      return [];
+      return NULL;
     }
 
     // If units is specified, then we need to convert it to units_id, which


### PR DESCRIPTION
If you submit the planting quick form without providing values for quantities, an empty quantity is still created. The check for no `value` just needs to be updated to return null.

![harvest-empty-quantity](https://github.com/farmOS/farmOS/assets/3116995/8ee050b3-63f2-4c24-a355-bdc2c7aed3eb)
![edit-empty-quantity](https://github.com/farmOS/farmOS/assets/3116995/7b62587f-a45e-4101-b341-d8802495df5a)
