### PR TITLE
Remove data_table from existing plan_record entity type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Remove data_table from existing plan_record entity type definition #829](https://github.com/farmOS/farmOS/pull/829)
+
 ## [3.2.1] 2024-04-12
 
 ### Fixed

--- a/modules/core/plan/plan.post_update.php
+++ b/modules/core/plan/plan.post_update.php
@@ -16,3 +16,22 @@ function plan_post_update_install_plan_record(&$sandbox) {
     \Drupal::entityTypeManager()->getDefinition('plan_record')
   );
 }
+
+/**
+ * Remove the plan_record data_table attribute.
+ */
+function plan_post_update_remove_plan_record_data_table(&$sandbox) {
+
+  // Load existing plan_record entity type and remove the data_table attribute.
+  $update_manager = \Drupal::entityDefinitionUpdateManager();
+  $plan_record = $update_manager->getEntityType('plan_record');
+  $plan_record->set('data_table', NULL);
+
+  // Get the existing field storage definitions. This is a required parameter
+  // for EntityDefinitionUpdateManagerInterface::updateFieldableEntityType.
+  // We cannot use EntityDefinitionUpdateManagerInterface::updateEntityType.
+  $field_storage_definitions = \Drupal::service('entity.last_installed_schema.repository')->getLastInstalledFieldStorageDefinitions('plan_record');
+
+  // Update the entity type.
+  $update_manager->updateFieldableEntityType($plan_record, $field_storage_definitions, $sandbox);
+}


### PR DESCRIPTION
This fixes a bug introduced with #818 . We need to remove `data_table` from the existing `plan_record` entity type definition.

![Screenshot from 2024-04-12 12-02-37](https://github.com/farmOS/farmOS/assets/3116995/8a1481b5-9858-4347-bb29-bbd2fd60701a)
