### PR TITLE
Patch JSON:API Schema to fix Issue #3390505: Error: uri is not a valid type for a JSON document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Patch JSON:API Schema to fix [Issue #3390505: Error: uri is not a valid type for a JSON document](https://www.drupal.org/project/jsonapi_schema/issues/3390505)
+
 ## [3.2.0] 2024-04-10
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,8 @@
                 "Issue #3246251: Change format utc-millisec to date-time": "https://www.drupal.org/files/issues/2021-10-27/3246251-2.patch",
                 "Issue #3189930: TypeError: Argument 1 passed to Drupal\\jsonapi_schema\\Controller\\JsonApiSchemaController::Drupal\\jsonapi_schema\\Controller\\{closure}() must be an instance of Drupal\\jsonapi\\ResourceType\\ResourceType": "https://www.drupal.org/files/issues/2020-12-26/3189930-2.patch",
                 "Issue #3322227: Document schema title wrong for multiple resource types": "https://www.drupal.org/files/issues/2022-11-17/3322227-0.patch",
-                "Issue #3397275: Use OptionsProviderInterface::getPossibleOptions() for allowed field values (anyOf / oneOf)": "https://www.drupal.org/files/issues/2024-03-29/3397275-5.patch"
+                "Issue #3397275: Use OptionsProviderInterface::getPossibleOptions() for allowed field values (anyOf / oneOf)": "https://www.drupal.org/files/issues/2024-03-29/3397275-5.patch",
+                "Issue #3390505: Error: uri is not a valid type for a JSON document": "https://www.drupal.org/files/issues/2024-04-11/3390505-3.patch"
             },
             "drupal/simple_oauth": {
                 "Issue #3322325: Cannot authorize clients with empty string set as secret": "https://www.drupal.org/files/issues/2023-10-31/3322325-8.patch",


### PR DESCRIPTION
After releasing 3.2.0 I discovered an issue that was introduced by #808. If you try to view the schema for taxonomy terms it causes an error in the JSON:API Schema module: https://www.drupal.org/project/jsonapi_schema/issues/3390505

Tl;dr: the JSON:API Schema module doesn't support fields of type `uri`. Our new `external_uri` field on all taxonomy terms breaks our JSON Schema endpoints for terms.

I originally discovered this issue back in September, when I tried to view the schema of `file` entities (which also have a URI field), but fixing it wasn't a high priority. Now that it's happening on terms we need to fix it.

I submitted a merge request to the upstream module. This PR simply applies the patch to `jsonapi_schema` in farmOS.