### PR TITLE
Use strict identical operator when checking geometry format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Correct alter hook to add password grant to static scopes #755](https://github.com/farmOS/farmOS/pull/755)
+- [Use strict identical operator when checking geometry format #756](https://github.com/farmOS/farmOS/pull/756)
 
 ## [3.0.0-beta3] 2023-11-27
 

--- a/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
+++ b/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
@@ -104,7 +104,7 @@ class ContentEntityGeometryNormalizer implements NormalizerInterface, Serializer
     // Check that the data is a content entity.
     // Only formats that are prefixed with "geometry_" are supported.
     // This makes it easier for other modules to provide geometry encoders.
-    return $data instanceof ContentEntityInterface && strpos($format, 'geometry_') == 0;
+    return $data instanceof ContentEntityInterface && strpos($format, 'geometry_') === 0;
   }
 
   /**


### PR DESCRIPTION
Right now the `ContentEntityGeometryNormalizer` ends up being used for all normalization of content entities - no bueno!

This doesn't break any core farmOS features, but would break any other modules/features that use the default normalization of content entities. A simple example is using `restws` module and configuring formats to export entities like `/asset/1?_format=json`. Right now this results in an empty array.