### PR TITLE
Add min/max options to decimal fields in farm_field.factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Issue #3390486: Add an Ontology URI field to all taxonomy terms](https://www.drupal.org/project/farm/issues/3390486)
 - [Add "Days of harvest" field to Plant type terms #794](https://github.com/farmOS/farmOS/pull/794)
 - [Plan record views integration #818](https://github.com/farmOS/farmOS/pull/818)
+- [Add min/max options to decimal fields in farm_field.factory #822](https://github.com/farmOS/farmOS/pull/822)
 
 ### Changed
 

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -125,6 +125,8 @@ Both methods expect an array of field definition options. These include:
           decimal point). Defaults to 10.
         - `scale` (optional) - Number digits to the right of the decimal point.
           Defaults to 2.
+        - `min` (optional) - The minimum value.
+        - `max` (optional) - The maximum value.
     - `email` - Email field.
     - `entity_reference` - Reference other entities. Additional options:
         - `target_type` (required) - The entity type to reference (eg: `asset`,

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -264,6 +264,14 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
       $field->setSetting('scale', $options['scale']);
     }
 
+    // Set the min/max constraints, if specified.
+    if (isset($options['min'])) {
+      $field->setSetting('min', $options['min']);
+    }
+    if (isset($options['max'])) {
+      $field->setSetting('max', $options['max']);
+    }
+
     // Build form and view display settings.
     $field->setDisplayOptions('form', [
       'type' => 'number',


### PR DESCRIPTION
This adds `min` and `max` options to `decimal` fields in `farm_field.factory`. We did the same thing for `integer` fields in #768 (and in hindsight probably should have done this at the same time).