### PR TITLE
Fix saving inventory quick form configuration with existing units term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Check for correct update operation access in location hierarchy form #800](https://github.com/farmOS/farmOS/pull/800)
 - [Update to itamair/geophp 1.6 #801](https://github.com/farmOS/farmOS/pull/801) to fix deprecated function warnings.
+- [Fix saving inventory quick form configuration with existing units term #803](https://github.com/farmOS/farmOS/pull/803)
 
 ## [3.1.1] 2024-02-07
 

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -498,7 +498,19 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
     $this->configuration['asset'] = $form_state->getValue('asset');
     $this->configuration['units'] = NULL;
     if (!empty($form_state->getValue('units'))) {
-      $this->configuration['units'] = $form_state->getValue('units')['entity']->label();
+
+      // Existing terms will be represented as a numeric term ID.
+      if (is_numeric($form_state->getValue('units'))) {
+        $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($form_state->getValue('units'));
+        if (!empty($term)) {
+          $this->configuration['units'] = $term->label();
+        }
+      }
+
+      // New terms will be represented as a term entity object.
+      elseif (!empty($form_state->getValue('units')['entity'])) {
+        $this->configuration['units'] = $form_state->getValue('units')['entity']->label();
+      }
     }
     $this->configuration['measure'] = $form_state->getValue('measure');
     $this->configuration['inventory_adjustment'] = $form_state->getValue('inventory_adjustment');


### PR DESCRIPTION
The `entity_autocomplete` `$form_state` value differs depending on whether it is referencing an existing term or creating a new term.

This fixes the submit logic in the configuration form of the inventory quick form to handle both cases. Before this change, it was only possible to create a new term. Referencing an existing term would result in a PHP error:

`TypeError: "Cannot access offset of type string on string"`