### PR TITLE
Add healthcheck to MariaDB container to ensure it is ready to accept external connections before reporting as ready

### DIFF
--- a/docker/docker-compose.testing.mariadb.yml
+++ b/docker/docker-compose.testing.mariadb.yml
@@ -12,6 +12,13 @@ services:
       MYSQL_DATABASE: farm
       MYSQL_USER: farm
       MYSQL_PASSWORD: farm
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
 
   www:
     depends_on:

--- a/docker/docker-compose.testing.mariadb.yml
+++ b/docker/docker-compose.testing.mariadb.yml
@@ -22,4 +22,5 @@ services:
 
   www:
     depends_on:
-      - db
+      db:
+        condition: service_healthy


### PR DESCRIPTION
Currently, tests running in GitHub Actions sometimes randomly fail when connection to MariaDB server fails. It usually fails only in first tests, with later ones running without problems. A recent example can be seen in https://github.com/farmOS/farmOS/pull/751#issuecomment-1856072384.

The problem is with MariaDB container being reported as ready before the actual MariaDB server is ready to accept external connections.

It can be fixed by adding a [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck) to the MariaDB container that checks if MariaDB server accepts external connections before reporting the container as ready. To do that, MariaDB container image provides [a helper script](https://mariadb.com/kb/en/using-healthcheck-sh/) that can be used in a healthcheck.

This pr adds a healthcheck as described at https://mariadb.org/mariadb-server-docker-official-images-healthcheck-without-mysqladmin/ to the MariaDB container used in tests, which should prevent random failures caused by connectivity issues between MariaDB server and farmOS when MariaDB server is starting.