### PR TITLE
Allow multiple locations to be referenced in the planting quick form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Allow multiple locations to be referenced in the planting quick form #839](https://github.com/farmOS/farmOS/pull/839)
+
 ### Fixed
 
 - [Remove data_table from existing plan_record entity type definition #829](https://github.com/farmOS/farmOS/pull/829)

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -356,6 +356,7 @@ class Planting extends QuickFormBase {
         ],
         'match_operator' => 'CONTAINS',
       ],
+      '#tags' => TRUE,
       '#required' => TRUE,
     ];
     $field_info['quantity'] = $this->buildInlineContainer();
@@ -439,7 +440,7 @@ class Planting extends QuickFormBase {
       }
     }
 
-    // Get the location name.
+    // Get the location name(s).
     // The "final" location of the plant is assumed to be the transplanting
     // location (if the transplanting module is enabled). If a transplanting is
     // not being created, but a seeding is, then use the seeding location.
@@ -450,13 +451,10 @@ class Planting extends QuickFormBase {
     $location_name = '';
     foreach ($location_keys as $key) {
       if ($form_state->hasValue($key)) {
-        $location_id = $form_state->getValue($key);
-        if (!empty($location_id)) {
-          $location = $this->entityTypeManager->getStorage('asset')->load($location_id);
-          if (!empty($location)) {
-            $location_name = $location->label();
-          }
-        }
+        $location_names = array_map(function ($value) {
+          return $this->entityTypeManager->getStorage('asset')->load($value['target_id'])->label();
+        }, $form_state->getValue($key));
+        $location_name = implode(', ', $location_names);
       }
     }
 

--- a/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
@@ -196,7 +196,9 @@ class QuickPlantingTest extends QuickFormTestBase {
           'date' => '2022-05-15',
           'time' => '00:00:00',
         ],
-        'location' => $land1->label(),
+        'location' => [
+          ['target_id' => $land1->id()],
+        ],
         'quantity' => [
           'measure' => 'weight',
           'value' => '10.01',
@@ -251,7 +253,9 @@ class QuickPlantingTest extends QuickFormTestBase {
           'date' => '2022-05-15',
           'time' => '00:00:00',
         ],
-        'location' => $land1->label(),
+        'location' => [
+          ['target_id' => $land1->id()],
+        ],
         'notes' => [],
         'done' => TRUE,
       ],
@@ -261,7 +265,9 @@ class QuickPlantingTest extends QuickFormTestBase {
           'date' => '2022-06-15',
           'time' => '00:00:00',
         ],
-        'location' => $land2->label(),
+        'location' => [
+          ['target_id' => $land2->id()],
+        ],
         'notes' => [],
         'done' => FALSE,
       ],
@@ -291,6 +297,36 @@ class QuickPlantingTest extends QuickFormTestBase {
     $this->assertEquals('pending', $log->get('status')->value);
     $log = $logs[4];
     $this->assertEquals('pending', $log->get('status')->value);
+
+    // Test referencing multiple locations.
+    $this->submitQuickForm([
+      'seasons' => [['target_id' => $season->id()]],
+      'crops' => [[['target_id' => $crop->id()]]],
+      'crop_count' => 1,
+      'log_types' => [
+        'seeding' => 'seeding',
+      ],
+      'seeding' => [
+        'type' => 'seeding',
+        'date' => [
+          'date' => '2022-05-15',
+          'time' => '00:00:00',
+        ],
+        'location' => [
+          ['target_id' => $land1->id()],
+          ['target_id' => $land2->id()],
+        ],
+        'notes' => [],
+        'done' => TRUE,
+      ],
+    ]);
+
+    // Confirm that another log was created and it references both locations.
+    $logs = $this->logStorage->loadMultiple();
+    $this->assertCount(5, $logs);
+    $log = $logs[5];
+    $this->assertEquals($land1->id(), $log->get('location')->referencedEntities()[0]->id());
+    $this->assertEquals($land2->id(), $log->get('location')->referencedEntities()[1]->id());
   }
 
 }


### PR DESCRIPTION
Fixes #749 

I made this commit last year but completely forgot about it. It still needed tests, so I added some.