### PR TITLE
Fix FieldException: Attempted to create a configurable field of non-configurable field storage image during update.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Patch JSON:API Schema to fix [Issue #3390505: Error: uri is not a valid type for a JSON document](https://www.drupal.org/project/jsonapi_schema/issues/3390505)
+- [Fix FieldException: Attempted to create a configurable field of non-configurable field storage image during update.php #828](https://github.com/farmOS/farmOS/pull/828)
 
 ## [3.2.0] 2024-04-10
 

--- a/modules/core/entity/modules/fields/farm_entity_fields.install
+++ b/modules/core/entity/modules/fields/farm_entity_fields.install
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the farm_entity_fields module.
+ */
+
+use Drupal\Core\Database\DatabaseExceptionWrapper;
+
+/**
+ * Install taxonomy term file and image fields.
+ */
+function farm_entity_fields_update_100300(&$sandbox) {
+  $entity_type = 'taxonomy_term';
+  $module_name = 'farm_entity_fields';
+
+  // Ensure that this has not run already.
+  // farmOS 3.2.0 was released with this code in a hook_post_update_NAME()
+  // hook. It was discovered that this does not work when run in the browser
+  // via update.php because Drupal core calls drupal_flush_all_caches() in
+  // between hook_update_N() and hook_post_update_NAME() hooks, which does not
+  // happen when updates are run via drush. This causes an error because the
+  // image field changes from a config field to a base field. So this code was
+  // moved to a hook_update_N() hook. This means there's a risk of it running
+  // twice, if a site was updated to 3.2.0 and then to 3.2.1. So we prevent that
+  // here by checking for the existence of the file base field database table.
+  try {
+    \Drupal::database()->query('SELECT COUNT(*) FROM {taxonomy_term__file}');
+    return;
+  }
+  catch (DatabaseExceptionWrapper $e) {
+  }
+
+  // Install file field.
+  $field_info = [
+    'type' => 'file',
+    'label' => t('Files'),
+    'file_directory' => 'farm/term/[date:custom:Y]-[date:custom:m]',
+    'multiple' => TRUE,
+    'weight' => [
+      'form' => 90,
+      'view' => 90,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->baseFieldDefinition($field_info);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('file', $entity_type, $module_name, $field_definition);
+
+  // Install image field.
+  $field_info = [
+    'type' => 'image',
+    'label' => t('Images'),
+    'file_directory' => 'farm/term/[date:custom:Y]-[date:custom:m]',
+    'multiple' => TRUE,
+    'weight' => [
+      'form' => 89,
+      'view' => 89,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->baseFieldDefinition($field_info);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('image', $entity_type, $module_name, $field_definition);
+
+  // If the farm_plant_type module is installed, remove old image field config.
+  // This module previously provided an image field for plant_type taxonomy
+  // terms, so we need to clean up the configuration entities it created.
+  if (\Drupal::moduleHandler()->moduleExists('farm_plant_type')) {
+    foreach (['field.field.taxonomy_term.plant_type.image', 'field.storage.taxonomy_term.image'] as $config) {
+      \Drupal::configFactory()->getEditable($config)->delete();
+    }
+  }
+}

--- a/modules/core/entity/modules/fields/farm_entity_fields.post_update.php
+++ b/modules/core/entity/modules/fields/farm_entity_fields.post_update.php
@@ -15,51 +15,6 @@ function farm_entity_fields_post_update_enable_farm_parent(&$sandbox = NULL) {
 }
 
 /**
- * Install taxonomy term file and image fields.
- */
-function farm_entity_fields_post_update_install_term_file_fields(&$sandbox) {
-  $entity_type = 'taxonomy_term';
-  $module_name = 'farm_entity_fields';
-
-  // Install file field.
-  $field_info = [
-    'type' => 'file',
-    'label' => t('Files'),
-    'file_directory' => 'farm/term/[date:custom:Y]-[date:custom:m]',
-    'multiple' => TRUE,
-    'weight' => [
-      'form' => 90,
-      'view' => 90,
-    ],
-  ];
-  $field_definition = \Drupal::service('farm_field.factory')->baseFieldDefinition($field_info);
-  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('file', $entity_type, $module_name, $field_definition);
-
-  // Install image field.
-  $field_info = [
-    'type' => 'image',
-    'label' => t('Images'),
-    'file_directory' => 'farm/term/[date:custom:Y]-[date:custom:m]',
-    'multiple' => TRUE,
-    'weight' => [
-      'form' => 89,
-      'view' => 89,
-    ],
-  ];
-  $field_definition = \Drupal::service('farm_field.factory')->baseFieldDefinition($field_info);
-  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('image', $entity_type, $module_name, $field_definition);
-
-  // If the farm_plant_type module is installed, remove old image field config.
-  // This module previously provided an image field for plant_type taxonomy
-  // terms, so we need to clean up the configuration entities it created.
-  if (\Drupal::moduleHandler()->moduleExists('farm_plant_type')) {
-    foreach (['field.field.taxonomy_term.plant_type.image', 'field.storage.taxonomy_term.image'] as $config) {
-      \Drupal::configFactory()->getEditable($config)->delete();
-    }
-  }
-}
-
-/**
  * Install taxonomy term external URI field.
  */
 function farm_entity_fields_post_update_add_term_external_uri(&$sandbox) {


### PR DESCRIPTION
See https://github.com/farmOS/farmOS/issues/826

I tested the following scenarios, all updating from `3.1.2` with a `plant_type` term that has a photo uploaded to the `image` field:

- Update from `3.1.2` to `3.x-fix-3.2.0-update` via `update.php` (to ensure `update.php` works).
- Update from `3.1.2` to `3.x-fix-3.2.0-update` via `drush updb` (to ensure `drush updb` works).
- Update from `3.1.2` to `3.2.0` to `3.x-fix-3.2.0-update` via `drush updb` (to ensure the update doesn't run twice if someone updates to both `3.2.0` and the upcoming `3.2.1`).

All work smoothly.