### PR TITLE
Update to itamair/geophp 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "drupal/views_geojson": "^1.2",
         "drush/drush": "^12.4.3",
         "ext-simplexml": "*",
-        "itamair/geophp": "1.3"
+        "itamair/geophp": "1.6"
     },
     "extra": {
         "patchLevel": {


### PR DESCRIPTION
Fixes an issue identified in https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/613

> Deprecated function: Creation of dynamic property KML::$xmlobj is deprecated in KML->geomFromText() (line 64 of /app/vendor/itamair/geophp/lib/adapters/KML.class.php)

This seems to be fixed in the latest release 1.6 of itamair/geophp: https://github.com/itamair/geoPHP/commit/f210e37ab3d4706b7e8cfe3183fec2f5be8a85e6

It seems like there have been various releases since 1.3 and it wouldn't hurt to update, as long as the patch still applied