### PR TITLE
Plan record views integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add file and image base fields to all taxonomy terms #807](https://github.com/farmOS/farmOS/pull/807)
 - [Issue #3390486: Add an Ontology URI field to all taxonomy terms](https://www.drupal.org/project/farm/issues/3390486)
 - [Add "Days of harvest" field to Plant type terms #794](https://github.com/farmOS/farmOS/pull/794)
+- [Plan record views integration #818](https://github.com/farmOS/farmOS/pull/818)
 
 ### Changed
 

--- a/modules/core/entity/modules/views/farm_entity_views.module
+++ b/modules/core/entity/modules/views/farm_entity_views.module
@@ -44,7 +44,7 @@ function farm_entity_views_entity_type_build(array &$entity_types) {
   /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
 
   // Set the views data handler class to FarmEntityViewsData.
-  foreach (['asset', 'log', 'plan', 'quantity'] as $entity_type) {
+  foreach (['asset', 'log', 'plan', 'plan_record', 'quantity'] as $entity_type) {
     if (!empty($entity_types[$entity_type])) {
 
       // Use the correct class for each entity type.

--- a/modules/core/plan/src/Entity/PlanRecord.php
+++ b/modules/core/plan/src/Entity/PlanRecord.php
@@ -33,7 +33,6 @@ use Drupal\Core\Field\BaseFieldDefinition;
  *     },
  *   },
  *   base_table = "plan_record",
- *   data_table = "plan_record_data",
  *   entity_keys = {
  *     "id" = "id",
  *     "uuid" = "uuid",


### PR DESCRIPTION
This PR makes two changes so that `plan_record` entities can be used in views.

I was surprised that the `plan_record_data` table actually isn't even being created right now... I know I suggested we add that here: https://github.com/farmOS/farmOS/pull/781#pullrequestreview-1850491589

It seems this table might only be created if you have a `translatable` entity? Anyways, I think we should remove the `data_table` attribute from the entity definition. The presence of the attribute without existence of the table breaks the core `EntityViewsData` integration.