### PR TITLE
Add post update hook to install the new quick_form entity type on existing farmOS installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix planting quick form creating empty quantities #737](https://github.com/farmOS/farmOS/pull/737)
+- [Add post update hook to install the new quick_form entity type on existing farmOS installations #738](https://github.com/farmOS/farmOS/pull/738)
 
 ## [2.2.1] 2023-10-09
 

--- a/modules/core/quick/farm_quick.post_update.php
+++ b/modules/core/quick/farm_quick.post_update.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the farmOS Quick Form module.
+ */
+
+/**
+ * Install the new quick_form entity type.
+ */
+function farm_quick_post_update_install_quick_form_entity_type(&$sandbox) {
+  \Drupal::entityDefinitionUpdateManager()->installEntityType(
+    \Drupal::entityTypeManager()->getDefinition('quick_form')
+  );
+}


### PR DESCRIPTION
Fixes problem reported at https://farmos.discourse.group/t/status-quick-form-entity-type/1772.

By default, new entity types are automatically installed only on module install. Since the quick_form entity type [was added](https://github.com/farmOS/farmOS/pull/707) in an existing farm_quick module that is already installed on many farmOS instances, a [hook_update_N](https://api.drupal.org/api/drupal/core!lib!Drupal!Core!Extension!module.api.php/function/hook_update_N/9) implementation should be added to install the entity type during database updates.

