### PR TITLE
Document how to use symfony/mailer for email SMTP relay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ requirements (inherited from Drupal 11):
 - [Add map layer for "Other Location" assets #966](https://github.com/farmOS/farmOS/pull/966)
 - [Add ability to assign plan ownership #1015](https://github.com/farmOS/farmOS/pull/1015)
 - [Show violation messages when validation fails in bulk action forms #1018](https://github.com/farmOS/farmOS/pull/1018)
+- [Document how to use symfony/mailer for email SMTP relay #844](https://github.com/farmOS/farmOS/pull/844)
 
 ### Changed
 

--- a/docs/hosting/email.md
+++ b/docs/hosting/email.md
@@ -21,11 +21,23 @@ you will see this error message when farmOS tries to send an email:
 
 There are two potential solutions to this:
 
-1. Install and configure the [SMTP](https://drupal.org/project/smtp) module.
-   This is a contributed Drupal module that allows emails to be relayed through
-   a third-party SMTP server. This module is not included with farmOS, but can
-   be downloaded into `[farmOS-codebase]/web/sites/all/modules` and enabled in
-   `https://[farmOS-hostname]/admin/modules`.
+1. Use a third-party SMTP server as a relay. This can be achieved by adding the
+   following code to your `settings.php` file. Replace the `host`, `port`,
+   `user`, and `password` values with your SMTP relay credentials. For more
+   information and examples, refer to this Drupal core change record:
+   https://www.drupal.org/node/3369935
+
+    ```php
+    $config['system.mail']['interface']['default'] = 'symfony_mailer';
+    $config['system.mail']['mailer_dsn'] = [
+      'scheme' => 'smtp',
+      'host' => 'smtp.example.com',
+      'port' => 587,
+      'user' => 'my-smtp-user',
+      'password' => 'my-smtp-password',
+    ];
+    ```
+
 2. Create your own Docker image which inherits from the farmOS image. This
    image can install an SMTP server like Postfix, which can be configured to
    send email directly, or relay it through another SMTP server.


### PR DESCRIPTION
This changes our https://farmos.org/hosting/email/ documentation to recommend using `symfony/mailer` for SMTP email relays, instead of the [contrib SMTP module](drupal.org/project/smtp).

Kudos to @pcambra for turning me on to this new option! https://github.com/farmOS/farmOS/pull/837#issuecomment-2093359751