### PR TITLE
Add "Days of harvest" field to Plant type terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Update patch for Issue #3397275 to fix boolean field JSON Schema #819](https://github.com/farmOS/farmOS/pull/819)
 - [Do not trim whitespace from quantity field item content #820](https://github.com/farmOS/farmOS/pull/820)
 - [Do not install base modules when --existing-config is used #821](https://github.com/farmOS/farmOS/pull/821)
+- [Set the minimum value of maturity_days and transplant_days to 1 #794](https://github.com/farmOS/farmOS/pull/794)
 
 ## [3.1.2] 2024-02-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add a Notes filter to the logs views #825](https://github.com/farmOS/farmOS/pull/825)
 - [Add file and image base fields to all taxonomy terms #807](https://github.com/farmOS/farmOS/pull/807)
 - [Issue #3390486: Add an Ontology URI field to all taxonomy terms](https://www.drupal.org/project/farm/issues/3390486)
+- [Add "Days of harvest" field to Plant type terms #794](https://github.com/farmOS/farmOS/pull/794)
 
 ### Changed
 

--- a/docs/model/type/term.md
+++ b/docs/model/type/term.md
@@ -105,6 +105,7 @@ Terms in the "Plant type" vocabulary have the following additional attributes:
 
 - Days to maturity (Integer)
 - Days to transplant (Integer)
+- Days of harvest (Integer)
 
 And the following additional relationships:
 

--- a/modules/taxonomy/plant_type/config/install/field.field.taxonomy_term.plant_type.harvest_days.yml
+++ b/modules/taxonomy/plant_type/config/install/field.field.taxonomy_term.plant_type.harvest_days.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.harvest_days
+    - taxonomy.vocabulary.plant_type
+  enforced:
+    module:
+      - farm_plant_type
+id: taxonomy_term.plant_type.harvest_days
+field_name: harvest_days
+entity_type: taxonomy_term
+bundle: plant_type
+label: 'Days of harvest'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ' day| days'
+field_type: integer

--- a/modules/taxonomy/plant_type/config/install/field.field.taxonomy_term.plant_type.maturity_days.yml
+++ b/modules/taxonomy/plant_type/config/install/field.field.taxonomy_term.plant_type.maturity_days.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
+  min: 1
   max: null
   prefix: ''
   suffix: ' day| days'

--- a/modules/taxonomy/plant_type/config/install/field.field.taxonomy_term.plant_type.transplant_days.yml
+++ b/modules/taxonomy/plant_type/config/install/field.field.taxonomy_term.plant_type.transplant_days.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value: {  }
 default_value_callback: ''
 settings:
-  min: null
+  min: 1
   max: null
   prefix: ''
   suffix: ' day| days'

--- a/modules/taxonomy/plant_type/config/install/field.storage.taxonomy_term.harvest_days.yml
+++ b/modules/taxonomy/plant_type/config/install/field.storage.taxonomy_term.harvest_days.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_plant_type
+  module:
+    - taxonomy
+id: taxonomy_term.harvest_days
+field_name: harvest_days
+entity_type: taxonomy_term
+type: integer
+settings:
+  unsigned: true
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/taxonomy/plant_type/farm_plant_type.module
+++ b/modules/taxonomy/plant_type/farm_plant_type.module
@@ -40,6 +40,14 @@ function farm_plant_type_entity_form_display_alter(EntityFormDisplayInterface $f
       'region' => 'content',
       'weight' => 15,
     ]);
+    $form_display->setComponent('harvest_days', [
+      'type' => 'number',
+      'settings' => [
+        'placeholder' => '',
+      ],
+      'region' => 'content',
+      'weight' => 30,
+    ]);
     $form_display->setComponent('companions', [
       'type' => 'entity_reference_autocomplete',
       'settings' => [
@@ -87,6 +95,16 @@ function farm_plant_type_entity_view_display_alter(EntityViewDisplayInterface $d
       ],
       'region' => 'content',
       'weight' => 15,
+    ]);
+    $display->setComponent('harvest_days', [
+      'type' => 'number_integer',
+      'label' => 'inline',
+      'settings' => [
+        'thousand_separator' => '',
+        'prefix_suffix' => TRUE,
+      ],
+      'region' => 'content',
+      'weight' => 30,
     ]);
     $display->setComponent('companions', [
       'type' => 'entity_reference_label',

--- a/modules/taxonomy/plant_type/farm_plant_type.post_update.php
+++ b/modules/taxonomy/plant_type/farm_plant_type.post_update.php
@@ -7,12 +7,12 @@
 
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\Entity\EntityViewDisplay;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Delete default form/view display config for plant type fields.
  */
 function farm_plant_type_post_update_delete_display_config(&$sandbox) {
-
   // We only do this if the farm_update module is enabled, under the assumption
   // that farm_update would be keeping these configurations in a default state.
   if (\Drupal::moduleHandler()->moduleExists('farm_update')) {
@@ -20,5 +20,35 @@ function farm_plant_type_post_update_delete_display_config(&$sandbox) {
     $form_display_config->delete();
     $view_display_config = EntityViewDisplay::load('taxonomy_term.plant_type.default');
     $view_display_config->delete();
+  }
+}
+
+/**
+ * Set the minimum value of maturity_days and transplant_days to 1.
+ */
+function farm_plant_type_post_update_min_1_day(&$sandbox) {
+
+  // Set the min setting of both fields to 1.
+  $field_names = [
+    'maturity_days',
+    'transplant_days',
+  ];
+  foreach ($field_names as $field_name) {
+    $field = FieldConfig::load('taxonomy_term.plant_type.' . $field_name);
+    if (!empty($field)) {
+      $field->setSetting('min', 1);
+      $field->save();
+    }
+  }
+
+  // Delete any zero values from the database.
+  $tables = [
+    'taxonomy_term__maturity_days' => 'maturity_days_value',
+    'taxonomy_term__transplant_days' => 'transplant_days_value',
+    'taxonomy_term_revision__maturity_days' => 'maturity_days_value',
+    'taxonomy_term_revision__transplant_days' => 'transplant_days_value',
+  ];
+  foreach ($tables as $table => $column) {
+    \Drupal::database()->query('DELETE FROM {' . $table . '} WHERE ' . $column . ' = 0');
   }
 }

--- a/modules/taxonomy/plant_type/farm_plant_type.post_update.php
+++ b/modules/taxonomy/plant_type/farm_plant_type.post_update.php
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\Entity\EntityFormDisplay;
 use Drupal\Core\Entity\Entity\EntityViewDisplay;
 use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 
 /**
  * Delete default form/view display config for plant type fields.
@@ -27,7 +28,6 @@ function farm_plant_type_post_update_delete_display_config(&$sandbox) {
  * Set the minimum value of maturity_days and transplant_days to 1.
  */
 function farm_plant_type_post_update_min_1_day(&$sandbox) {
-
   // Set the min setting of both fields to 1.
   $field_names = [
     'maturity_days',
@@ -49,6 +49,69 @@ function farm_plant_type_post_update_min_1_day(&$sandbox) {
     'taxonomy_term_revision__transplant_days' => 'transplant_days_value',
   ];
   foreach ($tables as $table => $column) {
-    \Drupal::database()->query('DELETE FROM {' . $table . '} WHERE ' . $column . ' = 0');
+    \Drupal::database()
+      ->query('DELETE FROM {' . $table . '} WHERE ' . $column . ' = 0');
   }
+}
+
+/**
+ * Add harvest_days field to plant_type terms.
+ */
+function farm_plant_type_post_update_add_harvest_days(&$sandbox) {
+  $field_storage = FieldStorageConfig::create([
+    'id' => 'taxonomy_term.harvest_days',
+    'field_name' => 'harvest_days',
+    'entity_type' => 'taxonomy_term',
+    'type' => 'integer',
+    'settings' => [
+      'unsigned' => TRUE,
+      'size' => 'normal',
+    ],
+    'module' => 'core',
+    'locked' => FALSE,
+    'cardinality' => 1,
+    'indexes' => [],
+    'persist_with_no_fields' => FALSE,
+    'custom_storage' => FALSE,
+    'dependencies' => [
+      'enforced' => [
+        'module' => [
+          'farm_plant_type',
+        ],
+      ],
+      'module' => [
+        'taxonomy',
+      ],
+    ],
+  ]);
+  $field_storage->save();
+  $field = FieldConfig::create([
+    'id' => 'taxonomy_term.plant_type.harvest_days',
+    'field_name' => 'harvest_days',
+    'entity_type' => 'taxonomy_term',
+    'bundle' => 'plant_type',
+    'label' => 'Days of harvest',
+    'description' => '',
+    'required' => FALSE,
+    'default_value' => [],
+    'default_value_callback' => '',
+    'settings' => [
+      'min' => 1,
+      'max' => NULL,
+      'prefix' => '',
+      'suffix' => ' day| days',
+    ],
+    'field_type' => 'integer',
+    'dependencies' => [
+      'enforced' => [
+        'module' => [
+          'farm_plant_type',
+        ],
+      ],
+      'module' => [
+        'taxonomy',
+      ],
+    ],
+  ]);
+  $field->save();
 }


### PR DESCRIPTION
This adds a `harvest_days` field to `plant_type` taxonomy terms, alongside the existing `transplant_days` and `maturity_days`.

Along with the other two field, this will provide core data storage at the plant type level, which can then be used in other places. In particular, we would like to use this field in the [Crop planning](drupal.org/project/farm_crop_plan) module.