### PR TITLE
Include SMTP module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Include SMTP module #837](https://github.com/farmOS/farmOS/pull/837)
+
 ### Fixed
 
 - [Remove data_table from existing plan_record entity type definition #829](https://github.com/farmOS/farmOS/pull/829)

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "drupal/role_delegation": "^1.2",
         "drupal/simple_oauth": "6.0.0-beta5",
         "drupal/simple_oauth_password_grant": "^1.0@RC",
+        "drupal/smtp": "^1.2",
         "drupal/state_machine": "^1.9",
         "drupal/subrequests": "^3.0.6",
         "drupal/token": "^1.11",

--- a/docs/hosting/email.md
+++ b/docs/hosting/email.md
@@ -24,9 +24,8 @@ There are two potential solutions to this:
 
 1. Install and configure the [SMTP](https://drupal.org/project/smtp) module.
    This is a contributed Drupal module that allows emails to be relayed through
-   a third-party SMTP server. This module is not included with farmOS, but can
-   be downloaded into `[farmOS-codebase]/web/sites/all/modules` and enabled in
-   `https://[farmOS-hostname]/admin/modules`.
+   a third-party SMTP server. This module is included with farmOS and can be
+   enabled in `https://[farmOS-hostname]/admin/modules`.
 2. Create your own Docker image which inherits from the farmOS image. This
    image can install an SMTP server like Postfix, which can be configured to
    send email directly, or relay it through another SMTP server.


### PR DESCRIPTION
This adds the SMTP module to farmOS's `composer.json`, and updates the documentation to note that it doesn't need to be downloaded separately anymore.

This makes it easier for people who are self-hosting farmOS in a Docker container to configure email.