### PR TITLE
Improve comment settings and edit sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Allow multiple locations to be referenced in the planting quick form #839](https://github.com/farmOS/farmOS/pull/839)
 - [Update farmOS-map to v2.3.0 #841](https://github.com/farmOS/farmOS/pull/841) to [add the ability to use custom stroke colors #201](https://github.com/farmOS/farmOS-map/issues/201) (in custom map layers)
+- [Improve comment settings and edit sidebar #846](https://github.com/farmOS/farmOS/pull/846)
 
 ### Removed
 

--- a/modules/core/comment/farm_comment.module
+++ b/modules/core/comment/farm_comment.module
@@ -56,7 +56,7 @@ function farm_comment_base_field_definition(string $entity_type) {
   // Build form display settings.
   $field->setDisplayOptions('form', [
     'type' => 'comment_default',
-    'weight' => 1000,
+    'weight' => 450,
   ]);
 
   // Build view display settings.

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -163,7 +163,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
           '#group' => $tab_group,
           '#optional' => TRUE,
           '#weight' => $tab_info['weight'],
-          '#open' => $tab_id === 'default_field_group' || $tab_group === 'advanced',
+          '#open' => $tab_id === 'default_field_group' || $tab_id === 'meta_field_group',
         ];
       }
 

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -108,7 +108,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
       'revision' => [
         'location' => 'sidebar',
         'title' => $this->t('Revision information'),
-        'weight' => 200,
+        'weight' => 500,
       ],
     ] + $this->moduleHandler->invokeAll('farm_ui_theme_field_groups', [$entity_type, $bundle]);
     return $field_groups;
@@ -174,6 +174,12 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
           $form[$field_id]['#group'] = "{$tab_id}_field_group";
         }
       }
+    }
+
+    // Comments are a special case because the CommentWidget sets the #group
+    // for the widget to advanced but this weight is never set.
+    if (isset($form['comment']['widget'][0])) {
+      $form['comment']['widget'][0]['#weight'] = $form['comment']['#weight'];
     }
 
     // Add authoring information for existing entities.


### PR DESCRIPTION
Two changes:
- Move "Comment settings" sidebar group from the top, to the bottom directly above revision information
- Only open the "Meta" sidebar group by default