### PR TITLE
Update drupal/consumers to ^1.19 and fix tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Update drupal/consumers to ^1.19 and fix kernel API tests](https://github.com/farmOS/farmOS/pull/857)
+
 ## [3.2.3] 2024-07-21
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/admin_toolbar": "^3.3",
         "drupal/core": "10.2.7",
         "drupal/config_update": "^2.0@alpha",
-        "drupal/consumers": "^1.15",
+        "drupal/consumers": "^1.19",
         "drupal/csv_serialization": "^4.0",
         "drupal/date_popup": "^1.3",
         "drupal/entity": "1.4",

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -56,6 +56,7 @@ class FarmApiTest extends KernelTestBase {
    */
   public function setUp(): void {
     parent::setUp();
+    $this->installEntitySchema('consumer');
     $this->installEntitySchema('asset');
     $this->installEntitySchema('log');
     $this->installConfig([


### PR DESCRIPTION
`drupal/consumers ` includes a change in 1.18 to fix the cacheability of responses for consumers: https://www.drupal.org/project/consumers/issues/3001043

The first implementation didn't catch the scenario where there are no consumer entities and thus not a single "default" consumer entity, causing it to crash page responses. This fixed in 1.19 via https://www.drupal.org/project/consumers/issues/3463248

After these changes we need to update our API kernel tests to install the consumer entity schema so that the consumers module can attempt to load consumers from the DB.