### PR TITLE
Issue #3314741: EntityFieldManager::getFieldMap() doesn't show farmOS bundle fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Issue #3454144: Fix untranslated plant_type descriptions in plant and seed asset types](https://www.drupal.org/project/farm/issues/3454144)
 - [Set owner of cloned assets to current user #851](https://github.com/farmOS/farmOS/pull/851)
+- [Issue #3314741: EntityFieldManager::getFieldMap() doesn't show farmOS bundle fields](https://www.drupal.org/project/farm/issues/3314741)
 
 ## [3.2.2] 2024-05-17
 

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2024-01-03/2339235-10.2.x-82.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
                 "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch",
-                "Issue #3129179: Provide some way to rebuild the persistent bundle field map": "https://www.drupal.org/files/issues/2023-08-30/rebuild_field_map-3129179-39.patch"
+                "Issue #3129179: Provide some way to rebuild the persistent bundle field map": "https://www.drupal.org/files/issues/2024-07-17/3129179-49.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
                 "Issue #2429699: Add Views EntityReference filter to be available for all entity reference fields.": "https://www.drupal.org/files/issues/2021-12-02/2429699-453-9.3.x.patch",
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2024-01-03/2339235-10.2.x-82.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
-                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch"
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch",
+                "Issue #3129179: Provide some way to rebuild the persistent bundle field map": "https://www.drupal.org/files/issues/2023-08-30/rebuild_field_map-3129179-39.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -15,6 +15,24 @@ use Drupal\farm_entity\BundlePlugin\FarmEntityBundlePluginHandler;
 use Drupal\farm_entity\Routing\DefaultHtmlRouteProvider;
 
 /**
+ * Implements hook_modules_installed().
+ */
+function farm_entity_modules_installed($modules, $is_syncing) {
+
+  // Rebuild bundle field map when modules are installed.
+  \Drupal::service('entity_field.manager')->rebuildBundleFieldMap();
+}
+
+/**
+ * Implements hook_modules_uninstalled().
+ */
+function farm_entity_modules_uninstalled($modules, $is_syncing) {
+
+  // Rebuild bundle field map when modules are uninstalled.
+  \Drupal::service('entity_field.manager')->rebuildBundleFieldMap();
+}
+
+/**
  * Implements hook_module_implements_alter().
  */
 function farm_entity_module_implements_alter(&$implementations, $hook) {

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -15,3 +15,10 @@ function farm_entity_post_update_enforce_plan_eri(&$sandbox) {
   $config->set('enabled_entity_type_ids', $entity_types);
   $config->save();
 }
+
+/**
+ * Rebuild bundle field maps.
+ */
+function farm_entity_post_update_rebuild_bundle_field_maps(&$sandbox = NULL) {
+  \Drupal::service('entity_field.manager')->rebuildBundleFieldMap();
+}

--- a/modules/core/entity/tests/modules/farm_entity_bundle_fields_test/config/install/plan.type.second.yml
+++ b/modules/core/entity/tests/modules/farm_entity_bundle_fields_test/config/install/plan.type.second.yml
@@ -1,6 +1,9 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - farm_entity_bundle_fields_test
 id: second
 label: Second
 description: ''

--- a/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
@@ -77,9 +77,10 @@ class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
     $result = $this->moduleInstaller->install(['farm_entity_contrib_test']);
     $this->assertTrue($result);
 
-    // Reload the entity field map.
-    $this->entityFieldManager->setFieldMap([]);
-    \Drupal::service('cache.discovery')->delete('entity_field_map');
+    // Reload the entity field map. We need to get a new instance of the
+    // entity_field.manager service from the container without old state.
+    $this->container->set('entity_field.manager', NULL);
+    $this->entityFieldManager = $this->container->get('entity_field.manager');
     $field_map = $this->entityFieldManager->getFieldMap();
 
     // Confirm that the 'test_contrib_hook_bundle_field' exists in the log field
@@ -92,9 +93,10 @@ class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
     $result = $this->moduleInstaller->uninstall(['farm_entity_contrib_test']);
     $this->assertTrue($result);
 
-    // Reload the entity field map.
-    $this->entityFieldManager->setFieldMap([]);
-    \Drupal::service('cache.discovery')->delete('entity_field_map');
+    // Reload the entity field map. We need to get a new instance of the
+    // entity_field.manager service from the container without old state.
+    $this->container->set('entity_field.manager', NULL);
+    $this->entityFieldManager = $this->container->get('entity_field.manager');
     $field_map = $this->entityFieldManager->getFieldMap();
 
     // Confirm that the 'test_contrib_hook_bundle_field' no longer exists in the


### PR DESCRIPTION
This fixes [Issue #3314741: EntityFieldManager::getFieldMap() doesn't show farmOS bundle fields](https://www.drupal.org/project/farm/issues/3314741).

This PR replaces an earlier one that targeted the 2.x branch of farmOS: #583

It also greatly simplifies the changes by leveraging a patch to Drupal core (thanks for finding this @paul121! :raised_hands:):

- [Issue #3129179: Provide some way to rebuild the persistent bundle field map](https://www.drupal.org/project/drupal/issues/3129179).

The patch adds a new method to Drupal core's `entity_field.manager` service, which provides a way to rebuild the bundle field map:

`\Drupal::service('entity_field.manager')->rebuildBundleFieldMap();`

However, the patch itself does not call this method when new modules are installed/uninstalled, so it does not fix [#3314741](https://www.drupal.org/project/farm/issues/3314741) by itself, so this PR also adds simple implementations of `hook_modules_installed()` and `hook_modules_uninstalled()` which run the method. This serves to ensure bundle fields are correctly added to (or removed from) the field map when a module that provides them is installed/uninstalled.

An update hook is also provided that runs the same method. This serves to ensure that any bundle fields that were installed previously (and are currently broken) are correctly represented in the field map.

I copied the functional test that I wrote for #583 to add test coverage and tests are passing.

One other notable difference from #583 is that this PR is NOT changing the `quick` or `equipment` fields to base fields. We may still want to consider doing that, but there are other considerations there, and they don't need to block this fix.