### PR TITLE
Announce new releases on farmOS.discourse.group

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -222,8 +222,8 @@ jobs:
           fi
     outputs:
       announce: ${{ env.ANNOUNCE_RELEASE }}
-  announce:
-    name: Announce new release
+  announce-microblog:
+    name: Announce new release on farmOS-microblog
     if: needs.publish.outputs.announce
     needs:
       - build
@@ -234,3 +234,25 @@ jobs:
       message: '#farmOS ${{ needs.build.outputs.farmos_version }} has been released! https://github.com/farmOS/farmOS/releases/${{ needs.build.outputs.farmos_version }}'
     secrets:
       MICROBLOG_DEPLOY_KEY: ${{ secrets.MICROBLOG_DEPLOY_KEY }}
+  announce-discourse:
+    name: Announce new release on farmOS.discourse.group
+    if: needs.publish.outputs.announce
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - release
+      - publish
+    steps:
+      - name: Discourse API request
+        env:
+          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
+        run: |
+          curl --fail-with-body -X POST "https://farmos.discourse.group/posts/" \
+            -H "Content-Type: application/json" \
+            -H "Api-Key: ${DISCOURSE_API_KEY}" \
+            -H "Api-Username: mstenta" \
+            -d '{
+              "title": "farmOS ${{ needs.build.outputs.farmos_version }} has been released",
+              "raw": "farmOS [${{ needs.build.outputs.farmos_version }}](https://github.com/farmOS/farmOS/releases/${{ needs.build.outputs.farmos_version }}) has been released.\n\nFor the full release notes, see [CHANGELOG.md](https://github.com/farmOS/farmOS/blob/${{ needs.build.outputs.farmos_version }}/CHANGELOG.md).",
+              "category": 7
+            }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Announce new releases on farmOS.discourse.group #780](https://github.com/farmOS/farmOS/pull/780)
+
 ## [3.0.1] 2024-01-18
 
 ### Added


### PR DESCRIPTION
This adds a step to the end of our `deliver.yml` GitHub Actions workflow that uses the Discourse API to automate the creation of a "farmOS [version] has been released" topic, which is currently a manual step of the release procedure.

See https://farmos.discourse.group/t/3-x-release-procedure/1070

Example of a manual topic I create every release: https://farmos.discourse.group/t/farmos-3-0-1-has-been-released/1838

I tested this with a `3.x-announce-discourse-test` branch in my fork, which created this topic in the "Staff" category (only visible to farmOS.discourse.group admins): https://farmos.discourse.group/t/farmos-3-x-announce-discourse-test-has-been-released/1841