### PR TITLE
Update to gin 3.0-rc16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Permissions page is blank #887](https://github.com/farmOS/farmOS/issues/887)
+
 ## [3.3.2] 2024-11-20
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/exif_orientation": "^1.2",
         "drupal/fraction": "^2.3.1",
         "drupal/geofield": "^1.40",
-        "drupal/gin": "3.0-rc10",
+        "drupal/gin": "3.0-rc12",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",
         "drupal/jsonapi_extras": "^3.22",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/exif_orientation": "^1.2",
         "drupal/fraction": "^2.3.1",
         "drupal/geofield": "^1.40",
-        "drupal/gin": "3.0-rc12",
+        "drupal/gin": "3.0-rc13",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",
         "drupal/jsonapi_extras": "^3.22",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/exif_orientation": "^1.2",
         "drupal/fraction": "^2.3.1",
         "drupal/geofield": "^1.40",
-        "drupal/gin": "3.0-rc13",
+        "drupal/gin": "3.0-rc16",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",
         "drupal/jsonapi_extras": "^3.22",


### PR DESCRIPTION
Opening this issue to track any changes we need to support gin [3.0-rc12](https://www.drupal.org/project/gin/releases/8.x-3.0-rc12).

Since we are currently on 3.0-rc10 this also includes various improvements and bugfixes from [3.0-rc11](https://www.drupal.org/project/gin/releases/8.x-3.0-rc11)

But most notably a new feature that moves all form action buttons to a top sticky header: https://www.drupal.org/project/gin/issues/3356717
- So far I've found one bug related to this change and submitted a fix: https://www.drupal.org/project/gin/issues/3440148
- The feature is turned off by default but can be turned on in user overrides, so we should make sure it doesn't break anything too much. It seems that it might default to "on" in an upcoming release so it might be good to embrace the change.
- I have mixed feelings but am coming around to it. It's a nice improvement and would create some consistency across all forms but certainly is a significant change for existing users.