### PR TITLE
Override the birth log asset label and description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Move transplant_days field to farm_transplant module #795](https://github.com/farmOS/farmOS/pull/795)
 - [Use content form for taxonomy terms #810](https://github.com/farmOS/farmOS/pull/810)
 - [Override the lab_test log timestamp label and description #774](https://github.com/farmOS/farmOS/pull/774)
+- [Override the birth log asset label and description #824](https://github.com/farmOS/farmOS/pull/824)
 
 ### Fixed
 

--- a/modules/log/birth/config/install/core.base_field_override.log.birth.asset.yml
+++ b/modules/log/birth/config/install/core.base_field_override.log.birth.asset.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - log.type.birth
+id: log.birth.asset
+field_name: asset
+entity_type: log
+bundle: birth
+label: Children
+description: 'Which child assets were born?'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: views
+  handler_settings:
+    view:
+      view_name: farm_asset_reference
+      display_name: entity_reference
+field_type: entity_reference

--- a/modules/log/birth/farm_birth.module
+++ b/modules/log/birth/farm_birth.module
@@ -8,38 +8,8 @@
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\Entity\BaseFieldOverride;
 use Drupal\Core\Url;
-
-/**
- * Implements hook_form_BASE_FORM_ID_alter().
- */
-function farm_birth_form_log_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-
-  // Only proceed if the mother and asset fields exist.
-  if (empty($form['mother']) || empty($form['asset'])) {
-    return;
-  }
-
-  // Rename the asset field to Children.
-  $form['asset']['widget']['#title'] = t('Children');
-}
-
-/**
- * Implements hook_ENTITY_TYPE_view_alter().
- */
-function farm_birth_log_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
-
-  // Only alter birth logs.
-  if ($entity->bundle() != 'birth') {
-    return;
-  }
-
-  // Rename the asset field to Children.
-  if (!empty($build['asset'])) {
-    $build['asset']['#title'] = t('Children');
-  }
-}
 
 /**
  * Implements hook_ENTITY_TYPE_view_alter().
@@ -74,13 +44,21 @@ function farm_birth_asset_view_alter(array &$build, EntityInterface $entity, Ent
 }
 
 /**
- * Implements hook_entity_base_field_info_alter().
+ * Implements hook_entity_bundle_field_info().
  */
-function farm_birth_entity_base_field_info_alter(&$fields, EntityTypeInterface $entity_type) {
-  /** @var \Drupal\field\Entity\FieldConfig[] $fields */
+function farm_birth_entity_bundle_field_info(EntityTypeInterface $entity_type, $bundle, array $base_field_definitions) {
+  $fields = [];
 
-  // Validate that only one birth log references an asset.
-  if ($entity_type->id() == 'log' && !empty($fields['asset'])) {
+  // Add the UniqueBirthLog validation constraint to the asset field of birth
+  // logs. We need to do this via hook_entity_bundle_field_info() instead of
+  // hook_entity_field_info_alter() because this module also provides a
+  // BaseFieldOverride for the asset field, and there is a Drupal core issue
+  // that prevents these from working together normally.
+  // @see https://www.drupal.org/project/drupal/issues/3193351
+  if ($entity_type->id() == 'log' && $bundle == 'birth') {
+    $fields['asset'] = BaseFieldOverride::loadByName($entity_type->id(), $bundle, 'asset') ?: clone $base_field_definitions['asset'];
     $fields['asset']->addConstraint('UniqueBirthLog');
   }
+
+  return $fields;
 }

--- a/modules/log/birth/farm_birth.post_update.php
+++ b/modules/log/birth/farm_birth.post_update.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the farm_birth module.
+ */
+
+/**
+ * Override the birth log asset label and description.
+ */
+function farm_birth_post_update_override_birth_asset_label_description(&$sandbox) {
+
+  // Override the asset field label and description on birth logs to make it
+  // clear that it should be used to reference the child assets that were born.
+  // This also checks to make sure they haven't been overridden already first.
+  /** @var \Drupal\Core\Field\Entity\BaseFieldOverride $config */
+  $config = \Drupal::service('entity_field.manager')->getBaseFieldDefinitions('log')['asset']->getConfig('birth');
+  if ($config->isNew()) {
+    $config->set('label', 'Children');
+    $config->set('description', 'Which child assets were born?');
+    $config->save();
+  }
+}


### PR DESCRIPTION
This overrides the "Asset" field on Birth logs to change the label and description as follows.

- Label: Children
- Description: Which child assets were born?

See @paul121's comment here for the inspiration: https://github.com/farmOS/farmOS/pull/774#issuecomment-1894813820

This is nearly identical in implementation to #774 

I'm open to suggestions on the label/description. I thought "Children" would be better than "Child" in this case, even though it's inconsistent with our normally singular labels. I don't feel too strongly though, so if others prefer "Child" I can change it to that.