### PR TITLE
Update to Drupal 10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Increase weight of Asset and Log tasks on canonical user route #757](https://github.com/farmOS/farmOS/pull/757)
+- Update Drupal core to 10.2.0.
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Increase weight of Asset and Log tasks on canonical user route #757](https://github.com/farmOS/farmOS/pull/757)
-- Update Drupal core to 10.2.0.
+- [Update Drupal core to 10.2](https://github.com/farmOS/farmOS/pull/765)
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.3",
-        "drupal/core": "10.1.6",
+        "drupal/core": "10.2.0",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.15",
         "drupal/csv_serialization": "^4.0",
@@ -48,7 +48,7 @@
         "drupal/subrequests": "^3.0.6",
         "drupal/token": "^1.11",
         "drupal/views_geojson": "^1.2",
-        "drush/drush": "^11.3",
+        "drush/drush": "^12.4.3",
         "ext-simplexml": "*",
         "itamair/geophp": "1.3"
     },
@@ -59,10 +59,9 @@
         "patches": {
             "drupal/core": {
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
-                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2023-10-05/2339235-10.1.x-80.patch",
+                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2024-01-03/2339235-10.2.0-81.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
-                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch",
-                "Issue #3349973: Automatically install pg_trgm extension on PostgreSQL 13+": "https://www.drupal.org/files/issues/2023-05-08/3349973-26.patch"
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.3",
-        "drupal/core": "10.2.0",
+        "drupal/core": "10.2.1",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.15",
         "drupal/csv_serialization": "^4.0",
@@ -59,7 +59,7 @@
         "patches": {
             "drupal/core": {
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
-                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2024-01-03/2339235-10.2.0-81.patch",
+                "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2024-01-03/2339235-10.2.x-82.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
                 "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch"
             },

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "10.1.6"
+        "drupal/core-composer-scaffold": "10.2.0"
     },
     "require-dev": {
         "behat/mink": "^1.10",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "10.2.0"
+        "drupal/core-composer-scaffold": "10.2.1"
     },
     "require-dev": {
         "behat/mink": "^1.10",

--- a/modules/core/field/src/Plugin/Field/FieldWidget/TimestampDatetimeOptionalWidget.php
+++ b/modules/core/field/src/Plugin/Field/FieldWidget/TimestampDatetimeOptionalWidget.php
@@ -3,10 +3,7 @@
 namespace Drupal\farm_field\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Datetime\Element\Datetime;
-use Drupal\Core\Datetime\Entity\DateFormat;
 use Drupal\Core\Datetime\Plugin\Field\FieldWidget\TimestampDatetimeWidget;
-use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 
 /**
@@ -25,17 +22,6 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class TimestampDatetimeOptionalWidget extends TimestampDatetimeWidget {
-
-  /**
-   * {@inheritdoc}
-   */
-  public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-    $element = parent::formElement($items, $delta, $element, $form, $form_state);
-    $date_format = DateFormat::load('html_date')->getPattern();
-    $time_format = DateFormat::load('html_time')->getPattern();
-    $element['value']['#description'] = $this->t('Format: %format.', ['%format' => Datetime::formatExample($date_format . ' ' . $time_format)]);
-    return $element;
-  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
Updated a Drupal core patch [2339235](https://www.drupal.org/project/drupal/issues/2339235#comment-15382658) and got tests to pass, but have not tested this locally.

10.2.0 release notes: https://www.drupal.org/project/drupal/releases/10.2.0

I don't think there are any major changes to be worried about here....

> [Form elements in the stable9 base theme now have form-type-[form-element-type] class](https://www.drupal.org/node/3385635).

This could potentially affect some UI/CSS changes we have made, but seems unlikely.
