### PR TITLE
Patch state_machine to fix Issue #3396186: State constraint is not validated on new entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix planting quick form creating empty quantities #737](https://github.com/farmOS/farmOS/pull/737)
 - [Add post update hook to install the new quick_form entity type on existing farmOS installations #738](https://github.com/farmOS/farmOS/pull/738)
+- Patch State Machine module to fix [Issue #3396186: State constraint is not validated on new entities](https://www.drupal.org/project/state_machine/issues/3396186)
 
 ## [2.2.1] 2023-10-09
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "drupal/migrate_tools": "^6.0.2",
         "drupal/role_delegation": "^1.2",
         "drupal/simple_oauth": "5.2.3",
-        "drupal/state_machine": "^1.0",
+        "drupal/state_machine": "1.8",
         "drupal/subrequests": "^3.0.3",
         "drupal/token": "^1.7",
         "drupal/views_geojson": "^1.2",
@@ -76,6 +76,9 @@
             },
             "drupal/simple_oauth": {
                 "Issue #3322325: Cannot authorize clients with empty string set as secret": "https://www.drupal.org/files/issues/2022-11-17/3322325-1.patch"
+            },
+            "drupal/state_machine": {
+                "Issue #3396186: State constraint is not validated on new entities": "https://www.drupal.org/files/issues/2023-10-23/3396186-2.patch"
             },
             "itamair/geophp": {
                 "Use BCMath (where available) for all float arithmetic #115": "https://patch-diff.githubusercontent.com/raw/phayes/geoPHP/pull/115.patch"


### PR DESCRIPTION
See upstream issue: https://www.drupal.org/project/state_machine/issues/3396186

This was originally reported in farmOS chat, where it was discovered that the CSV importers (#722) allow invalid `status` for assets and logs. I discovered that this was due to a bug in the upstream `state_machine` module. I opened the above-linked upstream issue and submitted a patch to get it fixed there. In the meantime, this PR adds the patch to farmOS so we can get the fix sooner.