### PR TITLE
Remove decreased page top margin

### DIFF
--- a/modules/core/ui/theme/css/regions.css
+++ b/modules/core/ui/theme/css/regions.css
@@ -15,9 +15,3 @@
   margin-right: 0 !important;
 }
 
-/* Decrease top margin from elements below page title. */
-.layout-container .page-content > .help,
-.layout-container .page-content > .region-highlighted,
-.layout-container .page-content > .region-content {
-  margin-top: var(--gin-spacing-s);
-}


### PR DESCRIPTION
We previously implemented this style change to decrease some white space that is included at the top of pages. Since then I think something has changed as now some of the page content is slightly cut-off at the very top. I think this indicates that some previous extra space has since been removed. Let's just remove this style change.

![page-margin-top-before](https://github.com/farmOS/farmOS/assets/3116995/0db96eae-0248-46ba-a185-117b8c4bfe5b)
![Screenshot from 2024-01-30 15-11-58](https://github.com/farmOS/farmOS/assets/3116995/6facee3d-0e95-435a-b601-14c8087a4984)
