### PR TITLE
Add a Product asset type and Product type taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Announce new releases on farmOS.discourse.group #780](https://github.com/farmOS/farmOS/pull/780)
+- [Add a Product asset type and Product type taxonomy #787](https://github.com/farmOS/farmOS/pull/787)
 
 ### Changed
 

--- a/docs/model/type/asset.md
+++ b/docs/model/type/asset.md
@@ -25,6 +25,7 @@ included with farmOS define the following Asset types:
 - Sensor
 - Water
 - Material
+- Product
 - Group&ast;
 
 &ast;Group Assets are unique in that they can "contain" other Assets as "group
@@ -271,6 +272,12 @@ Plant Assets have the following additional relationships:
 
 - Plant type (references a Term in the "Plant type" vocabulary)
 - Season (references a Term in the "Season" vocabulary)
+
+#### Product Assets
+
+Product Assets have the following additional relationships:
+
+- Product type (references a Term in the "Product type" vocabulary)
 
 #### Sensor Assets
 

--- a/docs/model/type/term.md
+++ b/docs/model/type/term.md
@@ -20,6 +20,7 @@ is enabled. The modules included with farmOS define the following vocabularies:
 - Log category
 - Material type
 - Plant type
+- Product type
 - Season
 - Unit
 

--- a/farm.profile
+++ b/farm.profile
@@ -48,6 +48,7 @@ function farm_modules() {
       'farm_inventory' => t('Inventory management'),
       'farm_material' => t('Material assets'),
       'farm_seed' => t('Seed assets'),
+      'farm_product' => t('Product assets'),
       'farm_sensor' => t('Sensor assets'),
       'farm_compost' => t('Compost assets'),
       'farm_group' => t('Group assets'),

--- a/modules/asset/product/config/install/asset.type.product.yml
+++ b/modules/asset/product/config/install/asset.type.product.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_product
+id: product
+label: Product
+description: ''
+workflow: asset_default
+new_revision: true

--- a/modules/asset/product/config/optional/farm_map.layer_style.asset_product.yml
+++ b/modules/asset/product/config/optional/farm_map.layer_style.asset_product.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_product
+id: asset_product
+color: blue
+conditions:
+  asset_type:
+    - product

--- a/modules/asset/product/farm_product.info.yml
+++ b/modules/asset/product/farm_product.info.yml
@@ -1,0 +1,9 @@
+name: Product asset
+description: Adds an Product asset type.
+type: module
+package: farmOS Assets
+core_version_requirement: ^10
+dependencies:
+  - farm:asset
+  - farm:farm_entity
+  - farm:farm_product_type

--- a/modules/asset/product/src/Plugin/Asset/AssetType/Product.php
+++ b/modules/asset/product/src/Plugin/Asset/AssetType/Product.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\farm_product\Plugin\Asset\AssetType;
+
+use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
+
+/**
+ * Provides the product asset type.
+ *
+ * @AssetType(
+ *   id = "product",
+ *   label = @Translation("Product"),
+ * )
+ */
+class Product extends FarmAssetType {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildFieldDefinitions() {
+    $fields = parent::buildFieldDefinitions();
+    $field_info = [
+      'product_type' => [
+        'type' => 'entity_reference',
+        'label' => $this->t('Product type'),
+        'description' => $this->t("Enter the type of product."),
+        'target_type' => 'taxonomy_term',
+        'target_bundle' => 'product_type',
+        'auto_create' => TRUE,
+        'required' => TRUE,
+        'weight' => [
+          'form' => -90,
+          'view' => -50,
+        ],
+      ],
+    ];
+    foreach ($field_info as $name => $info) {
+      $fields[$name] = $this->farmFieldFactory->bundleFieldDefinition($info);
+    }
+    return $fields;
+  }
+
+}

--- a/modules/taxonomy/product_type/config/install/taxonomy.vocabulary.product_type.yml
+++ b/modules/taxonomy/product_type/config/install/taxonomy.vocabulary.product_type.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_product_type
+name: Product type
+vid: product_type
+description: 'A list of product types.'
+weight: 0

--- a/modules/taxonomy/product_type/farm_product_type.info.yml
+++ b/modules/taxonomy/product_type/farm_product_type.info.yml
@@ -1,0 +1,7 @@
+name: Product type vocabulary
+description: Provides an Product type vocabulary.
+type: module
+package: farmOS Taxonomies
+core_version_requirement: ^10
+dependencies:
+  - drupal:taxonomy


### PR DESCRIPTION
I originally started this in a separate module (https://github.com/mstenta/farm_product), but I think we should consider adding it to farmOS core as a standard asset type.

Inspired by this forum topic today: https://farmos.discourse.group/t/asset-type-product/1864

For more discussion/context see: https://farmos.discourse.group/t/tracking-products-and-inventory-product-quantity/1613