### PR TITLE
Remove default country from farm settings form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Allow multiple locations to be referenced in the planting quick form #839](https://github.com/farmOS/farmOS/pull/839)
 
+### Removed
+
+- [Remove default country from farm settings form #840](https://github.com/farmOS/farmOS/pull/840)
+
 ### Fixed
 
 - [Remove data_table from existing plan_record entity type definition #829](https://github.com/farmOS/farmOS/pull/829)

--- a/modules/core/settings/src/Form/FarmSettingsFarmInfoForm.php
+++ b/modules/core/settings/src/Form/FarmSettingsFarmInfoForm.php
@@ -2,12 +2,9 @@
 
 namespace Drupal\farm_settings\Form;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Datetime\TimeZoneFormHelper;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Locale\CountryManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for configuring basic farm info.
@@ -15,36 +12,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ingroup farm
  */
 class FarmSettingsFarmInfoForm extends ConfigFormBase {
-
-  /**
-   * The country manager.
-   *
-   * @var \Drupal\Core\Locale\CountryManagerInterface
-   */
-  protected $countryManager;
-
-  /**
-   * Constructs a RegionalForm object.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   * @param \Drupal\Core\Locale\CountryManagerInterface $country_manager
-   *   The country manager.
-   */
-  public function __construct(ConfigFactoryInterface $config_factory, CountryManagerInterface $country_manager) {
-    parent::__construct($config_factory);
-    $this->countryManager = $country_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory'),
-      $container->get('country_manager')
-    );
-  }
 
   /**
    * {@inheritdoc}
@@ -86,19 +53,6 @@ class FarmSettingsFarmInfoForm extends ConfigFormBase {
     // Get the system.date config.
     $system_date = $this->config('system.date');
 
-    // Get countries.
-    $countries = $this->countryManager->getList();
-
-    // Default country select.
-    $form['default_country'] = [
-      '#type' => 'select',
-      '#title' => $this->t('Default country'),
-      '#empty_value' => '',
-      '#default_value' => $system_date->get('country.default'),
-      '#options' => $countries,
-      '#attributes' => ['class' => ['country-detect']],
-    ];
-
     // Get list of timezones.
     $timezones = TimeZoneFormHelper::getOptionsList();
 
@@ -135,16 +89,12 @@ class FarmSettingsFarmInfoForm extends ConfigFormBase {
       ->set('name', $site_name)
       ->save();
 
-    // Get the submitted country.
-    $default_country = $form_state->getValue('default_country');
-
     // Get the submitted timezone.
     $default_timezone = $form_state->getValue('default_timezone');
 
     // Update system.date config.
     $this->configFactory->getEditable('system.date')
       ->set('timezone.default', $default_timezone)
-      ->set('country.default', $default_country)
       ->save();
 
     // Display message from parent submitForm.


### PR DESCRIPTION
@nicxvan opened this issue in the drupal.org/project/farm issue queue: https://www.drupal.org/project/farm/issues/3444991

In that, I learned that Drupal core has removed country selection from its installation form. Core doesn't use the `country.default` configuration anywhere itself.

> The way you use it is one of the reasons we removed the default country from the install page, core didn't use it at all and most contrib just used it like you are here to either set it themselves or use it as a default internally.
> 
> If you're not using that value in your system, it might be better to just remove it unless you have plans to use it in the future.

If I remember correctly, the only reason we included it in the farmOS settings form was because it was included in the Drupal core installation form. A lot of farmOS users (especially on cloud-hosted instances) do not install farmOS themselves, so they don't have the option to pick these values, and they do not have permission to change them after installation, so we made a form for them (it also serves to centralize the farmOS-relevant Drupal core settings alongside other farmOS settings).

So, since Drupal core is removing this from the installation form, and not using it anywhere itself, I think we can follow suit.

If we do NOT do this, then we will need to figure out what adjustments (if any) are necessary to be compatible with the new validation constraint that Drupal core is adding to the `country.default` configuration in 10.3: https://www.drupal.org/project/drupal/issues/3437325