### PR TITLE
Require asset name in bulk KML importer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Remove data_table from existing plan_record entity type definition #829](https://github.com/farmOS/farmOS/pull/829)
 - [Use farm_people entity_reference View for exposed Owner filter in farm_asset View #835](https://github.com/farmOS/farmOS/pull/835)
+- [Require asset name in bulk KML importer #836](https://github.com/farmOS/farmOS/pull/836)
 
 ## [3.2.1] 2024-04-12
 

--- a/modules/core/import/modules/kml/src/Form/KmlImporter.php
+++ b/modules/core/import/modules/kml/src/Form/KmlImporter.php
@@ -179,6 +179,7 @@ class KmlImporter extends FormBase {
         '#type' => 'textfield',
         '#title' => $this->t('Name'),
         '#default_value' => $geometry->properties['name'] ?? '',
+        '#required' => TRUE,
       ];
 
       $form['output']['assets'][$index]['land_type'] = [


### PR DESCRIPTION
The bulk KML importer form does not currently require the "Name" field to be filled in. This allows assets with blank names to be generated.