### PR TITLE
Add bulk delete action to farm_log_quantity View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add bulk delete action to farm_log_quantity View #860](https://github.com/farmOS/farmOS/pull/860)
+
 ### Changed
 
 - [Update Drupal core to 10.3 #872](https://github.com/farmOS/farmOS/pull/872)

--- a/modules/core/quantity/config/optional/system.action.quantity_delete_action.yml
+++ b/modules/core/quantity/config/optional/system.action.quantity_delete_action.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - quantity
+id: quantity_delete_action
+label: 'Delete quantity'
+type: quantity
+plugin: entity:delete_action:quantity
+configuration: {  }

--- a/modules/core/quantity/quantity.post_update.php
+++ b/modules/core/quantity/quantity.post_update.php
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Entity\Entity\EntityViewMode;
+use Drupal\system\Entity\Action;
 
 /**
  * Create plain text view mode for quantities.
@@ -28,4 +29,23 @@ function quantity_post_update_plain_text_view_mode(&$sandbox) {
     ],
   ]);
   $view_mode->save();
+}
+
+/**
+ * Create quantity delete action.
+ */
+function quantity_post_update_delete_action(&$sandbox) {
+  $action = Action::create([
+    'id' => 'quantity_delete_action',
+    'label' => t('Delete quantity'),
+    'type' => 'quantity',
+    'plugin' => 'entity:delete_action:quantity',
+    'configuration' => [],
+    'dependencies' => [
+      'module' => [
+        'quantity',
+      ],
+    ],
+  ]);
+  $action->save();
 }

--- a/modules/core/quantity/src/Entity/Quantity.php
+++ b/modules/core/quantity/src/Entity/Quantity.php
@@ -64,6 +64,9 @@ use Drupal\user\EntityOwnerTrait;
  *   },
  *   bundle_entity_type = "quantity_type",
  *   common_reference_target = TRUE,
+ *   links = {
+ *     "delete-multiple-form" = "/quantity/delete",
+ *   },
  *   revision_metadata_keys = {
  *     "revision_user" = "revision_user",
  *     "revision_created" = "revision_created",

--- a/modules/core/ui/views/config/install/views.view.farm_log_quantity.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log_quantity.yml
@@ -34,6 +34,59 @@ display:
     display_options:
       title: 'Log Quantities'
       fields:
+        quantity_bulk_form:
+          id: quantity_bulk_form
+          table: quantity
+          field: quantity_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: quantity
+          plugin_id: bulk_form
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
         id:
           id: id
           table: quantity


### PR DESCRIPTION
This PR adds a "Delete" action for quantity entities, and adds a "Bulk update" column to the `farm_log_quantity` View, allowing users to delete quantities in bulk across multiple logs.

Note that this PR builds on top of #858 (so that needs to be merged first). We should also merge #859 before this, to ensure references to deleted quantities are cleaned up.

This is also a pre-step towards adding a new "Export CSV" bulk action to the `farm_log_quantity` View. We need to add the "Bulk update" column to the `farm_log_quantity` View in order for that new "Export CSV" action to show up (without explicitly depending on the `farm_export_csv` module), but the Drupal core Views module does not make a "Bulk update" column available unless there are bulk actions available for the entity type. Right now, `quantity` entities do not have any bulk actions available. So by adding a "delete" action, we both get a new feature (ability to delete quantities in bulk), and we make it easier to add new actions in next steps.