### PR TITLE
Tag new releases of farmOS/composer-project when a new version of farmOS is tagged

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -130,8 +130,10 @@ jobs:
       - name: Test Drush site install with all modules
         run: docker compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'
   release:
-    name: Create GitHub release
-    if: github.event_name == 'push' && github.ref_type == 'tag'
+    name: Create release
+    # We only create a release if this is a tag push event to the official
+    # repository.
+    if: github.repository == 'farmOS/farmOS' && github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     needs:
       - build

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -161,6 +161,21 @@ jobs:
           files: /tmp/farmOS-${{ env.FARMOS_VERSION }}.tar.gz
           draft: false
           prerelease: false
+      - name: Checkout the farmOS/composer-project repository
+        uses: actions/checkout@v3
+        with:
+          repository: farmOS/composer-project
+          ref: 2.x
+          path: composer-project
+      - name: Tag a new release of farmOS/composer-project
+        run: |
+          cd composer-project
+          cp /tmp/farmOS/composer.json ./
+          cp /tmp/farmOS/composer.lock ./
+          git add .
+          git commit -m 'farmOS ${{ env.FARMOS_VERSION }}'
+          git tag ${{ env.FARMOS_VERSION }}
+          git push origin ${{ env.FARMOS_VERSION }}
   publish:
     name: Publish to Docker Hub
     # We only publish to Docker Hub if this is a tag or 2.x branch push event

--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -23,8 +23,17 @@ git reset --hard
 # Create a temporary Composer cache directory.
 export COMPOSER_HOME="$(mktemp -d)"
 
-# Add the farmOS repository to composer.json.
-composer config repositories.farmos git ${FARMOS_REPO}
+# If FARMOS_VERSION is a valid semantic versioning string, we assume that it is
+# a tagged version.
+IS_TAGGED_RELEASE=false
+if [[ "${FARMOS_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+  IS_TAGGED_RELEASE=true
+fi
+
+# Add the farmOS repository to composer.json (if this is not a tagged release).
+if [[ ! ${IS_TAGGED_RELEASE} ]]; then
+  composer config repositories.farmos git ${FARMOS_REPO}
+fi
 
 # Require the correct farmOS version in composer.json. Defaults to 2.x.
 # If FARMOS_VERSION is not a valid semantic versioning string, we assume that
@@ -33,7 +42,7 @@ composer config repositories.farmos git ${FARMOS_REPO}
 # that it is a tagged version and require that version.
 if [ "${FARMOS_VERSION}" = "2.x" ]; then
   FARMOS_COMPOSER_VERSION="2.x-dev"
-elif [[ ! "${FARMOS_VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
+elif [[ ! ${IS_TAGGED_RELEASE} ]]; then
   FARMOS_COMPOSER_VERSION="dev-${FARMOS_VERSION}"
 fi
 composer require farmos/farmos ${FARMOS_COMPOSER_VERSION} --no-install

--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -45,7 +45,7 @@ if [ "${FARMOS_VERSION}" = "2.x" ]; then
 elif [[ ! ${IS_TAGGED_RELEASE} ]]; then
   FARMOS_COMPOSER_VERSION="dev-${FARMOS_VERSION}"
 fi
-composer require farmos/farmos ${FARMOS_COMPOSER_VERSION} --no-install
+composer require farmos/farmos:${FARMOS_COMPOSER_VERSION} --no-install
 
 # Add allow-plugins config.
 allowedPlugins=(


### PR DESCRIPTION
Currently our [Composer docs](https://farmos.org/hosting/composer/) instruct end-users to start a farmOS-based project with:

```
composer create-project farmos/project
```

However, this fails because https://github.com/farmOS/composer-project does not have any tagged releases.

See original issue reported here:

- https://github.com/farmOS/composer-project/issues/10

This PR aims to fix that by creating a tag commit in the https://github.com/farmOS/composer-project every time a tagged release of farmOS is created. These "tag commits" would not be part of the `2.x` branch itself, but instead would be "hanging" off of the latest `2.x` branch commit (or `3.x` if we decide to adopt this and start doing it with farmOS v3 releases).

@paul121 and I discussed this in chat today, and while we are still unsure if this is the best solution, it was easy enough to sketch it up as a PR so that we could have something concrete to consider.

Apart from fixing https://github.com/farmOS/composer-project/issues/10, there are two other small benefits to doing this:

1. When a new project is started using `composer create-project farmos/project`, their `composer.json` file will be referencing a specific tag of farmOS, instead of `^2.0`, which forces them to be intentional about their upgrades by default. They can, of course, choose to switch to `^2.0`.
2. This will include `composer.lock` in the tag commit, which will ensure that anyone starting a project is starting with the same exact `composer.lock` that we generate and include in our packaged release tarballs.

Both of those ensure that users are getting the same exact code as our official Docker image and tarball releases. Once they start their project, they become responsible for the `composer.json` and `composer.lock` files, so they can decide how they want to manage them onward from that point.