### PR TITLE
Add min/max options to integer fields in farm_field.factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add min/max options to integer fields in farm_field.factory #768](https://github.com/farmOS/farmOS/pull/768)
+
 ## [3.0.0] 2024-01-05
 
 This is the first "stable" release of farmOS v3. See the release notes for

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -142,6 +142,8 @@ Both methods expect an array of field definition options. These include:
     - `integer` - Integer number. Additional options:
         - `size` (optional) - The integer database column size (`tiny`,
           `small`, `medium`, `normal`, or `big`). Defaults to `normal`.
+        - `min` (optional) - The minimum value.
+        - `max` (optional) - The maximum value.
     - `list_string` - Select list with allowed values. Additional options:
         - `allowed_values` - An associative array of allowed values.
         - `allowed_values_function` - The name of a function that returns an

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -781,6 +781,14 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
       $field->setSetting('size', $options['size']);
     }
 
+    // Set the min/max constraints, if specified.
+    if (isset($options['min'])) {
+      $field->setSetting('min', $options['min']);
+    }
+    if (isset($options['max'])) {
+      $field->setSetting('max', $options['max']);
+    }
+
     // Build form and view display settings.
     $field->setDisplayOptions('form', [
       'type' => 'number',


### PR DESCRIPTION
This is a simple PR that just adds `min` and `max` options to the `integer` field type in the `farm_field.factory` service (https://farmos.org/development/module/services/#field-factory-service).