### PR TITLE
Do not trim whitespace from quantity field item content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix Client error when passing asset parameter to forms #814](https://github.com/farmOS/farmOS/pull/814)
 - [Update patch for Issue #3397275 to fix boolean field JSON Schema #819](https://github.com/farmOS/farmOS/pull/819)
+- [Do not trim whitespace from quantity field item content #820](https://github.com/farmOS/farmOS/pull/820)
 
 ## [3.1.2] 2024-02-26
 

--- a/modules/core/quantity/templates/field--quantity--field.html.twig
+++ b/modules/core/quantity/templates/field--quantity--field.html.twig
@@ -38,7 +38,7 @@
     <span><strong>{{ label }}</strong></span>
   {% endif %}
 
-  {%- for item in items -%}
+  {% for item in items %}
     {{ item.content }}
-  {%- endfor -%}
+  {% endfor %}
 </span>


### PR DESCRIPTION
This fixes #817.

I'm not sure if it's the "best" solution, but it was very simple, so I'm throwing it at the wall to see if it sticks. :-)

Curious your thoughts @paul121 since you were the original author of these lines. Were they copied from a core template?