### PR TITLE
Run tests against mariadb:10 instead of mariadb:latest

### DIFF
--- a/docker/docker-compose.testing.mariadb.yml
+++ b/docker/docker-compose.testing.mariadb.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   db:
-    image: mariadb:latest
+    image: mariadb:10
     volumes:
       - './db:/var/lib/mysql'
     ports:


### PR DESCRIPTION
MariaDB tests started failing recently with the following error:

`SQLSTATE[HY000] [2054] Server sent charset (0) unknown to the client.`

I traced this to the fact that we are running tests against the `mariadb:latest` Docker image, which is version 11.

Changing our `docker-compose.testing.mariadb.yml` configuration to use `mariadb:10` fixes the issue.

I didn't dig into the root cause of this issue in MariaDB 11, but this PR will get our tests running again as a first step. Worth noting: we also pin our PostgreSQL tests (`postgres:13`), so this is consistent with that.

We may want to open a separate follow-up issue to explore why MariaDB 11 doesn't work, and see if we need to document this in https://farmos.org/hosting/install/#database-server...