### PR TITLE
Check for correct update operation access in location hierarchy form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Check for correct update operation access in location hierarchy form #800](https://github.com/farmOS/farmOS/pull/800)
+
 ## [3.1.1] 2024-02-07
 
 ### Fixed

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -296,9 +296,9 @@ class LocationHierarchyForm extends FormBase {
       // Load the asset.
       $asset = $storage->load($change['asset_id']);
 
-      // If the user does not have permission to edit the asset, count it so
+      // If the user does not have permission to update the asset, count it so
       // that we can add a warning message later, and skip it.
-      if (!$asset->access('edit')) {
+      if (!$asset->access('update')) {
         $restricted_assets[] = $asset;
         continue;
       }


### PR DESCRIPTION
Fixes a bug as reported in https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/614

We should check the `update` operation, not `edit`. Currently I think this means that the location hierarchy form is broken because no user will have access to the non-existent `edit` operation.