### PR TITLE
Display a warning if there are outstanding database updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Display a warning if there are outstanding database updates #838](https://github.com/farmOS/farmOS/pull/838)
+
 ### Fixed
 
 - [Remove data_table from existing plan_record entity type definition #829](https://github.com/farmOS/farmOS/pull/829)

--- a/modules/core/update/farm_update.services.yml
+++ b/modules/core/update/farm_update.services.yml
@@ -5,3 +5,8 @@ services:
   farm.update:
     class: Drupal\farm_update\FarmUpdate
     arguments: [ '@logger.channel.farm_update', '@module_handler', '@entity_type.manager', '@config.factory', '@config_update.config_diff', '@config_update.config_list', '@config_update.config_update' ]
+  farm_update.db_update_subscriber:
+    class: Drupal\farm_update\EventSubscriber\DatabaseUpdateSubscriber
+    arguments: [ '@module_handler', '@update.update_hook_registry', '@update.post_update_registry', '@messenger' ]
+    tags:
+      - { name: 'event_subscriber' }

--- a/modules/core/update/src/EventSubscriber/DatabaseUpdateSubscriber.php
+++ b/modules/core/update/src/EventSubscriber/DatabaseUpdateSubscriber.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Drupal\farm_update\EventSubscriber;
+
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Update\UpdateHookRegistry;
+use Drupal\Core\Update\UpdateRegistry;
+use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Event subscriber for notifying users of outstanding database updates.
+ */
+class DatabaseUpdateSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The update registry service.
+   *
+   * @var \Drupal\Core\Update\UpdateHookRegistry
+   */
+  protected $updateRegistry;
+
+  /**
+   * The post update registry.
+   *
+   * @var \Drupal\Core\Update\UpdateRegistry
+   */
+  protected $postUpdateRegistry;
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * DatabaseUpdateSubscriber constructor.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
+   * @param \Drupal\Core\Update\UpdateHookRegistry $update_registry
+   *   The update registry service.
+   * @param \Drupal\Core\Update\UpdateRegistry $post_update_registry
+   *   The post update registry.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler, UpdateHookRegistry $update_registry, UpdateRegistry $post_update_registry, MessengerInterface $messenger) {
+    $this->moduleHandler = $module_handler;
+    $this->updateRegistry = $update_registry;
+    $this->postUpdateRegistry = $post_update_registry;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * Get subscribed events.
+   *
+   * @inheritdoc
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = ['databaseUpdateCheck'];
+    return $events;
+  }
+
+  /**
+   * Check for outstanding database updates.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\RequestEvent $event
+   *   The RequestEvent object.
+   */
+  public function databaseUpdateCheck(RequestEvent $event) {
+
+    // Check installed modules for pending updates.
+    // This is adapted directly from the core system_requirements().
+    $has_pending_updates = FALSE;
+    foreach ($this->moduleHandler->getModuleList() as $module => $filename) {
+      $updates = $this->updateRegistry->getAvailableUpdates($module);
+      if ($updates) {
+        $default = $this->updateRegistry->getInstalledVersion($module);
+        if (max($updates) > $default) {
+          $has_pending_updates = TRUE;
+          break;
+        }
+      }
+    }
+    if (!$has_pending_updates) {
+      $missing_post_update_functions = $this->postUpdateRegistry->getPendingUpdateFunctions();
+      if (!empty($missing_post_update_functions)) {
+        $has_pending_updates = TRUE;
+      }
+    }
+
+    // If there are pending updates, display a message.
+    if ($has_pending_updates) {
+      $message = $this->t('Some modules have database schema updates to install. You should run the <a href=":update">database update script</a> immediately.', [':update' => Url::fromRoute('system.db_update')->toString()]);
+      $this->messenger->addWarning($message);
+    }
+  }
+
+}


### PR DESCRIPTION
This adds a warning message that is displayed on every page if/when there are outstanding database updates that need to be run.

We've seen in the community forum/chat that sometimes people who are self-hosting don't know that they need to run database updates and rebuild the cache. This is dangerous because it means they could be running code that is not compatible with their database/configuration. This warning serves as a simple safety check to help prevent that.

Notably, this copies the logic and message text directly from the Drupal core `system` module's `hook_requirements()`, which shows a message on the admin status report page. All we are doing here is showing that same message on all pages, so it can't be missed.