### PR TITLE
Update csv_serialization dependency to ^4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Update csv_serialization dependency to ^4.0 #745](https://github.com/farmOS/farmOS/pull/745)
+
 ## [3.0.0-beta1] 2023-11-01
 
 This is the first release of the farmOS 3.x branch, following

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drupal/core": "10.1.6",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.15",
-        "drupal/csv_serialization": "^3.0@beta",
+        "drupal/csv_serialization": "^4.0",
         "drupal/date_popup": "^1.3",
         "drupal/entity": "1.4",
         "drupal/entity_browser": "2.9",


### PR DESCRIPTION
Just discovered after trying to update a site to v3. This is a weird one... `csv_serialization` `3.0.0-beta1` claimed support for D9 and D10, but that was incorrect. Due to a symfony change this module cannot have a release that supports both D9 and D10: https://www.drupal.org/project/csv_serialization/issues/3396149

Going forward, `3.x` will have support for D9 and `4.x` will have support for D10.