### PR TITLE
Add an asset.logs service for retrieving logs that reference an asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add an "Export Quantity CSV" bulk action to Log Views](https://github.com/farmOS/farmOS/pull/861)
 - [Allow modules to alter dashboard panes #868](https://github.com/farmOS/farmOS/pull/868)
 - [Add geometry/location fields to CSV importers #815](https://github.com/farmOS/farmOS/pull/815)
+- [Add an asset.logs service for retrieving logs that reference an asset #850](https://github.com/farmOS/farmOS/pull/850)
 
 ### Changed
 

--- a/docs/development/module/services.md
+++ b/docs/development/module/services.md
@@ -4,6 +4,32 @@ farmOS provides some [services](https://symfony.com/doc/current/service_containe
 that encapsulate common logic like querying logs and getting an asset's current
 location. Some of these services are documented here.
 
+## Asset logs service
+
+**Service name**: `asset.logs`
+
+The asset logs service provides methods for retrieving logs that reference
+assets.
+
+**Methods**:
+
+`getLogs($asset, $log_type = NULL, $access_check = TRUE)` - Load a list of logs
+that reference an asset, optionally filtered by log type. Access checking is
+performed by default but can be optionally disabled. Returns a list of log
+entities.
+
+`getFirstLog($asset, $log_type = NULL, $access_check = TRUE)` - Load the first
+log that references an asset, optionally filtered by log type. Access checking
+is performed by default but can be optionally disabled. Returns a log entity, or
+`NULL` if no logs were found.
+
+**Example usage**:
+
+```php
+// Get all observation logs that reference an asset.
+$observation_logs = \Drupal::service('asset.logs')->getLogs($asset, 'observation');
+```
+
 ## Asset location service
 
 **Service name**: `asset.location`

--- a/modules/core/log/farm_log.services.yml
+++ b/modules/core/log/farm_log.services.yml
@@ -1,4 +1,8 @@
 services:
+  asset.logs:
+    class: Drupal\farm_log\AssetLogs
+    arguments:
+      [ '@entity_type.manager', '@farm.log_query' ]
   farm.log_query:
     class: Drupal\farm_log\LogQueryFactory
     arguments:

--- a/modules/core/log/src/AssetLogs.php
+++ b/modules/core/log/src/AssetLogs.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Drupal\farm_log;
+
+use Drupal\asset\Entity\AssetInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Service for loading logs that reference assets.
+ */
+class AssetLogs implements AssetLogsInterface {
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected EntityTypeManagerInterface $entityTypeManager;
+
+  /**
+   * Log query factory.
+   *
+   * @var \Drupal\farm_log\LogQueryFactoryInterface
+   */
+  protected LogQueryFactoryInterface $logQueryFactory;
+
+  /**
+   * Class constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   Entity type manager.
+   * @param \Drupal\farm_log\LogQueryFactoryInterface $log_query_factory
+   *   Log query factory.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LogQueryFactoryInterface $log_query_factory) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->logQueryFactory = $log_query_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLogs(AssetInterface $asset, string $log_type = NULL, bool $access_check = TRUE): array {
+    $log_ids = $this->query($asset, $log_type, $access_check)->execute();
+    if (empty($log_ids)) {
+      return [];
+    }
+    return $this->entityTypeManager->getStorage('log')->loadMultiple($log_ids);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFirstLog(AssetInterface $asset, string $log_type = NULL, bool $access_check = TRUE) {
+    $log_ids = $this->query($asset, $log_type, $access_check, 1)->execute();
+    if (empty($log_ids)) {
+      return NULL;
+    }
+    return $this->entityTypeManager->getStorage('log')->load(reset($log_ids));
+  }
+
+  /**
+   * Build a log query.
+   *
+   * @param \Drupal\asset\Entity\AssetInterface $asset
+   *   The asset entity.
+   * @param string|null $log_type
+   *   Optionally filter by log type.
+   * @param bool $access_check
+   *   Whether to check log entity access.
+   * @param int|null $limit
+   *   The number of logs to return.
+   *
+   * @return \Drupal\Core\Entity\Query\QueryInterface
+   *   A query object.
+   */
+  protected function query(AssetInterface $asset, string $log_type = NULL, bool $access_check = TRUE, int $limit = NULL) {
+    $options = [
+      'asset' => $asset,
+      'direction' => 'ASC',
+    ];
+    if (!empty($limit)) {
+      $options['limit'] = $limit;
+    }
+    $query = $this->logQueryFactory->getQuery($options);
+    if (!empty($log_type)) {
+      $query->condition('type', $log_type);
+    }
+    $query->accessCheck($access_check);
+    return $query;
+  }
+
+}

--- a/modules/core/log/src/AssetLogsInterface.php
+++ b/modules/core/log/src/AssetLogsInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\farm_log;
+
+use Drupal\asset\Entity\AssetInterface;
+
+/**
+ * The interface for asset logs service.
+ */
+interface AssetLogsInterface {
+
+  /**
+   * Get all logs for an asset.
+   *
+   * @param \Drupal\asset\Entity\AssetInterface $asset
+   *   The asset entity.
+   * @param string|null $log_type
+   *   Optionally filter by log type.
+   * @param bool $access_check
+   *   Whether to check log entity access (defaults to TRUE).
+   *
+   * @return \Drupal\log\Entity\LogInterface[]
+   *   Returns an array of Log entities.
+   */
+  public function getLogs(AssetInterface $asset, string $log_type = NULL, bool $access_check = TRUE): array;
+
+  /**
+   * Get the first log of an asset.
+   *
+   * @param \Drupal\asset\Entity\AssetInterface $asset
+   *   The asset entity.
+   * @param string|null $log_type
+   *   Optionally filter by log type.
+   * @param bool $access_check
+   *   Whether to check log entity access.
+   *
+   * @return \Drupal\log\Entity\LogInterface|null
+   *   Returns a log entity or NULL if no logs were found.
+   */
+  public function getFirstLog(AssetInterface $asset, string $log_type = NULL, bool $access_check = TRUE);
+
+}

--- a/modules/core/log/src/LogQueryFactory.php
+++ b/modules/core/log/src/LogQueryFactory.php
@@ -61,9 +61,11 @@ class LogQueryFactory implements LogQueryFactoryInterface {
       $query->condition('asset.entity.id', $options['asset']->id());
     }
 
-    // Sort by timestamp and then log ID, descending.
-    $query->sort('timestamp', 'DESC');
-    $query->sort('id', 'DESC');
+    // Sort by timestamp and then log ID. Optionally accept a sort direction.
+    // Default to timestamp+id descending.
+    $direction = $options['direction'] ?? 'DESC';
+    $query->sort('timestamp', $direction);
+    $query->sort('id', $direction);
 
     // If a limit is specified, limit the results.
     if (isset($options['limit'])) {


### PR DESCRIPTION
This adds a new `asset.logs` service for retrieving logs that reference an asset.

See the included developer documentation for more info.