### PR TITLE
Move transplant_days field to farm_transplant module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Do not trim whitespace from quantity field item content #820](https://github.com/farmOS/farmOS/pull/820)
 - [Do not install base modules when --existing-config is used #821](https://github.com/farmOS/farmOS/pull/821)
 - [Set the minimum value of maturity_days and transplant_days to 1 #794](https://github.com/farmOS/farmOS/pull/794)
+- [Move transplant_days field to farm_transplant module #795](https://github.com/farmOS/farmOS/pull/795)
 
 ## [3.1.2] 2024-02-26
 

--- a/docs/model/type/term.md
+++ b/docs/model/type/term.md
@@ -104,7 +104,7 @@ above, some types add additional type-specific fields. These include:
 Terms in the "Plant type" vocabulary have the following additional attributes:
 
 - Days to maturity (Integer)
-- Days to transplant (Integer)
+- Days to transplant (Integer) (Added by the optional Transplanting module)
 - Days of harvest (Integer)
 
 And the following additional relationships:

--- a/modules/log/transplanting/config/install/field.field.taxonomy_term.plant_type.transplant_days.yml
+++ b/modules/log/transplanting/config/install/field.field.taxonomy_term.plant_type.transplant_days.yml
@@ -6,7 +6,7 @@ dependencies:
     - taxonomy.vocabulary.plant_type
   enforced:
     module:
-      - farm_plant_type
+      - farm_transplanting
 id: taxonomy_term.plant_type.transplant_days
 field_name: transplant_days
 entity_type: taxonomy_term

--- a/modules/log/transplanting/config/install/field.storage.taxonomy_term.transplant_days.yml
+++ b/modules/log/transplanting/config/install/field.storage.taxonomy_term.transplant_days.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   enforced:
     module:
-      - farm_plant_type
+      - farm_transplanting
   module:
     - taxonomy
 id: taxonomy_term.transplant_days

--- a/modules/log/transplanting/farm_transplanting.info.yml
+++ b/modules/log/transplanting/farm_transplanting.info.yml
@@ -6,4 +6,5 @@ core_version_requirement: ^10
 dependencies:
   - farm:farm_entity
   - farm:farm_plant
+  - farm:farm_plant_type
   - log:log

--- a/modules/log/transplanting/farm_transplanting.module
+++ b/modules/log/transplanting/farm_transplanting.module
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * Contains farm_transplanting.module.
+ */
+
+use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+
+/**
+ * Implements hook_entity_form_display_alter().
+ */
+function farm_transplanting_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
+  if ($context['entity_type'] == 'taxonomy_term' && $context['bundle'] == 'plant_type' && $form_display->getMode() == 'default' && $form_display->isNew()) {
+    $form_display->setComponent('transplant_days', [
+      'type' => 'number',
+      'settings' => [
+        'placeholder' => '',
+      ],
+      'region' => 'content',
+      'weight' => 15,
+    ]);
+  }
+}
+
+/**
+ * Implements hook_entity_view_display_alter().
+ */
+function farm_transplanting_entity_view_display_alter(EntityViewDisplayInterface $display, array $context) {
+  if ($context['entity_type'] == 'taxonomy_term' && $context['bundle'] == 'plant_type' && $display->getMode() == 'full' && $display->isNew()) {
+    $display->setComponent('transplant_days', [
+      'type' => 'number_integer',
+      'label' => 'inline',
+      'settings' => [
+        'thousand_separator' => '',
+        'prefix_suffix' => TRUE,
+      ],
+      'region' => 'content',
+      'weight' => 15,
+    ]);
+  }
+}

--- a/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
@@ -24,6 +24,7 @@ class QuickPlantingTest extends QuickFormTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'entity_reference_validators',
     'farm_harvest',
     'farm_land',
     'farm_plant',
@@ -34,6 +35,7 @@ class QuickPlantingTest extends QuickFormTestBase {
     'farm_seeding',
     'farm_transplanting',
     'farm_unit',
+    'field',
   ];
 
   /**
@@ -45,6 +47,7 @@ class QuickPlantingTest extends QuickFormTestBase {
       'farm_harvest',
       'farm_land',
       'farm_plant',
+      'farm_plant_type',
       'farm_quantity_standard',
       'farm_seeding',
       'farm_transplanting',

--- a/modules/taxonomy/plant_type/farm_plant_type.module
+++ b/modules/taxonomy/plant_type/farm_plant_type.module
@@ -32,14 +32,6 @@ function farm_plant_type_entity_form_display_alter(EntityFormDisplayInterface $f
       'region' => 'content',
       'weight' => 20,
     ]);
-    $form_display->setComponent('transplant_days', [
-      'type' => 'number',
-      'settings' => [
-        'placeholder' => '',
-      ],
-      'region' => 'content',
-      'weight' => 15,
-    ]);
     $form_display->setComponent('harvest_days', [
       'type' => 'number',
       'settings' => [
@@ -85,16 +77,6 @@ function farm_plant_type_entity_view_display_alter(EntityViewDisplayInterface $d
       ],
       'region' => 'content',
       'weight' => 20,
-    ]);
-    $display->setComponent('transplant_days', [
-      'type' => 'number_integer',
-      'label' => 'inline',
-      'settings' => [
-        'thousand_separator' => '',
-        'prefix_suffix' => TRUE,
-      ],
-      'region' => 'content',
-      'weight' => 15,
     ]);
     $display->setComponent('harvest_days', [
       'type' => 'number_integer',


### PR DESCRIPTION
Currently the `farm_plant_type` provides a `plant_type` taxonomy. These `plant_type` terms have a few fields added to them:

- `crop_family` - reference to a term in the `crop_family` vocabulary
- `companions` - reference to one or more terms in the `plant_type` vocabulary
- `transplant_days` - integer representing the number of days between seeding and transplanting
- `maturity_days` - integer representing the number of days between seeding and maturity/harvest

I am also proposing we add `harvest_days` to represent the "harvest window" in #794. (This PR is currently built on top of that that one, but we can separate them if we need to.)

My though behind moving `transplant_days` to the `farm_transplant` module is: not all farms deal with transplants. A farm that only deals with direct seeding may not have the `transplant` log type installed, and this `transplant_days` field is meaningless to them.

By moving it to the `farm_transplant` module, this field will only be installed when that module is.