### PR TITLE
When a quantity is deleted, clean up log references to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Update drupal/consumers to ^1.19 and fix kernel API tests](https://github.com/farmOS/farmOS/pull/857)
+- [When a quantity is deleted, clean up log references to it #859](https://github.com/farmOS/farmOS/pull/859)
 
 ## [3.2.3] 2024-07-21
 

--- a/modules/core/log/modules/quantity/farm_log_quantity.services.yml
+++ b/modules/core/log/modules/quantity/farm_log_quantity.services.yml
@@ -1,6 +1,6 @@
 services:
-  farm_log_quantity.log_delete:
-    class: Drupal\farm_log_quantity\EventSubscriber\LogEventSubscriber
+  farm_log_quantity.event_subscriber:
+    class: Drupal\farm_log_quantity\EventSubscriber\LogQuantityEventSubscriber
     arguments:
       [ '@entity_type.manager' ]
     tags:

--- a/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
+++ b/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
@@ -7,9 +7,9 @@ use Drupal\log\Event\LogEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Perform actions on log presave.
+ * Subscribe to events related to log quantities.
  */
-class LogEventSubscriber implements EventSubscriberInterface {
+class LogQuantityEventSubscriber implements EventSubscriberInterface {
 
   /**
    * Entity type manager.
@@ -70,7 +70,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
    * Perform actions on log delete.
    *
    * @param \Drupal\log\Event\LogEvent $event
-   *   Config crud event.
+   *   The log event.
    */
   public function logDelete(LogEvent $event) {
 

--- a/modules/core/log/modules/quantity/tests/modules/farm_log_quantity_test/config/install/log.type.test.yml
+++ b/modules/core/log/modules/quantity/tests/modules/farm_log_quantity_test/config/install/log.type.test.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+id: test
+label: Test
+description: ''
+name_pattern: 'Test log [log:id]'
+workflow: log_default
+new_revision: true

--- a/modules/core/log/modules/quantity/tests/modules/farm_log_quantity_test/config/install/quantity.type.test.yml
+++ b/modules/core/log/modules/quantity/tests/modules/farm_log_quantity_test/config/install/quantity.type.test.yml
@@ -1,0 +1,6 @@
+langcode: en
+status: true
+id: test
+label: Test
+description: 'Test quantity type.'
+new_revision: true

--- a/modules/core/log/modules/quantity/tests/modules/farm_log_quantity_test/farm_log_quantity_test.info.yml
+++ b/modules/core/log/modules/quantity/tests/modules/farm_log_quantity_test/farm_log_quantity_test.info.yml
@@ -1,0 +1,7 @@
+name: farmOS Log Quantity Tests
+description: 'Support module for log quantity testing.'
+type: module
+package: Testing
+core_version_requirement: ^10
+dependencies:
+  - farm:farm_log_quantity

--- a/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
+++ b/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Drupal\Tests\farm_log_quantity\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\log\Entity\Log;
+use Drupal\log\Event\LogEvent;
+use Drupal\quantity\Entity\Quantity;
+
+/**
+ * Tests for farmOS log quantity module.
+ *
+ * @group farm
+ */
+class LogQuantityTest extends KernelTestBase {
+
+  /**
+   * The log storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $logStorage;
+
+  /**
+   * The quantity storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $quantityStorage;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'entity_reference_revisions',
+    'log',
+    'farm_field',
+    'farm_log_quantity',
+    'farm_log_quantity_test',
+    'farm_unit',
+    'fraction',
+    'options',
+    'quantity',
+    'state_machine',
+    'taxonomy',
+    'text',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('log');
+    $this->installEntitySchema('quantity');
+    $this->installEntitySchema('taxonomy_term');
+    $this->installEntitySchema('user');
+    $this->installConfig([
+      'farm_log_quantity_test',
+      'farm_unit',
+    ]);
+    $this->logStorage = \Drupal::entityTypeManager()->getStorage('log');
+    $this->quantityStorage = \Drupal::entityTypeManager()->getStorage('quantity');
+  }
+
+  /**
+   * Test log quantity events.
+   */
+  public function testLogQuantityEvents() {
+
+    // Create a test log with a test quantity.
+    $quantity = Quantity::create([
+      'type' => 'test',
+      'value' => 1,
+    ]);
+    $quantity->save();
+    $log = Log::create([
+      'type' => 'test',
+      'quantity' => [
+        [
+          'target_id' => $quantity->id(),
+        ],
+      ],
+    ]);
+    $log->save();
+
+    // Test that cloning a log clones its quantities.
+    // This replicates the logic for cloning logs from
+    // \Drupal\log\Form\LogCloneActionForm::submitForm().
+    $cloned_log = $log->createDuplicate();
+    $event = new LogEvent($cloned_log);
+    \Drupal::service('event_dispatcher')->dispatch($event, LogEvent::CLONE);
+    $event->log->save();
+    $logs = $this->logStorage->loadMultiple();
+    $quantities = $this->quantityStorage->loadMultiple();
+    $this->assertCount(2, $logs);
+    $this->assertCount(2, $quantities);
+    $this->assertEquals($quantities[1]->get('value')->value, $quantities[2]->get('value')->value);
+
+    // Test that deleting a log deletes its quantities.
+    $logs[2]->delete();
+    $logs = $this->logStorage->loadMultiple();
+    $quantities = $this->quantityStorage->loadMultiple();
+    $this->assertCount(1, $logs);
+    $this->assertCount(1, $quantities);
+  }
+
+}

--- a/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
+++ b/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
@@ -104,6 +104,11 @@ class LogQuantityTest extends KernelTestBase {
     $quantities = $this->quantityStorage->loadMultiple();
     $this->assertCount(1, $logs);
     $this->assertCount(1, $quantities);
+
+    // Test that deleting a quantity cleans up the log's reference to it.
+    $quantity->delete();
+    $logs = $this->logStorage->loadMultiple();
+    $this->assertEmpty($logs[1]->get('quantity')->getValue());
   }
 
 }


### PR DESCRIPTION
Currently, the [Entity Reference Integrity](https://www.drupal.org/project/entity_reference_integrity) module prevents entities from being deleted if they are referenced by other entities. This does NOT currently protect `quantity` entities, however, because `entity_reference_integrity` only works with `entity_reference` fields, but logs reference quantities via an `entity_reference_revisions` field.

This means that when a quantity is deleted, references to it in the `quantity` field on `log` entities do not get cleaned up.

This PR takes the approach of adding an event subscriber that will clean up those references on `log` entities when a quantity is deleted. This serves to solve both problems, and also enables us to add a "Bulk delete" action for quantities as a next step (this will be a separate PR).

This is done in the `farm_log_quantity` module's event subscriber, so the logic is contained within the same module that adds the `quantity` field to `log` entities in the first place. Notably, this module also provides event subscriber logic for cloning quantities when logs are cloned, and deleting quantities when a log is deleted. We didn't have automated tests for these subscribers, so I added some, in addition to a new test for this PR's logic.