### PR TITLE
Merge multiple functional tests together to reduce test startup time

### DIFF
--- a/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
+++ b/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
@@ -44,9 +44,17 @@ class SensorDataApiTest extends FarmBrowserTestBase {
   }
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestApiGet();
+    $this->doTestApiPost();
+  }
+
+  /**
    * Test API GET requests.
    */
-  public function testApiGet() {
+  public function doTestApiGet() {
 
     // Build the path.
     $uri = $this->buildPath($this->asset);
@@ -82,7 +90,7 @@ class SensorDataApiTest extends FarmBrowserTestBase {
   /**
    * Test API POST requests.
    */
-  public function testApiPost() {
+  public function doTestApiPost() {
 
     // Build the path.
     $uri = $this->buildPath($this->asset);

--- a/modules/core/api/tests/src/Functional/EntryPointTest.php
+++ b/modules/core/api/tests/src/Functional/EntryPointTest.php
@@ -28,6 +28,14 @@ class EntryPointTest extends FarmBrowserTestBase {
   ];
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestEntryPoint();
+    $this->doTestFarmMeta();
+  }
+
+  /**
    * Test GET to the entry point.
    *
    * We extend the core JSONAPI EntryPoint controller to include a 'meta' key
@@ -41,7 +49,7 @@ class EntryPointTest extends FarmBrowserTestBase {
    *
    * @see \Drupal\Tests\jsonapi\Functional\EntryPointTest
    */
-  public function testEntryPoint() {
+  public function doTestEntryPoint() {
     $request_options = [];
     $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
     $response = $this->request('GET', Url::fromUri('base://api'), $request_options);
@@ -73,7 +81,7 @@ class EntryPointTest extends FarmBrowserTestBase {
   /**
    * Test that the meta.farm data is correct.
    */
-  public function testFarmMeta() {
+  public function doTestFarmMeta() {
     $request_options = [];
     $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
     $response = $this->request('GET', Url::fromUri('base://api'), $request_options);

--- a/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
+++ b/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
@@ -15,9 +15,22 @@ class AssetCRUDTest extends AssetTestBase {
   use StringTranslationTrait;
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestFieldsVisibility();
+    $this->doTestCreateAsset();
+    $this->doTestViewAsset();
+    $this->doTestEditAsset();
+    $this->doTestDeleteAsset();
+    $this->doTestArchiveAsset();
+    $this->doTestArchiveAssetViaTimestamp();
+  }
+
+  /**
    * Fields are displayed correctly.
    */
-  public function testFieldsVisibility() {
+  public function doTestFieldsVisibility() {
     $this->drupalGet('asset/add/default');
     $assert_session = $this->assertSession();
     $assert_session->statusCodeEquals(200);
@@ -32,7 +45,7 @@ class AssetCRUDTest extends AssetTestBase {
   /**
    * Create asset entity.
    */
-  public function testCreateAsset() {
+  public function doTestCreateAsset() {
     $assert_session = $this->assertSession();
     $name = $this->randomMachineName();
     $edit = [
@@ -59,7 +72,7 @@ class AssetCRUDTest extends AssetTestBase {
   /**
    * Display asset entity.
    */
-  public function testViewAsset() {
+  public function doTestViewAsset() {
     $edit = [
       'name' => $this->randomMachineName(),
       'created' => \Drupal::time()->getRequestTime(),
@@ -77,7 +90,7 @@ class AssetCRUDTest extends AssetTestBase {
   /**
    * Edit asset entity.
    */
-  public function testEditAsset() {
+  public function doTestEditAsset() {
     $asset = $this->createAssetEntity();
     $asset->save();
 
@@ -92,7 +105,7 @@ class AssetCRUDTest extends AssetTestBase {
   /**
    * Delete asset entity.
    */
-  public function testDeleteAsset() {
+  public function doTestDeleteAsset() {
     $asset = $this->createAssetEntity();
     $asset->save();
 
@@ -111,7 +124,7 @@ class AssetCRUDTest extends AssetTestBase {
   /**
    * Asset archiving.
    */
-  public function testArchiveAsset() {
+  public function doTestArchiveAsset() {
     $asset = $this->createAssetEntity();
     $asset->save();
 
@@ -141,7 +154,7 @@ class AssetCRUDTest extends AssetTestBase {
   /**
    * Asset archiving/unarchiving via timestamp.
    */
-  public function testArchiveAssetViaTimestamp() {
+  public function doTestArchiveAssetViaTimestamp() {
     $asset = $this->createAssetEntity();
     $asset->save();
 

--- a/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
@@ -60,9 +60,18 @@ class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
   }
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestBundleFieldMapUpdates();
+    $this->doTestBundleFieldPostponedInstall();
+    $this->doTestBundlePluginModuleUninstallation();
+  }
+
+  /**
    * Test that bundle field maps are updated on install/uninstall.
    */
-  public function testBundleFieldMapUpdates() {
+  public function doTestBundleFieldMapUpdates() {
 
     // Get the entity field map.
     $field_map = $this->entityFieldManager->getFieldMap();
@@ -107,7 +116,7 @@ class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
   /**
    * Test installing the farm_entity_contrib_test module after farm_entity_test.
    */
-  public function testBundleFieldPostponedInstall() {
+  public function doTestBundleFieldPostponedInstall() {
 
     // Install the farm_entity_contrib_test module.
     $result = $this->moduleInstaller->install(['farm_entity_contrib_test'], TRUE);
@@ -150,7 +159,7 @@ class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
   /**
    * Test that bundle fields can be reused across bundles.
    */
-  public function testBundlePluginModuleUninstallation() {
+  public function doTestBundlePluginModuleUninstallation() {
 
     // Test that database tables exist after uninstalling a bundle with
     // a field storage definition used by other bundles.

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -30,9 +30,17 @@ class UserLoginTest extends FarmBrowserTestBase {
   ];
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestValidLoginWithDestination();
+    $this->doTestPerUserLoginFloodControl();
+  }
+
+  /**
    * Tests login with destination.
    */
-  public function testValidLoginWithDestination() {
+  public function doTestValidLoginWithDestination() {
 
     // 1. Test for correct text in the login form.
     $this->drupalGet('user/login');
@@ -79,7 +87,7 @@ class UserLoginTest extends FarmBrowserTestBase {
    *
    * @see UserLoginTest::testPerUserLoginFloodControl()
    */
-  public function testPerUserLoginFloodControl() {
+  public function doTestPerUserLoginFloodControl() {
     $this->config('user.flood')
       // Set a high global limit out so that it is not relevant in the test.
       ->set('ip_limit', 4000)

--- a/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
+++ b/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
@@ -15,9 +15,22 @@ class PlanCRUDTest extends PlanTestBase {
   use StringTranslationTrait;
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestFieldsVisibility();
+    $this->doTestCreatePlan();
+    $this->doTestViewPlan();
+    $this->doTestEditPlan();
+    $this->doTestDeletePlan();
+    $this->doTestArchivePlan();
+    $this->doTestArchivePlanViaTimestamp();
+  }
+
+  /**
    * Fields are displayed correctly.
    */
-  public function testFieldsVisibility() {
+  public function doTestFieldsVisibility() {
     $this->drupalGet('plan/add/default');
     $assert_session = $this->assertSession();
     $assert_session->statusCodeEquals(200);
@@ -32,7 +45,7 @@ class PlanCRUDTest extends PlanTestBase {
   /**
    * Create plan entity.
    */
-  public function testCreatePlan() {
+  public function doTestCreatePlan() {
     $assert_session = $this->assertSession();
     $name = $this->randomMachineName();
     $edit = [
@@ -59,7 +72,7 @@ class PlanCRUDTest extends PlanTestBase {
   /**
    * Display plan entity.
    */
-  public function testViewPlan() {
+  public function doTestViewPlan() {
     $edit = [
       'name' => $this->randomMachineName(),
       'created' => \Drupal::time()->getRequestTime(),
@@ -77,7 +90,7 @@ class PlanCRUDTest extends PlanTestBase {
   /**
    * Edit plan entity.
    */
-  public function testEditPlan() {
+  public function doTestEditPlan() {
     $plan = $this->createPlanEntity();
     $plan->save();
 
@@ -93,7 +106,7 @@ class PlanCRUDTest extends PlanTestBase {
   /**
    * Delete plan entity.
    */
-  public function testDeletePlan() {
+  public function doTestDeletePlan() {
     $plan = $this->createPlanEntity();
     $plan->save();
 
@@ -112,7 +125,7 @@ class PlanCRUDTest extends PlanTestBase {
   /**
    * Plan archiving.
    */
-  public function testArchivePlan() {
+  public function doTestArchivePlan() {
     $plan = $this->createPlanEntity();
     $plan->save();
 
@@ -142,7 +155,7 @@ class PlanCRUDTest extends PlanTestBase {
   /**
    * Plan archiving/unarchiving via timestamp.
    */
-  public function testArchivePlanViaTimestamp() {
+  public function doTestArchivePlanViaTimestamp() {
     $plan = $this->createPlanEntity();
     $plan->save();
 

--- a/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
+++ b/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
@@ -38,9 +38,17 @@ class DashboardTest extends FarmBrowserTestBase {
   }
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestDashboardBlock();
+    $this->doTestDashboardView();
+  }
+
+  /**
    * Test that custom blocks are added to the dashboard.
    */
-  public function testDashboardBlock() {
+  public function doTestDashboardBlock() {
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
 
@@ -51,7 +59,7 @@ class DashboardTest extends FarmBrowserTestBase {
   /**
    * Test that custom views are added to the dashboard.
    */
-  public function testDashboardView() {
+  public function doTestDashboardView() {
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
 

--- a/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
@@ -66,23 +66,27 @@ class DashboardTasksTest extends FarmBrowserTestBase {
   }
 
   /**
-   * Test the upcoming tasks view on the dashboard.
+   * Test the upcoming and late tasks views on the dashboard.
    */
-  public function testUpcomingTasks() {
+  public function testDashboardTasks() {
+
+    // Load the dashboard.
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
 
-    // Assert that the upcoming tasks view was not added.
+    // Assert that the upcoming and late tasks views were not added.
     $this->assertSession()->pageTextNotContains('Upcoming tasks');
+    $this->assertSession()->pageTextNotContains('Late tasks');
 
     // Grant the user permission to view any log.
     $this->user->addRole($this->role);
     $this->user->save();
 
-    // Assert that the upcoming tasks view is added.
+    // Assert that the upcoming tasks and late tasks views are added.
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('Upcoming tasks');
+    $this->assertSession()->pageTextContains('Late tasks');
 
     // Assert that the log is not displayed.
     $this->assertSession()->pageTextContains('No logs found.');
@@ -92,48 +96,19 @@ class DashboardTasksTest extends FarmBrowserTestBase {
     $this->log->timestamp = \Drupal::time()->getCurrentTime() + 86400;
     $this->log->save();
 
-    // Assert that the upcoming tasks view is added.
-    $this->drupalGet('/dashboard');
-    $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('Upcoming tasks');
-
     // Assert that the log is displayed.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains($this->log->label());
-  }
-
-  /**
-   * Test the late tasks view on the dashboard.
-   */
-  public function testLateTasks() {
-    $this->drupalGet('/dashboard');
-    $this->assertSession()->statusCodeEquals(200);
-
-    // Assert that the upcoming tasks view was not added.
-    $this->assertSession()->pageTextNotContains('Late tasks');
-
-    // Grant the user permission to view any log.
-    $this->user->addRole($this->role);
-    $this->user->save();
-
-    // Assert that the upcoming tasks view is added.
-    $this->drupalGet('/dashboard');
-    $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('Late tasks');
-
-    // Assert that the log is not displayed.
-    $this->assertSession()->pageTextContains('No logs found.');
 
     // Mark the log as pending in the past.
     $this->log->status = 'pending';
     $this->log->timestamp = \Drupal::time()->getCurrentTime() - 86400;
     $this->log->save();
 
-    // Assert that the upcoming tasks view is added.
+    // Assert that the log is displayed.
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->pageTextContains('Late tasks');
-
-    // Assert that the log is displayed.
     $this->assertSession()->pageTextContains($this->log->label());
   }
 

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -88,9 +88,17 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
   }
 
   /**
+   * Run all tests.
+   */
+  public function testAll() {
+    $this->doTestTaxonomyTermAssetTaskTabsAppear();
+    $this->doTestTaxonomyTermAssetViews();
+  }
+
+  /**
    * Test that the asset view task links appear on taxonomy term pages.
    */
-  public function testTaxonomyTermAssetTaskTabsAppear() {
+  public function doTestTaxonomyTermAssetTaskTabsAppear() {
     $fava_term_url = 'taxonomy/term/' . $this->favaPlantType->id();
 
     $this->drupalGet($fava_term_url);
@@ -131,7 +139,7 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
   /**
    * Test that the views of assets for terms show the correct assets.
    */
-  public function testTaxonomyTermAssetViews() {
+  public function doTestTaxonomyTermAssetViews() {
     $fava_term_url = 'taxonomy/term/' . $this->favaPlantType->id();
 
     $this->drupalGet("$fava_term_url/assets/all");


### PR DESCRIPTION
I was looking into ways of improving the performance of our functional tests, and found this suggestion by @Berdir:

> Another thing to consider is to avoid having many test methods. Each runs in a completely new, isolated environment. A trick that is often used is to have a single testAll() method and many doTestSomething() methods, then they are faster by almost factor count(test methods), since set up is usually by far the slowest part.

https://drupal.stackexchange.com/a/213561

This PR tests out this suggestion. It seems to shave off about 30 seconds from our tests overall, based on the few times that I've run them so far.