### PR TITLE
Add geometry/location fields to CSV importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add bulk delete action to farm_log_quantity View #860](https://github.com/farmOS/farmOS/pull/860)
 - [Add an "Export Quantity CSV" bulk action to Log Views](https://github.com/farmOS/farmOS/pull/861)
 - [Allow modules to alter dashboard panes #868](https://github.com/farmOS/farmOS/pull/868)
+- [Add geometry/location fields to CSV importers #815](https://github.com/farmOS/farmOS/pull/815)
 
 ### Changed
 

--- a/modules/core/import/modules/csv/migrations/csv_asset.yml
+++ b/modules/core/import/modules/csv/migrations/csv_asset.yml
@@ -25,6 +25,17 @@ process:
       delimiter: ,
     - plugin: asset_lookup
 
+  # Is location/fixed booleans.
+  is_location:
+    plugin: boolean
+    source: is location
+  is_fixed:
+    plugin: boolean
+    source: is fixed
+
+  # Intrinsic geometry.
+  intrinsic_geometry: intrinsic geometry
+
   # Asset status.
   status:
     - plugin: get
@@ -42,6 +53,12 @@ third_party_settings:
         description: Parents of the asset. Accepts asset names, ID tags, UUIDs, and IDs. Multiple assets can be separated by commas with the whole cell wrapped in quotes.
       - name: notes
         description: Notes about the asset.
+      - name: is location
+        description: Whether this asset is a location. Accepts most boolean values. Leave this blank to use the default for this asset type.
+      - name: is fixed
+        description: Whether this asset has a fixed location. Accepts most boolean values. Leave this blank to use the default for this asset type.
+      - name: intrinsic geometry
+        description: The intrinsic geometry of the asset in WKT format. This is only used if the asset has a fixed location.
       - name: status
         description: 'Status of the asset. Allowed values: active, archived. Defaults to active.'
 

--- a/modules/core/import/modules/csv/migrations/csv_asset.yml
+++ b/modules/core/import/modules/csv/migrations/csv_asset.yml
@@ -18,9 +18,11 @@ process:
 
   # Parent asset reference lookup.
   parent:
+    - plugin: skip_on_empty
+      method: process
+      source: parents
     - plugin: explode
       delimiter: ,
-      source: parents
     - plugin: asset_lookup
 
   # Asset status.

--- a/modules/core/import/modules/csv/migrations/csv_log.yml
+++ b/modules/core/import/modules/csv/migrations/csv_log.yml
@@ -84,6 +84,14 @@ process:
     - plugin: term_lookup
       bundle: log_category
 
+  # Geometry.
+  geometry: geometry
+
+  # Is movement boolean.
+  is_movement:
+    plugin: boolean
+    source: is movement
+
   # Log status.
   status:
     - plugin: get
@@ -115,6 +123,10 @@ third_party_settings:
         description: Notes about the log.
       - name: categories
         description: Log category taxonomy terms. Multiple terms can be separated by commas with the whole cell wrapped in quotes.
+      - name: geometry
+        description: The geometry of the log in WKT format.
+      - name: is movement
+        description: Whether this log represents an asset movement. Accepts most boolean values. Leave this blank to use the default for this log type.
       - name: status
         description: 'Status of the log. Allowed values: pending, done. Defaults to done.'
 

--- a/modules/core/import/modules/csv/migrations/csv_log.yml
+++ b/modules/core/import/modules/csv/migrations/csv_log.yml
@@ -18,16 +18,20 @@ process:
 
   # Asset reference lookup.
   asset:
+    - plugin: skip_on_empty
+      method: process
+      source: assets
     - plugin: explode
       delimiter: ,
-      source: assets
     - plugin: asset_lookup
 
   # Location asset reference lookup.
   location:
+    - plugin: skip_on_empty
+      method: process
+      source: locations
     - plugin: explode
       delimiter: ,
-      source: locations
     - plugin: asset_lookup
 
   # Create a quantity, if necessary.
@@ -72,9 +76,11 @@ process:
 
   # Log category.
   category:
+    - plugin: skip_on_empty
+      method: process
+      source: categories
     - plugin: explode
       delimiter: ,
-      source: categories
     - plugin: term_lookup
       bundle: log_category
 

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/land.csv
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/land.csv
@@ -1,0 +1,3 @@
+name,land type,is location,is fixed,intrinsic geometry,status
+Field A,field,true,true,"POINT(1 2)",active
+Field B,field,false,false,,active

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/movements.csv
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/movements.csv
@@ -1,0 +1,2 @@
+timestamp,name,assets,locations,geometry,is movement,status
+2024-09-10,Move Garlic to Field B,Garlic,Field B,"POINT(1 2)",true,done

--- a/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
@@ -19,7 +19,12 @@ class AssetCsvImportTest extends CsvImportTestBase {
     'farm_entity',
     'farm_equipment',
     'farm_id_tag',
+    'farm_land',
+    'farm_land_types',
+    'farm_location',
+    'farm_map',
     'farm_parent',
+    'geofield',
   ];
 
   /**
@@ -27,7 +32,12 @@ class AssetCsvImportTest extends CsvImportTestBase {
    */
   public function setUp(): void {
     parent::setUp();
-    $this->installConfig(['farm_id_tag', 'farm_equipment']);
+    $this->installConfig([
+      'farm_id_tag',
+      'farm_equipment',
+      'farm_land',
+      'farm_land_types',
+    ]);
 
     // Add an asset to test parent relationship.
     $asset = Asset::create(['name' => 'Test parent', 'type' => 'equipment', 'status' => 'active']);
@@ -115,6 +125,27 @@ class AssetCsvImportTest extends CsvImportTestBase {
       $this->assertEquals($expected_values[$id]['status'], $asset->get('status')->value);
       $this->assertEquals('Imported via CSV.', $asset->getRevisionLogMessage());
     }
+
+    // Run the land CSV import.
+    $this->importCsv('land.csv', 'csv_asset:land');
+
+    // Load the assets that were created and confirm they have expected values.
+    $asset = Asset::load(5);
+    $this->assertEquals('land', $asset->bundle());
+    $this->assertEquals('Field A', $asset->label());
+    $this->assertEquals('field', $asset->get('land_type')->value);
+    $this->assertEquals('POINT(1 2)', $asset->get('intrinsic_geometry')->value);
+    $this->assertEquals(1, $asset->get('is_location')->value);
+    $this->assertEquals(1, $asset->get('is_fixed')->value);
+    $this->assertEquals('active', $asset->get('status')->value);
+    $asset = Asset::load(6);
+    $this->assertEquals('land', $asset->bundle());
+    $this->assertEquals('Field B', $asset->label());
+    $this->assertEquals('field', $asset->get('land_type')->value);
+    $this->assertEquals('', $asset->get('intrinsic_geometry')->value);
+    $this->assertEquals(0, $asset->get('is_location')->value);
+    $this->assertEquals(0, $asset->get('is_fixed')->value);
+    $this->assertEquals('active', $asset->get('status')->value);
   }
 
 }

--- a/modules/core/migrate/src/Plugin/migrate/process/Boolean.php
+++ b/modules/core/migrate/src/Plugin/migrate/process/Boolean.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\farm_migrate\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+
+/**
+ * This plugin converts values to a boolean.
+ *
+ * @codingStandardsIgnoreStart
+ *
+ * Example usage:
+ * @code
+ * destination:
+ *   plugin: 'entity:log'
+ * process:
+ *   is_movement:
+ *     plugin: boolean
+ *     source: is_movement
+ * @endcode
+
+ * @codingStandardsIgnoreEnd
+ *
+ * @MigrateProcessPlugin(
+ *   id = "boolean"
+ * )
+ */
+class Boolean extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+
+    // If the value is NULL or an empty string, return NULL so that the field's
+    // default value will be used.
+    if (is_null($value) || trim($value) === '') {
+      return NULL;
+    }
+
+    // Use PHP's filter_var() with FILTER_VALIDATE_BOOLEAN constant.
+    return filter_var($value, FILTER_VALIDATE_BOOLEAN);
+  }
+
+}


### PR DESCRIPTION
The goal of this is to add support for the following fields in CSV importers:

- On Logs:
  - `geometry`
  - `is_movement`
- On Assets:
  - `intrinsic_geometry`
  - `is_location`
  - `is_fixed`

We talked about this in some recent dev calls and I started sketching it up, so I wanted to get a draft PR opened up that we can work collaboratively on.

I have not tested any of this code yet, but I think it's functional.

Remaining todos:

- [x] Automated tests
- [x] Allow `assets`, `locations`, `categories`, and `parents` columns to be omitted from CSVs.