### PR TITLE
Move farm_quantity View to farm_log_quantities and require log relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Update Drupal core to 10.3 #872](https://github.com/farmOS/farmOS/pull/872)
+- [Move farm_quantity View to farm_log_quantities and require log relationship #858](https://github.com/farmOS/farmOS/pull/858)
 
 ### Security
 

--- a/modules/core/ui/views/config/install/views.view.farm_log_quantity.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log_quantity.yml
@@ -18,8 +18,8 @@ dependencies:
   enforced:
     module:
       - farm_ui_views
-id: farm_quantity
-label: 'Farm Quantities'
+id: farm_log_quantity
+label: 'Farm Log Quantities'
 module: views
 description: ''
 tag: ''
@@ -32,7 +32,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: Quantities
+      title: 'Log Quantities'
       fields:
         id:
           id: id
@@ -1527,7 +1527,7 @@ display:
           admin_label: Log
           entity_type: quantity
           plugin_id: entity_reverse
-          required: false
+          required: true
       header: {  }
       footer:
         result:
@@ -1603,7 +1603,7 @@ display:
       tags: {  }
   page:
     id: page
-    display_title: 'All quantities (page)'
+    display_title: 'All log quantities (page)'
     display_plugin: page
     position: 1
     display_options:
@@ -1635,12 +1635,12 @@ display:
       display_extenders:
         collapsible_filter:
           collapsible: true
-      path: quantities
+      path: log-quantities
       menu:
         type: normal
-        title: Quantities
+        title: 'Log Quantities'
         description: ''
-        weight: 0
+        weight: 10
         expanded: true
         menu_name: admin
         parent: farm.records
@@ -1735,7 +1735,7 @@ display:
       display_extenders:
         collapsible_filter:
           collapsible: true
-      path: quantities/%
+      path: log-quantities/%
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/core/ui/views/farm_ui_views.links.menu.yml
+++ b/modules/core/ui/views/farm_ui_views.links.menu.yml
@@ -13,7 +13,7 @@ farm.plan.type:
 farm.quantity.type:
   class: Drupal\Core\Menu\MenuLinkDefault
   deriver: Drupal\farm_ui_views\Plugin\Derivative\FarmQuantityViewsMenuLink
-  parent: views_view:views.farm_quantity.page
+  parent: views_view:views.farm_log_quantity.page
 farm.people:
   title: People
   parent: farm.base

--- a/modules/core/ui/views/farm_ui_views.module
+++ b/modules/core/ui/views/farm_ui_views.module
@@ -21,7 +21,7 @@ function farm_ui_views_help($route_name, RouteMatchInterface $route_match) {
   $entity_routes = [
     'asset' => 'entity.asset.collection',
     'log' => 'entity.log.collection',
-    'quantity' => 'view.farm_quantity.page',
+    'quantity' => 'view.farm_log_quantity.page',
     'people' => 'view.farm_people.page',
   ];
   $entity_urls = [

--- a/modules/core/ui/views/farm_ui_views.post_update.php
+++ b/modules/core/ui/views/farm_ui_views.post_update.php
@@ -5,6 +5,8 @@
  * Post update functions for farm_ui_views module.
  */
 
+use Drupal\views\Entity\View;
+
 /**
  * Enable collapsible_filter views display extender.
  */
@@ -29,4 +31,16 @@ function farm_ui_views_post_update_install_farm_export_csv(&$sandbox) {
   if (!\Drupal::service('module_handler')->moduleExists('farm_export_csv')) {
     \Drupal::service('module_installer')->install(['farm_export_csv']);
   }
+}
+
+/**
+ * Move farm_quantity View to farm_log_quantity.
+ */
+function farm_ui_views_post_update_farm_log_quantity(&$sandbox) {
+  $view = View::load('farm_quantity');
+  if (empty($view)) {
+    return;
+  }
+  $view->set('id', 'farm_log_quantity');
+  $view->save();
 }

--- a/modules/core/ui/views/farm_ui_views.routing.yml
+++ b/modules/core/ui/views/farm_ui_views.routing.yml
@@ -1,0 +1,7 @@
+farm_ui_views.quantities_redirect:
+  path: '/quantities'
+  defaults:
+    _controller: \Drupal\farm_ui_views\Controller\RedirectController::quantities
+  requirements:
+    # This controller redirects to a View, where access will be checked.
+    _access: 'TRUE'

--- a/modules/core/ui/views/src/Controller/RedirectController.php
+++ b/modules/core/ui/views/src/Controller/RedirectController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\farm_ui_views\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Redirect controller.
+ *
+ * @ingroup farm
+ */
+class RedirectController extends ControllerBase {
+
+  /**
+   * Redirect /quantities to /log-quantities.
+   *
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   Returns a Symfony redirect response.
+   */
+  public function quantities(): RedirectResponse {
+    return new RedirectResponse(Url::fromRoute('view.farm_log_quantity.page')->toString());
+  }
+
+}

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmAssetViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmAssetViewsMenuLink.php
@@ -12,4 +12,9 @@ class FarmAssetViewsMenuLink extends FarmViewsMenuLink {
    */
   protected string $entityType = 'asset';
 
+  /**
+   * {@inheritdoc}
+   */
+  protected string $viewId = 'farm_asset';
+
 }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsMenuLink.php
@@ -12,4 +12,9 @@ class FarmLogViewsMenuLink extends FarmViewsMenuLink {
    */
   protected string $entityType = 'log';
 
+  /**
+   * {@inheritdoc}
+   */
+  protected string $viewId = 'farm_log';
+
 }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmPlanViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmPlanViewsMenuLink.php
@@ -12,4 +12,9 @@ class FarmPlanViewsMenuLink extends FarmViewsMenuLink {
    */
   protected string $entityType = 'plan';
 
+  /**
+   * {@inheritdoc}
+   */
+  protected string $viewId = 'farm_plan';
+
 }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmQuantityViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmQuantityViewsMenuLink.php
@@ -15,6 +15,6 @@ class FarmQuantityViewsMenuLink extends FarmViewsMenuLink {
   /**
    * {@inheritdoc}
    */
-  protected string $viewId = 'farm_quantity';
+  protected string $viewId = 'farm_log_quantity';
 
 }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmQuantityViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmQuantityViewsMenuLink.php
@@ -12,4 +12,9 @@ class FarmQuantityViewsMenuLink extends FarmViewsMenuLink {
    */
   protected string $entityType = 'quantity';
 
+  /**
+   * {@inheritdoc}
+   */
+  protected string $viewId = 'farm_quantity';
+
 }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
@@ -27,6 +27,18 @@ class FarmViewsMenuLink extends ViewsMenuLink {
   protected string $entityType;
 
   /**
+   * Specify the View ID. This should be set in child classes.
+   *
+   * @var string
+   *
+   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmAssetViewsMenuLink
+   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmLogViewsMenuLink
+   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmPlanViewsMenuLink
+   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmQuantityViewsMenuLink
+   */
+  protected string $viewId;
+
+  /**
    * The entity type manager service.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -78,8 +90,8 @@ class FarmViewsMenuLink extends ViewsMenuLink {
     foreach ($bundles as $type => $bundle) {
       $links['farm.' . $this->entityType . '.' . $type] = [
         'title' => $bundle->label(),
-        'parent' => 'views_view:views.farm_' . $this->entityType . '.page',
-        'route_name' => 'view.farm_' . $this->entityType . '.page_type',
+        'parent' => 'views_view:views.' . $this->viewId . '.page',
+        'route_name' => 'view.' . $this->viewId . '.page_type',
         'route_parameters' => ['arg_0' => $type],
       ] + $base_plugin_definition;
     }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
@@ -15,12 +15,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class FarmViewsMenuLink extends ViewsMenuLink {
 
   /**
-   * Set this in child classes.
+   * Specify the entity type ID. This should be set in child classes.
    *
    * @var string
    *
    * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmAssetViewsMenuLink
    * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmLogViewsMenuLink
+   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmPlanViewsMenuLink
    * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmQuantityViewsMenuLink
    */
   protected string $entityType;

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
@@ -18,11 +18,6 @@ class FarmViewsMenuLink extends ViewsMenuLink {
    * Specify the entity type ID. This should be set in child classes.
    *
    * @var string
-   *
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmAssetViewsMenuLink
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmLogViewsMenuLink
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmPlanViewsMenuLink
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmQuantityViewsMenuLink
    */
   protected string $entityType;
 
@@ -30,11 +25,6 @@ class FarmViewsMenuLink extends ViewsMenuLink {
    * Specify the View ID. This should be set in child classes.
    *
    * @var string
-   *
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmAssetViewsMenuLink
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmLogViewsMenuLink
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmPlanViewsMenuLink
-   * @see \Drupal\farm_ui_views\Plugin\Derivative\FarmQuantityViewsMenuLink
    */
   protected string $viewId;
 


### PR DESCRIPTION
As discussed on the dev call yesterday, this PR moves the `farm_quantity` View to `farm_log_quantity` and makes the `log` relationship required. This serves to make this a View of "Log Quantities" specifically, instead of "Quantities" generally. This was implicitly true before, because the View joins in data from the `log` entities that reference the `quantity` entities, and adds log-specific columns and filters to the View. So it has always been specific to Log Quantities.

And while we don't have any plans in farmOS core to associate quantities with other entities, it's possible that downstream modules may do that. And if they do, then currently their quantities would appear in this View, but would have empty columns because they are not associated with logs. So this PR is mostly a defensive change to avoid potential issues in those cases, by making the intention of this View more explicit.

We also talked on the dev call about possible ways to create a general Quantities View that joined in ANY entity that references them, but there are some tricky technical questions/hurdles there. So this is a simple first step that at least avoids problems in the short term.

Notably, this also helps with (but doesn't solve) #775, by ensuring that orphaned quantities will not appear in the View anymore.