### PR TITLE
Grant config permissions create quick_form permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Grant config permissions create quick_form permission #791](https://github.com/farmOS/farmOS/pull/791)
+
 ## [3.1.0] 2024-02-02
 
 ### Added

--- a/modules/core/quick/farm_quick.managed_role_permissions.yml
+++ b/modules/core/quick/farm_quick.managed_role_permissions.yml
@@ -1,5 +1,6 @@
 farm_quick:
   config_permissions:
+    - create quick_form
     - update quick_form
     - administer quick_form
   default_permissions:


### PR DESCRIPTION
This permission is required on the quick form add_page and add_form routes. Currently users with the farm_manager or farm_account_admin roles are not able to create new quick form instances.