### PR TITLE
Increase weight of Asset and Log tasks on canonical user route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Increase weight of Asset and Log tasks on canonical user route #757](https://github.com/farmOS/farmOS/pull/757)
+
 ### Fixed
 
 - [Correct alter hook to add password grant to static scopes #755](https://github.com/farmOS/farmOS/pull/755)

--- a/modules/core/ui/views/config/install/views.view.farm_asset.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_asset.yml
@@ -1786,7 +1786,7 @@ display:
         type: tab
         title: Assets
         description: ''
-        weight: 0
+        weight: 40
         expanded: false
         menu_name: account
         parent: ''

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -2790,7 +2790,7 @@ display:
         type: tab
         title: Logs
         description: ''
-        weight: 0
+        weight: 50
         expanded: false
         menu_name: main
         parent: ''


### PR DESCRIPTION
The current weight of these menu items is 0 and makes it challenging to place other menu tasks between Edit and Asset. I would like to add a Notifications task item and keep it closer to the edit task.

Examples of a Notification task with weight `5`:

Before:
![notifications-end](https://github.com/farmOS/farmOS/assets/3116995/99ed41d7-9a23-4ad2-a606-9855fc81c8f6)

After:
![notification-0](https://github.com/farmOS/farmOS/assets/3116995/b962637d-9f68-46aa-8c0a-0ee4c35c03a3)
