### PR TITLE
Correct alter hook to add password grant to static scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Correct alter hook to add password grant to static scopes #755](https://github.com/farmOS/farmOS/pull/755)
+
 ## [3.0.0-beta3] 2023-11-27
 
 ### Fixed

--- a/modules/core/role/modules/roles/farm_role_roles.module
+++ b/modules/core/role/modules/roles/farm_role_roles.module
@@ -18,7 +18,7 @@ function farm_role_roles_oauth2_scope_info_alter(array &$scopes) {
       'farm_viewer',
     ];
     foreach ($target_scopes as $scope_id) {
-      if (isset($target_scopes[$scope_id])) {
+      if (isset($scopes[$scope_id])) {
         $scopes[$scope_id]['grant_types']['password'] = [
           'status' => TRUE,
         ];


### PR DESCRIPTION
Simple fix - a little typo meant we were not allowing the `password` grant for any of static scopes we provide.

Right now you get the following error as reported here: https://farmos.discourse.group/t/invalid-scope-when-trying-to-login-to-field-kit/1809

```
{
    "error": "invalid_scope",
    "error_description": "The requested scope is invalid, unknown, or malformed",
    "hint": "Check the `farm_manager` scope",
    "message": "The requested scope is invalid, unknown, or malformed"
}
```