### PR TITLE
Use phpcs and phpstan result cache in github actions

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -71,13 +71,38 @@ jobs:
           key: farmos-dev-${{ github.run_id }}
       - name: Load farmos/farmos:3.x-dev image
         run: docker load < /tmp/farmos-dev.tar
+      - name: Create cache directory
+        run: mkdir -p ./cache
+      - name: Load phpcs cache
+        uses: actions/cache/restore@v3
+        with:
+          path: |
+            ./cache/.phpcs.cache.farmos
+            ./cache/.phpcs.cache.contrib
+          key: phpcs-${{ hashFiles('./cache/.phpcs.cache.farmos', './cache/.phpcs.cache.contrib') }}
+          restore-keys: phpcs-
       - name: Run PHP CodeSniffer
-        run: docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) /opt/drupal/web/profiles/farm
+        run: |
+          docker run \
+            -v ./cache:/tmp/phpcs \
+            farmos/farmos:3.x-dev \
+            phpcs --cache=/tmp/phpcs/.phpcs.cache.farmos --parallel=$(nproc) /opt/drupal/web/profiles/farm
       - name: Run PHPStan
         run: docker run farmos/farmos:3.x-dev phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings).
         run: |
-          docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules /opt/drupal/web/themes
+          docker run \
+            -v ./cache:/tmp/phpcs \
+            farmos/farmos:3.x-dev \
+            phpcs --cache=/tmp/phpcs/.phpcs.cache.contrib --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules /opt/drupal/web/themes
+      - name: Save phpcs cache
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ./cache/.phpcs.cache.farmos
+            ./cache/.phpcs.cache.contrib
+          key: phpcs-${{ hashFiles('./cache/.phpcs.cache.farmos', './cache/.phpcs.cache.contrib') }}
+
   test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -77,8 +77,7 @@ jobs:
         run: docker run farmos/farmos:3.x-dev phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings).
         run: |
-          docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules
-          docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/themes
+          docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules /opt/drupal/web/themes
   test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -72,13 +72,13 @@ jobs:
       - name: Load farmos/farmos:3.x-dev image
         run: docker load < /tmp/farmos-dev.tar
       - name: Run PHP CodeSniffer
-        run: docker run farmos/farmos:3.x-dev phpcs /opt/drupal/web/profiles/farm
+        run: docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) /opt/drupal/web/profiles/farm
       - name: Run PHPStan
         run: docker run farmos/farmos:3.x-dev phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings).
         run: |
-          docker run farmos/farmos:3.x-dev phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules
-          docker run farmos/farmos:3.x-dev phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/themes
+          docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules
+          docker run farmos/farmos:3.x-dev phpcs --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/themes
   test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -73,14 +73,15 @@ jobs:
         run: docker load < /tmp/farmos-dev.tar
       - name: Create cache directory
         run: mkdir -p ./cache
-      - name: Load phpcs cache
+      - name: Load phpcs and phpstan cache
         uses: actions/cache/restore@v3
         with:
           path: |
             ./cache/.phpcs.cache.farmos
             ./cache/.phpcs.cache.contrib
-          key: phpcs-${{ hashFiles('./cache/.phpcs.cache.farmos', './cache/.phpcs.cache.contrib') }}
-          restore-keys: phpcs-
+            ./cache/resultCache.php
+          key: phpcs-phpstan-${{ hashFiles('./cache/.phpcs.cache.farmos', './cache/.phpcs.cache.contrib', './cache/resultCache.php') }}
+          restore-keys: phpcs-phpstan-
       - name: Run PHP CodeSniffer
         run: |
           docker run \
@@ -88,20 +89,25 @@ jobs:
             farmos/farmos:3.x-dev \
             phpcs --cache=/tmp/phpcs/.phpcs.cache.farmos --parallel=$(nproc) /opt/drupal/web/profiles/farm
       - name: Run PHPStan
-        run: docker run farmos/farmos:3.x-dev phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
+        run: |
+          docker run \
+          -v ./cache:/tmp/phpstan \
+          farmos/farmos:3.x-dev \
+          phpstan -vvv analyze --memory-limit 1G /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings).
         run: |
           docker run \
             -v ./cache:/tmp/phpcs \
             farmos/farmos:3.x-dev \
             phpcs --cache=/tmp/phpcs/.phpcs.cache.contrib --parallel=$(nproc) --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules /opt/drupal/web/themes
-      - name: Save phpcs cache
+      - name: Save phpcs and phpstan cache
         uses: actions/cache/save@v3
         with:
           path: |
             ./cache/.phpcs.cache.farmos
             ./cache/.phpcs.cache.contrib
-          key: phpcs-${{ hashFiles('./cache/.phpcs.cache.farmos', './cache/.phpcs.cache.contrib') }}
+            ./cache/resultCache.php
+          key: phpcs-phpstan-${{ hashFiles('./cache/.phpcs.cache.farmos', './cache/.phpcs.cache.contrib', './cache/resultCache.php') }}
 
   test:
     name: Run PHPUnit tests

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -62,8 +62,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v3
       - name: Restore farmOS dev Docker image from cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Adds several optimizations to how phpcs and phpstan are run in github actions:
- run phpcs checks in parallel
  - phpcs by default runs all checks in series but provides cli argument that allows to execute checks in parallel
- combine PHP compatibility checks of contrib modules and themes into single phpcs run
  - passing two paths at the same time allows to skip additional phpcs bootstrapping time
- use phpcs results cache and persist it between workflow runs
  - using results cache can significantly speedup performing checks since checks are run only for files that changed or are missing from cache
 - persist phpstan result cache between workflow runs
   - phpstan uses results cache by default but in github actions it is discarded after container stops, this change allows for it to be shared between workflow runs 
