### PR TITLE
Show map on /locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add a Product asset type and Product type taxonomy #787](https://github.com/farmOS/farmOS/pull/787)
 - [Inventory quick form #766](https://github.com/farmOS/farmOS/pull/766)
 - [Add UI for creating instances of quick forms #785](https://github.com/farmOS/farmOS/pull/785)
+- [Show map on /locations #779](https://github.com/farmOS/farmOS/pull/779)
 
 ### Changed
 

--- a/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -60,11 +60,9 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   public function onMapRender(MapRenderEvent $event) {
 
-    // Get the map ID.
-    $map_id = $event->getmapType()->id();
-
-    // Add land type layers to dashboard map.
-    if ($map_id == 'dashboard') {
+    // If the "locations" behavior is added to the map, add layers for each
+    // land type.
+    if (in_array('locations', $event->getMapBehaviors())) {
       $layers = [];
 
       // Define the parent group.

--- a/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -60,11 +60,9 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   public function onMapRender(MapRenderEvent $event) {
 
-    // Get the map ID.
-    $map_id = $event->getmapType()->id();
-
-    // Add structure type layers to dashboard map.
-    if ($map_id == 'dashboard') {
+    // If the "locations" behavior is added to the map, add layers for each
+    // structure type.
+    if (in_array('locations', $event->getMapBehaviors())) {
       $layers = [];
 
       // Define the parent group.

--- a/modules/core/map/src/Event/MapRenderEvent.php
+++ b/modules/core/map/src/Event/MapRenderEvent.php
@@ -92,8 +92,10 @@ class MapRenderEvent extends Event {
     /** @var \Drupal\farm_map\Entity\MapBehaviorInterface $behavior */
     $behavior = $this->entityTypeManager->getStorage('map_behavior')->load($behavior_name);
 
-    // Attach the library.
-    $this->element['#attached']['library'][] = $behavior->getLibrary();
+    // If the behavior has a library, attach it.
+    if (!empty($behavior->getLibrary())) {
+      $this->element['#attached']['library'][] = $behavior->getLibrary();
+    }
 
     // Add behavior settings if supplied.
     if (!empty($settings)) {

--- a/modules/core/map/src/Event/MapRenderEvent.php
+++ b/modules/core/map/src/Event/MapRenderEvent.php
@@ -73,6 +73,23 @@ class MapRenderEvent extends Event {
   }
 
   /**
+   * Getter method for map behaviors.
+   *
+   * This returns a merged list of map behaviors from both the map type
+   * configuration and the map element's #behaviors property.
+   *
+   * @return string[]
+   *   An array of map behavior IDs.
+   */
+  public function getMapBehaviors() {
+    $behaviors = $this->getMapType()->getMapBehaviors();
+    if (!empty($this->element['#behaviors'])) {
+      $behaviors = array_merge($behaviors, $this->element['#behaviors']);
+    }
+    return $behaviors;
+  }
+
+  /**
    * Add behavior to the map.
    *
    * @param string $behavior_name

--- a/modules/core/map/src/Plugin/Block/MapBlock.php
+++ b/modules/core/map/src/Plugin/Block/MapBlock.php
@@ -123,7 +123,7 @@ class MapBlock extends BlockBase implements ContainerFactoryPluginInterface {
     return [
       '#type' => 'farm_map',
       '#map_type' => $this->configuration['map_type'] ?? 'default',
-      '#behaviors' => array_keys($this->configuration['map_behaviors']) ?? [],
+      '#behaviors' => $this->configuration['map_behaviors'] ?? [],
     ];
   }
 

--- a/modules/core/ui/location/config/install/farm_map.map_type.locations.yml
+++ b/modules/core/ui/location/config/install/farm_map.map_type.locations.yml
@@ -1,0 +1,12 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_ui_location
+id: locations
+label: Locations
+description: 'The farmOS locations map.'
+behaviors:
+  - locations
+options: { }

--- a/modules/core/ui/location/farm_ui_location.info.yml
+++ b/modules/core/ui/location/farm_ui_location.info.yml
@@ -6,5 +6,6 @@ core_version_requirement: ^10
 dependencies:
   - farm:farm_entity
   - farm:farm_location
+  - farm:farm_ui_map
   - farm:farm_ui_menu
   - inspire_tree:inspire_tree

--- a/modules/core/ui/location/farm_ui_location.post_update.php
+++ b/modules/core/ui/location/farm_ui_location.post_update.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for farm_ui_location module.
+ */
+
+use Drupal\farm_map\Entity\MapType;
+
+/**
+ * Add farmOS locations map type.
+ */
+function farm_ui_location_post_update_add_locations_map_type(&$sandbox = NULL) {
+
+  // Create locations map type.
+  $map_type = MapType::create([
+    'id' => 'locations',
+    'label' => 'Locations',
+    'description' => 'The farmOS locations map.',
+    'behaviors' => [
+      'location',
+    ],
+    'options' => [],
+    'dependencies' => [
+      'enforced' => [
+        'module' => [
+          'farm_ui_location',
+        ],
+      ],
+    ],
+  ]);
+  $map_type->save();
+}

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -112,6 +112,14 @@ class LocationHierarchyForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state, AssetInterface $asset = NULL) {
 
+    // If no asset was specified, show a map of all locations.
+    if (is_null($asset)) {
+      $form['map'] = [
+        '#type' => 'farm_map',
+        '#map_type' => 'locations',
+      ];
+    }
+
     // Add a DIV for the JavaScript content.
     $form['content'] = [
       '#type' => 'html_tag',

--- a/modules/core/ui/map/config/install/farm_map.map_behavior.locations.yml
+++ b/modules/core/ui/map/config/install/farm_map.map_behavior.locations.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_ui_map
+id: locations
+label: Location asset layers
+description: 'Displays location asset geometries in layers by asset type.'
+library: ''
+settings: { }

--- a/modules/core/ui/map/config/install/farm_map.map_type.dashboard.yml
+++ b/modules/core/ui/map/config/install/farm_map.map_type.dashboard.yml
@@ -7,5 +7,6 @@ dependencies:
 id: dashboard
 label: Dashboard
 description: 'The farmOS dashboard map.'
-behaviors: { }
+behaviors:
+  - locations
 options: { }

--- a/modules/core/ui/map/farm_ui_map.info.yml
+++ b/modules/core/ui/map/farm_ui_map.info.yml
@@ -7,5 +7,4 @@ dependencies:
   - farm:asset
   - farm:farm_location
   - farm:farm_map
-  - farm:farm_ui_dashboard
   - farm:farm_ui_views

--- a/modules/core/ui/map/farm_ui_map.post_update.php
+++ b/modules/core/ui/map/farm_ui_map.post_update.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for farm_ui_map module.
+ */
+
+use Drupal\farm_map\Entity\MapBehavior;
+use Drupal\farm_map\Entity\MapType;
+
+/**
+ * Create farmOS-map locations behavior, add it to dashboard map.
+ */
+function farm_ui_map_post_update_locations_behavior(&$sandbox = NULL) {
+
+  // Create locations behavior.
+  $behavior = MapBehavior::create([
+    'id' => 'locations',
+    'label' => 'Location asset layers',
+    'description' => 'Displays location asset geometries in layers by asset type.',
+    'library' => '',
+    'settings' => [],
+    'dependencies' => [
+      'enforced' => [
+        'module' => [
+          'farm_ui_map',
+        ],
+      ],
+    ],
+  ]);
+  $behavior->save();
+
+  // Add the locations behavior to the dashboard map type.
+  $dashboard = MapType::load('dashboard');
+  $behaviors = $dashboard->getMapBehaviors();
+  $behaviors[] = 'locations';
+  $dashboard->set('behaviors', $behaviors);
+  $dashboard->save();
+}

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -61,11 +61,8 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   public function onMapRender(MapRenderEvent $event) {
 
-    // Get the map ID.
-    $map_id = $event->getmapType()->id();
-
     // Add behaviors/settings to default and geofield maps.
-    if (in_array($map_id, ['default', 'geofield'])) {
+    if (in_array($event->getmapType()->id(), ['default', 'geofield'])) {
 
       // Add "All locations" layers.
       $event->addBehavior('asset_type_layers');
@@ -86,8 +83,9 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
       }
     }
 
-    // Add asset layers to dashboard map.
-    elseif ($map_id == 'dashboard') {
+    // If the "locations" behavior is added to the map, add layers for each
+    // location asset type.
+    if (in_array('locations', $event->getMapBehaviors())) {
 
       $layers = [];
 


### PR DESCRIPTION
This PR takes the first, simplest, and most impactful step towards [Issue #2551091: Show map in /locations and /asset/[id]/locations](https://www.drupal.org/project/farm/issues/2551091).

It adds a map of locations to the /locations page in farmOS.

It does NOT add a map of locations to the /asset/[id]/locations pages. This has additional complexity, and I don't think there's a lot of value in taking this first step, and tackling the second part in a follow-up.

This PR also makes another general change, which is to rename/replace the current `dashboard` map type a `locations` map type (and also cleans up some dependencies). The thought behind this change is that the current `dashboard` map type is not dashboard-specific at all (other than the fact that it's only used on the dashboard). It is provided by the `farm_ui_map` module, not the `farm_ui_dashboard` module, and it adds layers for all locations to the map. So this just generalizes that to be more reusable, and then uses it in the /location page.

This needs CHANGELOG.md line(s), and will be saved for 3.1.0, so I'll leave it as a draft for right now.