### PR TITLE
Add default view_builder handler for asset type

### DIFF
--- a/modules/core/asset/src/Entity/AssetType.php
+++ b/modules/core/asset/src/Entity/AssetType.php
@@ -20,6 +20,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
  *   ),
  *   handlers = {
  *     "list_builder" = "Drupal\asset\AssetTypeListBuilder",
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "form" = {
  *       "add" = "Drupal\asset\Form\AssetTypeForm",
  *       "edit" = "Drupal\asset\Form\AssetTypeForm",

--- a/modules/core/plan/src/Entity/PlanType.php
+++ b/modules/core/plan/src/Entity/PlanType.php
@@ -20,6 +20,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
  *   ),
  *   handlers = {
  *     "list_builder" = "Drupal\plan\PlanTypeListBuilder",
+ *     "view_builder" = "Drupal\Core\Entity\EntityViewBuilder",
  *     "form" = {
  *       "add" = "Drupal\plan\Form\PlanTypeForm",
  *       "edit" = "Drupal\plan\Form\PlanTypeForm",


### PR DESCRIPTION
This fixes a potential bug where the canonical route is not created if a view_builder is not provided.

Right now this can be reproduced when trying to export assets to KML:

> Symfony\Component\Routing\Exception\RouteNotFoundException: Route "entity.asset_type.canonical" does not exist. in Drupal\Core\Routing\RouteProvider->getRouteByName() (line 206 of /opt/drupal/web/core/lib/Drupal/Core/Routing/RouteProvider.php)

This error comes from the [`EntityReferenceFIeldItemNormalizer`](https://git.drupalcode.org/project/drupal/-/blob/10.1.6/core/modules/serialization/src/Normalizer/EntityReferenceFieldItemNormalizer.php?ref_type=tags#L52) that expects a `canonical` route if the entity has a `canonical` link template. However, the [`DefaultHtmlRouteProvider`](https://git.drupalcode.org/project/drupal/-/blob/10.1.6/core/lib/Drupal/Core/Entity/Routing/DefaultHtmlRouteProvider.php?ref_type=tags#L218) only provides a `canonical` route if there is both a canonical link template and a view builder.

This change does not fix the KML export by itself. The KML export is broken because default content entity normalizers are running (like `EntityReferenceFieldItemNormalizer`), instead of our custom `ContentEntityGeometryNormalizer`. But this issue reveals that standard content entity normalizes are likely not working for assets (note that json:api has its own serialization process that must not be affected by this).