### PR TITLE
Use paratest to speedup tests in Github actions workflow

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -125,6 +125,10 @@ jobs:
       # The www-container-fs-ready file is only created once we expect the containers to be online
       # so waiting for that lets us know it is safe to start the tests
         run: until [ -f ./www/www-container-fs-ready ]; do sleep 0.1; done
+      - name: Install pg_trgm PostgreSQL extension
+      # This avoids race conditions when trying to automatically install it in concurrently run tests.
+        if: matrix.dbms == 'pgsql'
+        run: docker compose exec -T db psql -U farm -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
       - name: Run PHPUnit tests
         run: docker compose exec -u www-data -T www paratest -vv --processes=${{ matrix.processes }} /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -92,10 +92,13 @@ jobs:
         include:
           - dbms: pgsql
             DB_URL: pgsql://farm:farm@db/farm
+            processes: auto
           - dbms: mariadb
             DB_URL: mysql://farm:farm@db/farm
+            processes: auto
           - dbms: sqlite
             DB_URL: sqlite://localhost/sites/default/files/db.sqlite
+            processes: 1
     steps:
       - name: Print test matrix variables
         run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
@@ -123,7 +126,7 @@ jobs:
       # so waiting for that lets us know it is safe to start the tests
         run: until [ -f ./www/www-container-fs-ready ]; do sleep 0.1; done
       - name: Run PHPUnit tests
-        run: docker compose exec -u www-data -T www phpunit --verbose /opt/drupal/web/profiles/farm
+        run: docker compose exec -u www-data -T www paratest -vv --processes=${{ matrix.processes }} /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules
         run: docker compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'
   release:

--- a/composer.project.json
+++ b/composer.project.json
@@ -7,6 +7,7 @@
         "behat/mink": "^1.10",
         "behat/mink-browserkit-driver": "^2.1",
         "behat/mink-selenium2-driver": "^1.6",
+        "brianium/paratest": "^6",
         "drupal/coder": "^8.3",
         "mglaman/phpstan-drupal": "^1.1",
         "mikey179/vfsstream": "^1.6",


### PR DESCRIPTION
Reverts https://github.com/farmOS/farmOS/commit/6a9c872e9b04a5893e92f5e764aef1904303e368 and adds fix for the issue because of which paratest was removed.

> PostgreSQL tests fail because Drupal core patch is trying to install pg_trgm
extension in parallel multiple times.
> Failed to run installer database tasks: Drupal could not check for the pg_trgm extension: SQLSTATE[23505]: Unique violation: 7 ERROR:  duplicate key value violates unique constraint &quot;pg_extension_name_index&quot;
DETAIL:  Key (extname)=(pg_trgm) already exists.: CREATE EXTENSION IF NOT EXISTS pg_trgm;

To fix this, I added a step executed only when testing with Postgres that installs pg_trgm before starting tests so that automatic extension installation provided by Drupal is not executed during tests.