### PR TITLE
Remove "All" from "Items per page" options in Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Recommend running composer update twice #653](https://github.com/farmOS/farmOS/pull/786)
 - [Edit form UI improvements #770](https://github.com/farmOS/farmOS/pull/770)
 - [Improve asset and log CSV exports #783](https://github.com/farmOS/farmOS/pull/783)
+- [Remove "All" from "Items per page" options in Views #776](https://github.com/farmOS/farmOS/pull/776)
 
 ## [3.0.1] 2024-01-18
 

--- a/modules/asset/group/config/optional/views.view.farm_group_members.yml
+++ b/modules/asset/group/config/optional/views.view.farm_group_members.yml
@@ -618,7 +618,7 @@ display:
             items_per_page: true
             items_per_page_label: 'Items per page'
             items_per_page_options: '25, 50, 100, 250, 500'
-            items_per_page_options_all: true
+            items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset

--- a/modules/core/data_stream/config/optional/views.view.data_stream_basic_data.yml
+++ b/modules/core/data_stream/config/optional/views.view.data_stream_basic_data.yml
@@ -145,7 +145,7 @@ display:
             items_per_page: true
             items_per_page_label: Limit
             items_per_page_options: '1000,500,100,10,1'
-            items_per_page_options_all: true
+            items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset

--- a/modules/core/ui/views/config/install/views.view.farm_asset.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_asset.yml
@@ -687,7 +687,7 @@ display:
             items_per_page: true
             items_per_page_label: 'Items per page'
             items_per_page_options: '25, 50, 100, 250, 500'
-            items_per_page_options_all: true
+            items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -757,7 +757,7 @@ display:
             items_per_page: true
             items_per_page_label: 'Items per page'
             items_per_page_options: '25, 50, 100, 250, 500'
-            items_per_page_options_all: true
+            items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -423,7 +423,7 @@ display:
             items_per_page: true
             items_per_page_label: 'Items per page'
             items_per_page_options: '25, 50, 100, 250, 500'
-            items_per_page_options_all: true
+            items_per_page_options_all: false
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset


### PR DESCRIPTION
We currently provide the option to show "All" items in our Views. On a site with a lot of records, this is a guaranteed `PHP Fatal error: Allowed memory size of ... bytes exhausted`. I've seen this in my logs on Farmier when the "All" filter is used.

As nice as it is to offer this option, I think we need to acknowledge that it's not realistic.

Aside from "All" we currently offer these options in the "Items per page" dropdown: 25, 50, 100, 250, 500.

In some cases, even 500 could cause an OOM error, but I think we can leave that for now.