### PR TITLE
Override the lab_test log timestamp label and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Set the minimum value of maturity_days and transplant_days to 1 #794](https://github.com/farmOS/farmOS/pull/794)
 - [Move transplant_days field to farm_transplant module #795](https://github.com/farmOS/farmOS/pull/795)
 - [Use content form for taxonomy terms #810](https://github.com/farmOS/farmOS/pull/810)
+- [Override the lab_test log timestamp label and description #774](https://github.com/farmOS/farmOS/pull/774)
 
 ### Fixed
 

--- a/modules/log/lab_test/config/install/core.base_field_override.log.lab_test.timestamp.yml
+++ b/modules/log/lab_test/config/install/core.base_field_override.log.lab_test.timestamp.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - log.type.lab_test
+  enforced:
+    module:
+      - farm_lab_test
+id: log.lab_test.timestamp
+field_name: timestamp
+entity_type: log
+bundle: lab_test
+label: 'Date sampled'
+description: 'The date when the sample was collected.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: 'Drupal\log\Entity\Log::getRequestTime'
+settings: {  }
+field_type: timestamp

--- a/modules/log/lab_test/farm_lab_test.post_update.php
+++ b/modules/log/lab_test/farm_lab_test.post_update.php
@@ -176,3 +176,20 @@ function farm_lab_test_post_update_add_tissue_type(&$sandbox) {
   ]);
   $type->save();
 }
+
+/**
+ * Override the lab_test log timestamp label and description.
+ */
+function farm_lab_test_post_update_override_lab_test_timestamp_label_description(&$sandbox) {
+
+  // Override the timestamp field label and description on lab_test logs to
+  // make it clear that it should be used for the date the sample was taken.
+  // This also checks to make sure they haven't been overridden already first.
+  /** @var \Drupal\Core\Field\Entity\BaseFieldOverride $config */
+  $config = \Drupal::service('entity_field.manager')->getBaseFieldDefinitions('log')['timestamp']->getConfig('lab_test');
+  if ($config->isNew()) {
+    $config->set('label', 'Date sampled');
+    $config->set('description', 'The date when the sample was collected.');
+    $config->save();
+  }
+}

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -20,6 +20,30 @@ class LabTest extends FarmLogType {
   public function buildFieldDefinitions() {
     $fields = parent::buildFieldDefinitions();
 
+    // Date received.
+    $options = [
+      'type' => 'timestamp',
+      'label' => $this->t('Date received'),
+      'description' => $this->t('The date when the sample was received by the lab.'),
+      'weight' => [
+        'form' => -70,
+        'view' => -70,
+      ],
+    ];
+    $fields['lab_received_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
+
+    // Date processed.
+    $options = [
+      'type' => 'timestamp',
+      'label' => $this->t('Date processed'),
+      'description' => $this->t('The date when the sample was processed by the lab.'),
+      'weight' => [
+        'form' => -60,
+        'view' => -60,
+      ],
+    ];
+    $fields['lab_processed_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
+
     // Lab test type.
     $options = [
       'type' => 'list_string',
@@ -46,30 +70,6 @@ class LabTest extends FarmLogType {
       ],
     ];
     $fields['lab'] = $this->farmFieldFactory->bundleFieldDefinition($options);
-
-    // Date received.
-    $options = [
-      'type' => 'timestamp',
-      'label' => $this->t('Date received'),
-      'description' => $this->t('The date when the sample was received by the lab.'),
-      'weight' => [
-        'form' => -35,
-        'view' => -35,
-      ],
-    ];
-    $fields['lab_received_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
-
-    // Date processed.
-    $options = [
-      'type' => 'timestamp',
-      'label' => $this->t('Date processed'),
-      'description' => $this->t('The date when the sample was processed by the lab.'),
-      'weight' => [
-        'form' => -34,
-        'view' => -34,
-      ],
-    ];
-    $fields['lab_processed_date'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
     return $fields;
   }


### PR DESCRIPTION
I would like to propose that we override the `timestamp` field label and description on `lab_test` logs.

From: "Timestamp" / "Timestamp of the event being logged."
To: "Date sampled" / "The date when the sample was collected."

Before:

![Screenshot from 2024-01-16 15-08-26](https://github.com/farmOS/farmOS/assets/95381/d605b89b-7afd-47d6-a2e2-6916af8a5401)

After:

![Screenshot from 2024-01-16 15-08-36](https://github.com/farmOS/farmOS/assets/95381/f7b718f6-506b-48e6-b494-fd59b10a54ac)

Reasoning:

This idea came up originally back when I was working on the first draft convention for soil tests, which states that:

> The "Timestamp" (`timestamp`) field of the log MUST be the date when the sample(s) were collected.

Source: https://github.com/mstenta/farmOS-conventions/blob/wip/conventions/farmOS/soil-test/1.0/index.md

It came up again recently in work that I'm doing for the [Cornell Soil Health Lab](https://soilhealthlab.cals.cornell.edu/). I decided to go ahead and make the change in their system, and then figured it was worth proposing as a change in farmOS core.

The other reason I like this is it make all three date fields on lab test logs more consistent (especially when they are displayed together):

![Screenshot from 2024-01-16 15-17-17](https://github.com/farmOS/farmOS/assets/95381/71fd20e9-8f97-4d8e-9aa4-bb0282d9bed3)

We don't currently display them together in farmOS core, but I think that would be a worthwhile next step to consider... especially once #770 is merged.

This is achieved using a little-known mechanism that Drupal core provides, which lets you provide a single config entity to override base field labels and descriptions. There's a good writeup here: https://www.previousnext.com.au/blog/overriding-base-field-labels-and-descriptions-of-drupal-entities-without-custom-code