### PR TITLE
Entity layout and minor UI changes

### DIFF
--- a/modules/core/comment/farm_comment.module
+++ b/modules/core/comment/farm_comment.module
@@ -56,7 +56,7 @@ function farm_comment_base_field_definition(string $entity_type) {
   // Build form display settings.
   $field->setDisplayOptions('form', [
     'type' => 'comment_default',
-    'weight' => 1000,
+    'weight' => 450,
   ]);
 
   // Build view display settings.

--- a/modules/core/location/farm_location.base_fields.inc
+++ b/modules/core/location/farm_location.base_fields.inc
@@ -42,8 +42,14 @@ function farm_location_asset_base_fields() {
     'label' => t('Current geometry'),
     'computed' => AssetGeometryItemList::class,
     'hidden' => 'form',
-    'weight' => [
-      'view' => 95,
+    'view_display_options' => [
+      'label' => 'hidden',
+      'type' => 'farm_map_geofield',
+      'settings' => [
+        'output_format' => 'wkt',
+        'output_escape' => TRUE,
+      ],
+      'weight' => 95,
     ],
   ];
   $fields['geometry'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
@@ -154,6 +160,15 @@ function farm_location_log_base_fields() {
       'view' => 95,
     ],
     'populate_file_field' => 'file',
+    'view_display_options' => [
+      'label' => 'hidden',
+      'type' => 'farm_map_geofield',
+      'settings' => [
+        'output_format' => 'wkt',
+        'output_escape' => TRUE,
+      ],
+      'weight' => 95,
+    ],
   ];
   $fields['geometry'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
 

--- a/modules/core/ui/theme/css/comment.css
+++ b/modules/core/ui/theme/css/comment.css
@@ -6,12 +6,12 @@ article.comment {
   background: var(--gin-bg-layer);
   border: 1px solid var(--gin-border-color-layer);
   border-radius: var(--gin-border-m);
-  padding: var(--space-m);
-  margin-top: var(--space-m);
-  margin-bottom: var(--space-m);
+  padding: var(--gin-spacing-m);
+  margin-top: var(--gin-spacing-m);
+  margin-bottom: var(--gin-spacing-m);
 }
 article.comment p {
-  margin: 0 0 var(--space-xs);
+  margin: 0 0 var(--gin-spacing-xs);
 }
 article.comment p.comment__submitted {
   font-size: var(--gin-font-size-s);
@@ -32,8 +32,8 @@ section.comment-wrapper h2 {
 
 /* Decrease size of comments when rendered on entity page. */
 section.comment-wrapper article.comment {
-  padding: 0 0 0 var(--space-s);
-  margin: 0 0 var(--space-s);
+  padding: 0 0 0 var(--gin-spacing-s);
+  margin: 0 0 var(--gin-spacing-s);
   border: none;
   border-radius: 0;
   border-left: 5px solid var(--gin-border-color-secondary);

--- a/modules/core/ui/theme/css/comment.css
+++ b/modules/core/ui/theme/css/comment.css
@@ -24,10 +24,13 @@ article.comment ul.links.inline li:first-child {
   padding: 0;
 }
 
-/* Decrease size of comments when rendered on entity page. */
-section.comment-wrapper {
-  padding: 0 var(--space-m);
+/* Decrease font-size of comment headers. */
+section.comment-wrapper h2 {
+  font-size: var(--gin-font-size-h3);
+  margin-top: 0;
 }
+
+/* Decrease size of comments when rendered on entity page. */
 section.comment-wrapper article.comment {
   padding: 0 0 0 var(--space-s);
   margin: 0 0 var(--space-s);

--- a/modules/core/ui/theme/css/dashboard.css
+++ b/modules/core/ui/theme/css/dashboard.css
@@ -14,7 +14,7 @@
 }
 
 /* Split first and second regions to two columns on large screens. */
-@media (min-width: 48em) {
+@media screen and (min-width: 40em) {
   .layout--twocol .layout__region--first,
   .layout--twocol .layout__region--second {
     flex-basis: 50%;

--- a/modules/core/ui/theme/css/layout.css
+++ b/modules/core/ui/theme/css/layout.css
@@ -12,6 +12,11 @@
   }
 }
 
+/* Hide layout regions if there is no content. */
+.layout--twocol .layout__region:not(:has(div)){
+  display: none;
+}
+
 /* Style entity layout regions similar to gin-layer-wrapper. */
 .layout--twocol .layout__region {
   padding: var(--gin-spacing-s);

--- a/modules/core/ui/theme/css/layout.css
+++ b/modules/core/ui/theme/css/layout.css
@@ -1,4 +1,10 @@
-/* Add some vertical padding to layout regions. */
+/* Style entity layout regions similar to gin-layer-wrapper. */
 .layout--twocol .layout__region {
   margin-bottom: 1em;
+  padding: var(--gin-spacing-s);
+  background: var(--gin-bg-layer);
+  border: 1px solid var(--gin-border-color-layer);
+  border-radius: var(--gin-border-l);
+  box-sizing: border-box;
+  box-shadow: var(--gin-shadow-l1);
 }

--- a/modules/core/ui/theme/css/layout.css
+++ b/modules/core/ui/theme/css/layout.css
@@ -21,3 +21,8 @@
   box-sizing: border-box;
   box-shadow: var(--gin-shadow-l1);
 }
+
+/* Remove padding from top region if it only has a map. */
+.layout--twocol .layout__region--top:has(div.field--name-geometry:only-child) {
+  padding: 0;
+}

--- a/modules/core/ui/theme/css/layout.css
+++ b/modules/core/ui/theme/css/layout.css
@@ -1,6 +1,19 @@
+/* Add gap to layout. */
+.layout--twocol {
+  --layout-spacing: var(--gin-spacing-s);
+  gap: var(--layout-spacing);
+}
+
+/* Split first and second regions to two columns on large screens. */
+@media screen and (min-width: 40em) {
+  .layout--twocol > .layout__region--first,
+  .layout--twocol > .layout__region--second {
+    flex-basis: calc(50% - var(--layout-spacing)*.5);
+  }
+}
+
 /* Style entity layout regions similar to gin-layer-wrapper. */
 .layout--twocol .layout__region {
-  margin-bottom: 1em;
   padding: var(--gin-spacing-s);
   background: var(--gin-bg-layer);
   border: 1px solid var(--gin-border-color-layer);

--- a/modules/core/ui/theme/css/layout.css
+++ b/modules/core/ui/theme/css/layout.css
@@ -2,9 +2,3 @@
 .layout--twocol .layout__region {
   margin-bottom: 1em;
 }
-
-/* Hide geometry field label in asset and log page top region. */
-body.path-asset .layout__region--top .field--name-geometry .field__label,
-body.path-log .layout__region--top .field--name-geometry .field__label {
-  display: none;
-}

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -201,7 +201,7 @@ function farm_ui_theme_preprocess_block(&$variables) {
  */
 function farm_ui_theme_preprocess_field(&$variables) {
   if ($variables['field_type'] == 'comment') {
-    $variables['attributes']['class'][] = 'gin-layer-wrapper';
+    $variables['#attached']['library'][] = 'farm_ui_theme/comment';
   }
 }
 

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -163,7 +163,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
           '#group' => $tab_group,
           '#optional' => TRUE,
           '#weight' => $tab_info['weight'],
-          '#open' => $tab_id === 'default_field_group' || $tab_group === 'advanced',
+          '#open' => $tab_id === 'default_field_group' || $tab_id === 'meta_field_group',
         ];
       }
 

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -108,7 +108,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
       'revision' => [
         'location' => 'sidebar',
         'title' => $this->t('Revision information'),
-        'weight' => 200,
+        'weight' => 500,
       ],
     ] + $this->moduleHandler->invokeAll('farm_ui_theme_field_groups', [$entity_type, $bundle]);
     return $field_groups;
@@ -174,6 +174,12 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
           $form[$field_id]['#group'] = "{$tab_id}_field_group";
         }
       }
+    }
+
+    // Comments are a special case because the CommentWidget sets the #group
+    // for the widget to advanced but this weight is never set.
+    if (isset($form['comment']['widget'][0])) {
+      $form['comment']['widget'][0]['#weight'] = $form['comment']['#weight'];
     }
 
     // Add authoring information for existing entities.


### PR DESCRIPTION
My original motivation for this was to improve the display of the "Add new comment" field on entities. Ultimately I think the best solution is to make each of our layout regions use the "gin-layer-wrapper" styles so they get a background color/shadow and are lifted on the page to match the existing comment styles. Then decreasing the size of the comment text headers (h2 is pretty big) makes things look nice.

Last, some minor changes to make other css in farm_ui_theme consistent.