### PR TITLE
Set COMPOSER_ALLOW_SUPERUSER=1 to allow plugins to run as root/super user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,6 +50,9 @@ RUN apt-get update && apt-get install -y \
 # Set the COMPOSER_MEMORY_LIMIT environment variable to unlimited.
 ENV COMPOSER_MEMORY_LIMIT=-1
 
+# Set COMPOSER_ALLOW_SUPERUSER=1 to allow plugins to run as root/super user.
+ENV COMPOSER_ALLOW_SUPERUSER=1
+
 # Add the build-farmOS.sh script.
 COPY build-farmOS.sh /usr/local/bin/
 RUN chmod a+x /usr/local/bin/build-farmOS.sh


### PR DESCRIPTION
Docker image builds have started failing in our GitHub Actions with the following messages:

`Composer plugins have been disabled for safety in this non-interactive session. Set COMPOSER_ALLOW_SUPERUSER=1 if you want to allow plugins to run as root/super user.`

```
#18 10.20   - Installing cweagans/composer-patches (1.7.3): Extracting archive
#18 10.22 The "cweagans/composer-patches" plugin was not loaded as plugins are disabled.
#18 10.22   - Installing composer/installers (v2.2.0): Extracting archive
#18 10.24 The "composer/installers" plugin was not loaded as plugins are disabled.
#18 10.24   - Installing wikimedia/composer-merge-plugin (v2.1.0): Extracting archive
#18 10.25 The "wikimedia/composer-merge-plugin" plugin was not loaded as plugins are disabled.
#18 10.26   - Installing oomphinc/composer-installers-extender (2.0.1): Extracting archive
#18 10.27 The "oomphinc/composer-installers-extender" plugin was not loaded as plugins are disabled.
```

This PR fixes the issue by setting `COMPOSER_ALLOW_SUPERUSER=1`.

Ultimately, we should move to building with the `www-data` user, so Composer doesn't need to run as root, but that's a harder nut to crack and we need this in the meantime to keep the status quo working.