### PR TITLE
Fix warning message when rendering link to birth log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Update csv_serialization dependency to ^4.0 #745](https://github.com/farmOS/farmOS/pull/745)
+- [Fix warning message when rendering link to birth log #746](https://github.com/farmOS/farmOS/pull/746)
 
 ## [3.0.0-beta1] 2023-11-01
 

--- a/modules/log/birth/farm_birth.module
+++ b/modules/log/birth/farm_birth.module
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_form_BASE_FORM_ID_alter().
@@ -54,23 +55,19 @@ function farm_birth_asset_view_alter(array &$build, EntityInterface $entity, Ent
   if (!empty($build['birthdate'][0])) {
     /** @var \Drupal\Core\Entity\EntityStorageInterface $log_storage */
     $log_storage = \Drupal::service('entity_type.manager')->getStorage('log');
-
-    /** @var \Drupal\Core\Entity\Query\QueryInterface $query */
-    $query = $log_storage->getQuery()
+    $log_ids = $log_storage->getQuery()
       ->accessCheck(TRUE)
       ->condition('type', 'birth')
-      ->condition('asset', $entity->id());
+      ->condition('asset', $entity->id())
+      ->execute();
 
-    $ids = $query->execute();
-    if (!empty($ids)) {
-      $log = $log_storage->load(reset($ids));
-
-      // Render a link to the log with a title of the timestamp field value.
+    // Render a link to the log with a title of the timestamp field value.
+    if (!empty($log_ids)) {
       $title = $build['birthdate'][0];
       $build['birthdate'][0] = [
         '#type' => 'link',
         '#title' => $title,
-        '#url' => $log->toUrl(),
+        '#url' => Url::fromRoute('entity.log.canonical', ['log' => reset($log_ids)]),
       ];
     }
   }

--- a/modules/log/birth/farm_birth.module
+++ b/modules/log/birth/farm_birth.module
@@ -51,7 +51,7 @@ function farm_birth_asset_view_alter(array &$build, EntityInterface $entity, Ent
   }
 
   // Add a link to the asset's birth log.
-  if (!empty($build['birthdate'])) {
+  if (!empty($build['birthdate'][0])) {
     /** @var \Drupal\Core\Entity\EntityStorageInterface $log_storage */
     $log_storage = \Drupal::service('entity_type.manager')->getStorage('log');
 
@@ -64,7 +64,14 @@ function farm_birth_asset_view_alter(array &$build, EntityInterface $entity, Ent
     $ids = $query->execute();
     if (!empty($ids)) {
       $log = $log_storage->load(reset($ids));
-      $build['birthdate'][0]['#markup'] = '<a href="' . $log->toUrl()->toString() . '">' . $build['birthdate'][0]['#markup'] . '</a>';
+
+      // Render a link to the log with a title of the timestamp field value.
+      $title = $build['birthdate'][0];
+      $build['birthdate'][0] = [
+        '#type' => 'link',
+        '#title' => $title,
+        '#url' => $log->toUrl(),
+      ];
     }
   }
 }


### PR DESCRIPTION
If an animal asset has a birth date and a birth log, the birthdate field on the asset page is converted to be a link to that birth log. A nice feature but I think something changed with D10, and now the timestamp field does not use a `#markup` render item but `#text` instead. It produces this warning:

> Warning: Undefined array key "#markup" in farm_birth_asset_view_alter() (line 67 of profiles/farm/modules/log/birth/farm_birth.module).

You can reproduce this pretty easily by using the birth quick form and viewing the child animal asset that is created.