### PR TITLE
Use content form for taxonomy terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Make "done" the default log status #782](https://github.com/farmOS/farmOS/pull/782)
 - [Set the minimum value of maturity_days and transplant_days to 1 #794](https://github.com/farmOS/farmOS/pull/794)
 - [Move transplant_days field to farm_transplant module #795](https://github.com/farmOS/farmOS/pull/795)
+- [Use content form for taxonomy terms #810](https://github.com/farmOS/farmOS/pull/810)
 
 ### Fixed
 

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\farm_ui_theme\Form\AssetForm;
 use Drupal\farm_ui_theme\Form\LogForm;
 use Drupal\farm_ui_theme\Form\PlanForm;
+use Drupal\farm_ui_theme\Form\TaxonomyTermForm;
 
 /**
  * Implements hook_theme().
@@ -69,7 +70,7 @@ function farm_ui_theme_theme_suggestions_menu_local_tasks(array $variables) {
 function farm_ui_theme_entity_form_display_alter(EntityFormDisplayInterface $form_display, array $context) {
 
   // Only alter farm entity types.
-  $entity_types = ['asset', 'log', 'plan'];
+  $entity_types = ['asset', 'log', 'plan', 'taxonomy_term'];
   if (!in_array($context['entity_type'], $entity_types)) {
     return;
   }
@@ -127,6 +128,9 @@ function farm_ui_theme_farm_ui_theme_field_group_items(string $entity_type, stri
     case 'plan':
       break;
 
+    case 'taxonomy_term':
+      break;
+
     default:
       $fields = [];
   }
@@ -138,7 +142,7 @@ function farm_ui_theme_farm_ui_theme_field_group_items(string $entity_type, stri
  */
 function farm_ui_theme_gin_content_form_routes() {
   $routes = [];
-  $entity_types = ['asset', 'log', 'plan'];
+  $entity_types = ['asset', 'log', 'plan', 'taxonomy_term'];
   foreach ($entity_types as $entity_type) {
     $routes[] = "entity.$entity_type.add_form";
     $routes[] = "entity.$entity_type.edit_form";
@@ -155,9 +159,11 @@ function farm_ui_theme_entity_type_build(array &$entity_types) {
     'asset' => AssetForm::class,
     'log' => LogForm::class,
     'plan' => PlanForm::class,
+    'taxonomy_term' => TaxonomyTermForm::class,
   ];
   foreach ($target_entity_types as $entity_type => $form_class) {
     if (isset($entity_types[$entity_type])) {
+      $entity_types[$entity_type]->setFormClass('default', $form_class);
       $entity_types[$entity_type]->setFormClass('add', $form_class);
       $entity_types[$entity_type]->setFormClass('edit', $form_class);
     }

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -129,6 +129,7 @@ function farm_ui_theme_farm_ui_theme_field_group_items(string $entity_type, stri
       break;
 
     case 'taxonomy_term':
+      $fields['external_uri'] = 'reference';
       break;
 
     default:

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element\RenderCallbackInterface;
@@ -187,8 +188,13 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
         $revision_items[] = $this->t('Created @timestamp by @author', ['@timestamp' => $date, '@author' => $author]);
       }
 
-      // Only add changed metadata if available.
-      if ($this->entity instanceof EntityChangedInterface) {
+      // Only add revision information if available.
+      if ($this->entity instanceof RevisionLogInterface && $user = $this->entity->getRevisionUser()) {
+        $changed = $this->dateFormatter->format($this->entity->getRevisionCreationTime(), 'short', '', $this->currentUser()->getTimeZone(), '');
+        $revision_items[] = $this->t('Last saved: @timestamp by @author', ['@timestamp' => $changed, '@author' => $user->label()]);
+      }
+      // Else only add changed metadata if available.
+      elseif ($this->entity instanceof EntityChangedInterface) {
         $changed = $this->dateFormatter->format($this->entity->getChangedTime(), 'short', '', $this->currentUser()->getTimeZone(), '');
         $revision_items[] = $this->t('Last saved: @timestamp', ['@timestamp' => $changed]);
       }

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -160,7 +160,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
           '#group' => $tab_group,
           '#optional' => TRUE,
           '#weight' => $tab_info['weight'],
-          '#open' => TRUE,
+          '#open' => $tab_id === 'default_field_group' || $tab_group === 'advanced',
         ];
       }
 

--- a/modules/core/ui/theme/src/Form/TaxonomyTermForm.php
+++ b/modules/core/ui/theme/src/Form/TaxonomyTermForm.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\farm_ui_theme\Form;
+
+/**
+ * Taxonomy term form for gin content form.
+ */
+class TaxonomyTermForm extends GinContentFormBase {
+
+}

--- a/modules/core/ui/theme/src/Form/TaxonomyTermForm.php
+++ b/modules/core/ui/theme/src/Form/TaxonomyTermForm.php
@@ -2,9 +2,168 @@
 
 namespace Drupal\farm_ui_theme\Form;
 
+use Drupal\Core\Entity\EntityConstraintViolationListInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\taxonomy\TermInterface;
+
 /**
  * Taxonomy term form for gin content form.
  */
 class TaxonomyTermForm extends GinContentFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getFieldGroups() {
+    return parent::getFieldGroups() + [
+      'relations' => [
+        'location' => 'sidebar',
+        'title' => $this->t('Relations'),
+        'weight' => 50,
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    // Term relations logic copied from Drupal\taxonomy\TermForm::form.
+    $term = $this->entity;
+    $vocab_storage = $this->entityTypeManager->getStorage('taxonomy_vocabulary');
+    /** @var \Drupal\taxonomy\TermStorageInterface $taxonomy_storage */
+    $taxonomy_storage = $this->entityTypeManager->getStorage('taxonomy_term');
+    $vocabulary = $vocab_storage->load($term->bundle());
+
+    $parent = $this->getParentIds($term);
+    $form_state->set(['taxonomy', 'parent'], $parent);
+    $form_state->set(['taxonomy', 'vocabulary'], $vocabulary);
+
+    // \Drupal\taxonomy\TermStorageInterface::loadTree() and
+    // \Drupal\taxonomy\TermStorageInterface::loadParents() may contain large
+    // numbers of items so we check for taxonomy.settings:override_selector
+    // before loading the full vocabulary. Contrib modules can then intercept
+    // before hook_form_alter to provide scalable alternatives.
+    if (!$this->config('taxonomy.settings')->get('override_selector')) {
+      $exclude = [];
+      if (!$term->isNew()) {
+        $children = $taxonomy_storage->loadTree($vocabulary->id(), $term->id());
+
+        // A term can't be the child of itself, nor of its children.
+        foreach ($children as $child) {
+          $exclude[] = $child->tid;
+        }
+        $exclude[] = $term->id();
+      }
+
+      $tree = $taxonomy_storage->loadTree($vocabulary->id());
+      $options = ['<' . $this->t('root') . '>'];
+      if (empty($parent)) {
+        $parent = [0];
+      }
+
+      foreach ($tree as $item) {
+        if (!in_array($item->tid, $exclude)) {
+          $options[$item->tid] = str_repeat('-', $item->depth) . $item->name;
+        }
+      }
+    }
+    else {
+      $options = ['<' . $this->t('root') . '>'];
+      $parent = [0];
+    }
+
+    if ($this->getRequest()->query->has('parent')) {
+      $parent = array_values(array_intersect(
+        array_keys($options),
+        (array) $this->getRequest()->query->all()['parent'],
+      ));
+    }
+
+    // The select field doesn't support #group so needs to be under the
+    // relations_field_group form structure.
+    $form['relations_field_group']['parent'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Parent terms'),
+      '#options' => $options,
+      '#default_value' => $parent,
+      '#multiple' => TRUE,
+      '#group' => 'relations_field_group',
+    ];
+
+    // Textfields support #group so use that.
+    $form['weight'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Weight'),
+      '#size' => 6,
+      '#default_value' => $term->getWeight(),
+      '#description' => $this->t('Terms are displayed in ascending order by weight.'),
+      '#required' => TRUE,
+      '#group' => 'relations_field_group',
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildEntity(array $form, FormStateInterface $form_state) {
+    $term = parent::buildEntity($form, $form_state);
+
+    // Prevent leading and trailing spaces in term names.
+    $term->setName(trim($term->getName()));
+
+    // Assign parents with proper delta values starting from 0.
+    $term->parent = array_values($form_state->getValue('parent'));
+
+    return $term;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditedFieldNames(FormStateInterface $form_state) {
+    return array_merge(['parent', 'weight'], parent::getEditedFieldNames($form_state));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function flagViolations(EntityConstraintViolationListInterface $violations, array $form, FormStateInterface $form_state) {
+    // Manually flag violations of fields not handled by the form display. This
+    // is necessary as entity form displays only flag violations for fields
+    // contained in the display.
+    // @see ::form()
+    foreach ($violations->getByField('parent') as $violation) {
+      $form_state->setErrorByName('parent', $violation->getMessage());
+    }
+    foreach ($violations->getByField('weight') as $violation) {
+      $form_state->setErrorByName('weight', $violation->getMessage());
+    }
+
+    parent::flagViolations($violations, $form, $form_state);
+  }
+
+  /**
+   * Returns term parent IDs, including the root.
+   *
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   The taxonomy term entity.
+   *
+   * @return array
+   *   A list if parent term IDs.
+   */
+  protected function getParentIds(TermInterface $term): array {
+    $parent = [];
+    // Get the parent directly from the term as
+    // \Drupal\taxonomy\TermStorageInterface::loadParents() excludes the root.
+    foreach ($term->get('parent') as $item) {
+      $parent[] = (int) $item->target_id;
+    }
+    return $parent;
+  }
 
 }

--- a/modules/core/ui/theme/src/Form/TaxonomyTermForm.php
+++ b/modules/core/ui/theme/src/Form/TaxonomyTermForm.php
@@ -16,6 +16,11 @@ class TaxonomyTermForm extends GinContentFormBase {
    */
   protected function getFieldGroups() {
     return parent::getFieldGroups() + [
+      'reference' => [
+        'location' => 'main',
+        'title' => $this->t('Reference'),
+        'weight' => 50,
+      ],
       'relations' => [
         'location' => 'sidebar',
         'title' => $this->t('Relations'),


### PR DESCRIPTION
With upcoming changes/additions to taxonomy terms #807 #808 it seems it may be time we use the content form for taxonomy terms so keep the editing forms simple and also standardize with our other editing forms. This PR will add content forms for taxonomy terms and make a few other general improvements to content forms.

Adding this for taxonomy terms is not quite as straight forward though... will comment with some questions for us to figure out. Here is a screenshot of the basic changes this makes:

![Screenshot from 2024-03-22 18-27-05](https://github.com/farmOS/farmOS/assets/3116995/a0e88975-8a15-4bf1-a9a8-f43e158c4d08)