### PR TITLE
Reorder and improve entity field rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Update Drupal core to 10.3 #872](https://github.com/farmOS/farmOS/pull/872)
 - [Move farm_quantity View to farm_log_quantities and require log relationship #858](https://github.com/farmOS/farmOS/pull/858)
 - [Quantity CSV export improvements #861](https://github.com/farmOS/farmOS/pull/861)
+- [Reorder and improve entity field rendering #847](https://github.com/farmOS/farmOS/pull/847)
 
 ### Security
 

--- a/modules/asset/equipment/farm_equipment.module
+++ b/modules/asset/equipment/farm_equipment.module
@@ -23,8 +23,8 @@ function farm_equipment_farm_entity_bundle_field_info(EntityTypeInterface $entit
       'target_bundle' => 'equipment',
       'multiple' => TRUE,
       'weight' => [
-        'form' => 55,
-        'view' => -5,
+        'form' => 40,
+        'view' => 40,
       ],
     ];
     $fields['equipment'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);

--- a/modules/asset/group/farm_group.base_fields.inc
+++ b/modules/asset/group/farm_group.base_fields.inc
@@ -44,7 +44,7 @@ function farm_group_log_base_fields() {
     'label' => t('Is group assignment'),
     'description' => t('If this log is a group assignment, any referenced assets will become members of the groups referenced below.'),
     'weight' => [
-      'form' => 96,
+      'form' => 30,
     ],
     'view_display_options' => [
       'label' => 'inline',
@@ -55,7 +55,7 @@ function farm_group_log_base_fields() {
         'format_custom_true' => '',
         'hide_if_false' => TRUE,
       ],
-      'weight' => 96,
+      'weight' => 30,
     ],
   ];
   $fields['is_group_assignment'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
@@ -69,8 +69,8 @@ function farm_group_log_base_fields() {
     'target_bundle' => 'group',
     'multiple' => TRUE,
     'weight' => [
-      'form' => 97,
-      'view' => 97,
+      'form' => 30,
+      'view' => 30,
     ],
   ];
   $fields['group'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);

--- a/modules/asset/group/farm_group.module
+++ b/modules/asset/group/farm_group.module
@@ -69,6 +69,16 @@ function farm_group_farm_ui_theme_region_items(string $entity_type) {
       'bottom' => [],
     ];
   }
+  elseif ($entity_type == 'log') {
+    $region_items = [
+      'top' => [],
+      'first' => [],
+      'second' => [
+        'is_group_assignment',
+      ],
+      'bottom' => [],
+    ];
+  }
   return $region_items;
 }
 

--- a/modules/asset/land/farm_land.module
+++ b/modules/asset/land/farm_land.module
@@ -40,3 +40,23 @@ function farm_land_type_options() {
 function farm_land_type_field_allowed_values(FieldStorageDefinitionInterface $definition, ContentEntityInterface $entity = NULL, bool &$cacheable = TRUE) {
   return farm_land_type_options();
 }
+
+/**
+ * Implements hook_farm_ui_theme_region_items().
+ */
+function farm_land_farm_ui_theme_region_items(string $entity_type) {
+
+  // Define common asset, log, and plan region items on behalf of core modules.
+  switch ($entity_type) {
+
+    case 'asset':
+      return [
+        'second' => [
+          'land_type',
+        ],
+      ];
+
+    default:
+      return [];
+  }
+}

--- a/modules/asset/land/src/Plugin/Asset/AssetType/Land.php
+++ b/modules/asset/land/src/Plugin/Asset/AssetType/Land.php
@@ -27,8 +27,8 @@ class Land extends FarmAssetType {
       'allowed_values_function' => 'farm_land_type_field_allowed_values',
       'required' => TRUE,
       'weight' => [
-        'form' => -90,
-        'view' => -50,
+        'form' => -80,
+        'view' => -80,
       ],
     ];
     $fields['land_type'] = $this->farmFieldFactory->bundleFieldDefinition($options);

--- a/modules/asset/structure/farm_structure.module
+++ b/modules/asset/structure/farm_structure.module
@@ -40,3 +40,23 @@ function farm_structure_type_options() {
 function farm_structure_type_field_allowed_values(FieldStorageDefinitionInterface $definition, ContentEntityInterface $entity = NULL, bool &$cacheable = TRUE) {
   return farm_structure_type_options();
 }
+
+/**
+ * Implements hook_farm_ui_theme_region_items().
+ */
+function farm_structure_farm_ui_theme_region_items(string $entity_type) {
+
+  // Define common asset, log, and plan region items on behalf of core modules.
+  switch ($entity_type) {
+
+    case 'asset':
+      return [
+        'second' => [
+          'structure_type',
+        ],
+      ];
+
+    default:
+      return [];
+  }
+}

--- a/modules/asset/structure/src/Plugin/Asset/AssetType/Structure.php
+++ b/modules/asset/structure/src/Plugin/Asset/AssetType/Structure.php
@@ -27,8 +27,8 @@ class Structure extends FarmAssetType {
       'allowed_values_function' => 'farm_structure_type_field_allowed_values',
       'required' => TRUE,
       'weight' => [
-        'form' => -90,
-        'view' => -50,
+        'form' => -80,
+        'view' => -80,
       ],
     ];
     $fields['structure_type'] = $this->farmFieldFactory->bundleFieldDefinition($options);

--- a/modules/core/entity/modules/fields/farm_entity_fields.base_fields.inc
+++ b/modules/core/entity/modules/fields/farm_entity_fields.base_fields.inc
@@ -40,7 +40,7 @@ function farm_entity_fields_asset_base_fields() {
       'label' => t('Notes'),
       'weight' => [
         'form' => 95,
-        'view' => 10,
+        'view' => 95,
       ],
     ],
   ];
@@ -88,7 +88,7 @@ function farm_entity_fields_log_base_fields() {
       'label' => t('Notes'),
       'weight' => [
         'form' => 95,
-        'view' => 10,
+        'view' => 95,
       ],
     ],
   ];
@@ -134,7 +134,7 @@ function farm_entity_fields_plan_base_fields() {
       'label' => t('Notes'),
       'weight' => [
         'form' => 95,
-        'view' => 10,
+        'view' => 95,
       ],
     ],
   ];

--- a/modules/core/entity/modules/fields/farm_entity_fields.module
+++ b/modules/core/entity/modules/fields/farm_entity_fields.module
@@ -53,15 +53,15 @@ function farm_entity_fields_entity_base_field_info_alter(&$fields, EntityTypeInt
       'label' => 'hidden',
       'weight' => -100,
     ],
+    'status' => [
+      'weight' => -95,
+    ],
     'timestamp' => [
       'weight' => -90,
     ],
     'type' => [
       'weight' => -85,
       'hidden' => 'form',
-    ],
-    'status' => [
-      'weight' => -80,
     ],
     'created' => [
       'hidden' => TRUE,

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -659,7 +659,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         ];
         $view_display_options = [
           'type' => 'file_table',
-          'label' => 'visually_hidden',
+          'label' => 'above',
           'settings' => [
             'use_description_as_link_text' => TRUE,
           ],
@@ -678,7 +678,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         ];
         $view_display_options = [
           'type' => 'image',
-          'label' => 'visually_hidden',
+          'label' => 'above',
           'settings' => [
             'image_style' => 'large',
             'image_link' => 'file',

--- a/modules/core/flag/farm_flag.module
+++ b/modules/core/flag/farm_flag.module
@@ -126,6 +126,28 @@ function farm_flag_field_allowed_values(FieldStorageDefinitionInterface $definit
 }
 
 /**
+ * Implements hook_farm_ui_theme_region_items().
+ */
+function farm_flag_farm_ui_theme_region_items(string $entity_type) {
+
+  // Define common asset, log, and plan region items on behalf of core modules.
+  switch ($entity_type) {
+
+    case 'asset':
+    case 'log':
+    case 'plan':
+      return [
+        'second' => [
+          'flag',
+        ],
+      ];
+
+    default:
+      return [];
+  }
+}
+
+/**
  * Implements hook_theme().
  */
 function farm_flag_theme() {

--- a/modules/core/id_tag/farm_id_tag.module
+++ b/modules/core/id_tag/farm_id_tag.module
@@ -21,8 +21,8 @@ function farm_id_tag_entity_base_field_info(EntityTypeInterface $entity_type) {
       'description' => t('List any identification tags that this asset has. Use the fields below to describe the type, location, and ID of each.'),
       'multiple' => TRUE,
       'weight' => [
-        'form' => 50,
-        'view' => 0,
+        'form' => 20,
+        'view' => 20,
       ],
     ];
     $fields['id_tag'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($field_info);

--- a/modules/core/location/farm_location.base_fields.inc
+++ b/modules/core/location/farm_location.base_fields.inc
@@ -30,7 +30,7 @@ function farm_location_asset_base_fields() {
         'link' => TRUE,
         'render_without_location' => TRUE,
       ],
-      'weight' => 95,
+      'weight' => 50,
     ],
   ];
   $fields['location'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
@@ -43,7 +43,7 @@ function farm_location_asset_base_fields() {
     'computed' => AssetGeometryItemList::class,
     'hidden' => 'form',
     'weight' => [
-      'view' => 95,
+      'view' => 40,
     ],
   ];
   $fields['geometry'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
@@ -57,7 +57,7 @@ function farm_location_asset_base_fields() {
     'label' => t('Intrinsic geometry'),
     'description' => t('Add geometry data to this asset to describe its intrinsic location. This will only be used if the asset is fixed.'),
     'weight' => [
-      'form' => 96,
+      'form' => 50,
     ],
     'hidden' => 'view',
     'populate_file_field' => 'file',
@@ -71,7 +71,7 @@ function farm_location_asset_base_fields() {
     'description' => t('If this asset is a location, then other assets can be moved to it.'),
     'default_value_callback' => 'farm_location_is_location_default_value',
     'weight' => [
-      'form' => 95,
+      'form' => 0,
     ],
     'view_display_options' => [
       'label' => 'inline',
@@ -82,7 +82,7 @@ function farm_location_asset_base_fields() {
         'format_custom_true' => '',
         'hide_if_false' => TRUE,
       ],
-      'weight' => 95,
+      'weight' => 0,
     ],
   ];
   $fields['is_location'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
@@ -94,7 +94,7 @@ function farm_location_asset_base_fields() {
     'description' => t('If this asset is fixed, then it can have an intrinsic geometry. If the asset will move around, then it is not fixed and geometry will be determined by movement logs.'),
     'default_value_callback' => 'farm_location_is_fixed_default_value',
     'weight' => [
-      'form' => 95,
+      'form' => 10,
     ],
     'view_display_options' => [
       'label' => 'inline',
@@ -105,7 +105,7 @@ function farm_location_asset_base_fields() {
         'format_custom_true' => '',
         'hide_if_false' => TRUE,
       ],
-      'weight' => 96,
+      'weight' => 10,
     ],
   ];
   $fields['is_fixed'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);

--- a/modules/core/location/farm_location.base_fields.inc
+++ b/modules/core/location/farm_location.base_fields.inc
@@ -127,8 +127,8 @@ function farm_location_log_base_fields() {
     'target_type' => 'asset',
     'multiple' => TRUE,
     'weight' => [
-      'form' => 90,
-      'view' => 90,
+      'form' => 20,
+      'view' => 20,
     ],
   ];
   $field = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
@@ -150,8 +150,8 @@ function farm_location_log_base_fields() {
     'label' => t('Geometry'),
     'description' => t('Add geometry data to this log to describe where it took place.'),
     'weight' => [
-      'form' => 95,
-      'view' => 95,
+      'form' => 20,
+      'view' => 20,
     ],
     'populate_file_field' => 'file',
   ];
@@ -164,7 +164,7 @@ function farm_location_log_base_fields() {
     'description' => t('If this log is a movement, then all assets referenced by it will be located in the referenced locations and/or geometry at the time the log takes place. The log must be complete in order for the movement to take effect.'),
     'default_value_callback' => 'farm_location_is_movement_default_value',
     'weight' => [
-      'form' => 95,
+      'form' => 20,
     ],
     'view_display_options' => [
       'label' => 'inline',
@@ -175,7 +175,7 @@ function farm_location_log_base_fields() {
         'format_custom_true' => '',
         'hide_if_false' => TRUE,
       ],
-      'weight' => 95,
+      'weight' => 20,
     ],
   ];
   $fields['is_movement'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);

--- a/modules/core/log/modules/asset/farm_log_asset.module
+++ b/modules/core/log/modules/asset/farm_log_asset.module
@@ -25,8 +25,8 @@ function farm_log_asset_entity_base_field_info(EntityTypeInterface $entity_type)
     'target_type' => 'asset',
     'multiple' => TRUE,
     'weight' => [
-      'form' => 50,
-      'view' => -10,
+      'form' => 0,
+      'view' => 0,
     ],
   ];
   $fields['asset'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($field_info);

--- a/modules/core/log/modules/quantity/farm_log_quantity.module
+++ b/modules/core/log/modules/quantity/farm_log_quantity.module
@@ -28,7 +28,7 @@ function farm_log_quantity_entity_base_field_info(EntityTypeInterface $entity_ty
       'multiple' => TRUE,
       'weight' => [
         'form' => 0,
-        'view' => 0,
+        'view' => 50,
       ],
     ],
   ];

--- a/modules/core/parent/farm_parent.module
+++ b/modules/core/parent/farm_parent.module
@@ -22,7 +22,7 @@ function farm_parent_entity_base_field_info(EntityTypeInterface $entity_type) {
       'target_type' => 'asset',
       'multiple' => TRUE,
       'weight' => [
-        'form' => 40,
+        'form' => 0,
         'view' => 0,
       ],
     ];

--- a/modules/core/ui/theme/css/image.css
+++ b/modules/core/ui/theme/css/image.css
@@ -1,0 +1,6 @@
+div.field--name-image.field--type-image div.field__items {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  gap: var(--gin-spacing-m);
+}

--- a/modules/core/ui/theme/farm_ui_theme.libraries.yml
+++ b/modules/core/ui/theme/farm_ui_theme.libraries.yml
@@ -26,6 +26,10 @@ help:
   css:
     theme:
       css/help.css: { }
+image:
+  css:
+    theme:
+      css/image.css: { }
 layout:
   css:
     theme:

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -229,6 +229,13 @@ function farm_ui_theme_preprocess_field__flag(array &$variables) {
 /**
  * Implements hook_preprocess_HOOK().
  */
+function farm_ui_theme_preprocess_field__image(array &$variables) {
+  $variables['#attached']['library'][] = 'farm_ui_theme/image';
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function farm_ui_theme_preprocess_asset__full(&$variables) {
   farm_ui_theme_build_stacked_twocol_layout($variables, 'asset');
   $variables['#attached']['library'][] = 'farm_ui_theme/layout';
@@ -319,7 +326,6 @@ function farm_ui_theme_farm_ui_theme_region_items(string $entity_type) {
         ],
         'first' => [],
         'second' => [
-          'image',
           'inventory',
           'is_location',
           'is_fixed',
@@ -330,6 +336,7 @@ function farm_ui_theme_farm_ui_theme_region_items(string $entity_type) {
         ],
         'bottom' => [
           'api',
+          'image',
           'file',
         ],
       ];
@@ -341,12 +348,12 @@ function farm_ui_theme_farm_ui_theme_region_items(string $entity_type) {
         ],
         'first' => [],
         'second' => [
-          'image',
           'owner',
           'status',
           'type',
         ],
         'bottom' => [
+          'image',
           'file',
         ],
       ];
@@ -356,11 +363,11 @@ function farm_ui_theme_farm_ui_theme_region_items(string $entity_type) {
         'top' => [],
         'first' => [],
         'second' => [
-          'image',
           'status',
           'type',
         ],
         'bottom' => [
+          'image',
           'file',
         ],
       ];

--- a/modules/core/ui/theme/farm_ui_theme.module
+++ b/modules/core/ui/theme/farm_ui_theme.module
@@ -348,6 +348,7 @@ function farm_ui_theme_farm_ui_theme_region_items(string $entity_type) {
         ],
         'first' => [],
         'second' => [
+          'is_movement',
           'owner',
           'status',
           'type',

--- a/modules/taxonomy/log_category/farm_log_category.module
+++ b/modules/taxonomy/log_category/farm_log_category.module
@@ -34,3 +34,23 @@ function farm_log_category_entity_base_field_info(EntityTypeInterface $entity_ty
   }
   return $fields;
 }
+
+/**
+ * Implements hook_farm_ui_theme_region_items().
+ */
+function farm_log_category_farm_ui_theme_region_items(string $entity_type) {
+
+  // Define common asset, log, and plan region items on behalf of core modules.
+  switch ($entity_type) {
+
+    case 'log':
+      return [
+        'second' => [
+          'category',
+        ],
+      ];
+
+    default:
+      return [];
+  }
+}


### PR DESCRIPTION
This PR changes field weights for consistency and to improve their rendering in entity view pages. Even though the fields' form weights are changing, this PR should not be changing the order of any fields in forms because many fields are grouped into tabs of similar fields.

This PR also moves images to the `bottom` region and renders them in a simple `flex` container so that multiple images can be displayed horizontally in the same row and wrap to new rows as necessary (adjusts to screensize). I think this is a simple short-term optimization to displaying a potentially long vertical list of images all in the `second` region. It keeps images and files together and adds a field `label` for each.

<details>
<summary>Land asset before:</summary>

![land-asset-before-1](https://github.com/farmOS/farmOS/assets/3116995/3e554ceb-bbb9-48b9-9d5d-39c49e3a254d)
![land-asset-before-2](https://github.com/farmOS/farmOS/assets/3116995/b4860da0-1110-466d-ab7a-56c07e927515)


</details>

<details>
<summary>Land asset after:</summary>

![land-asset-after-1](https://github.com/farmOS/farmOS/assets/3116995/ab197f06-f895-4f90-b13a-374a2e8124b4)
![land-asset-after-2](https://github.com/farmOS/farmOS/assets/3116995/26c9fc0e-be90-4a60-9b79-956f88cec58e)


</details>

<details>
<summary>Log before:</summary>

![log-before-1](https://github.com/farmOS/farmOS/assets/3116995/a7086a71-a92a-4e2f-b01c-48d917894804)


</details>

<details>
<summary>Log after:</summary>

![log-after-1](https://github.com/farmOS/farmOS/assets/3116995/756c5079-a513-42aa-b126-4970e532beeb)


</details>
