### PR TITLE
Add a Notes filter to the logs views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Issue #3352183: Comments on farmOS records](https://www.drupal.org/project/farm/issues/3352183)
+- [Add a Notes filter to the logs views #825](https://github.com/farmOS/farmOS/pull/825)
 
 ### Changed
 

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -835,6 +835,51 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        notes__value:
+          id: notes__value
+          table: log_field_data
+          field: notes__value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: log
+          entity_field: notes
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: notes__value_op
+            label: Notes
+            description: ''
+            use_operator: false
+            operator: notes__value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: notes__value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         type:
           id: type
           table: log_field_data


### PR DESCRIPTION
We created this on the April 10th farmOS Monthly Call. It adds a "Notes" filter to the Logs Views.