### PR TITLE
Build multi-platform Docker images/manifests

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -16,10 +16,30 @@ env:
   DOCKER_IMG_PREFIX: farmos/farmos
 
 jobs:
+
   build:
     name: Build Docker images
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+         - amd64
+         - arm32v7
+         - arm64v8
+        include:
+          - platform: amd64
+            DOCKER_PLATFORM_NAME: linux/amd64
+          - platform: arm32v7
+            DOCKER_PLATFORM_NAME: linux/arm/v7
+          - platform: arm64v8
+            DOCKER_PLATFORM_NAME: linux/arm64/v8
     steps:
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Set default FARMOS_REPO and FARMOS_VERSION
@@ -37,51 +57,60 @@ jobs:
         run: |
           echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
           echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+      # This builds the production/dev Docker images using the specified FARMOS_VERSION,
+      # but notably it does NOT override the default PROJECT_VERSION, so the
+      # farmOS Composer project 3.x branch is always used.
       - name: Build and save the farmOS Docker image
         run: |
-          docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t $DOCKER_IMG_PREFIX:3.x docker
-          docker save $DOCKER_IMG_PREFIX:3.x > /tmp/farmos.tar
+          COMMON_BUILD_ARGS="--load --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --platform ${{ matrix.DOCKER_PLATFORM_NAME }}"
+          PROD_IMG_NAME=$DOCKER_IMG_PREFIX:3.x-${{ matrix.platform }}
+          DEV_IMG_NAME=$DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }}
+          docker buildx build $COMMON_BUILD_ARGS -t $PROD_IMG_NAME docker
+          docker buildx build $COMMON_BUILD_ARGS -t $DEV_IMG_NAME --target dev docker
+          docker save $PROD_IMG_NAME > /tmp/farmos-${{ matrix.platform }}.tar
+          docker save $DEV_IMG_NAME > /tmp/farmos-dev-${{ matrix.platform }}.tar
       - name: Cache the farmOS Docker image
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos.tar
-          key: farmos-${{ github.run_id }}
-      # This builds the dev Docker image using the specified FARMOS_VERSION,
-      # but notably it does NOT override the default PROJECT_VERSION, so the
-      # farmOS Composer project 3.x branch is always used.
-      - name: Build and save the farmOS dev Docker image
-        run: |
-          docker build --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} -t $DOCKER_IMG_PREFIX:3.x-dev --target dev docker
-          docker save $DOCKER_IMG_PREFIX:3.x-dev > /tmp/farmos-dev.tar
+          path: /tmp/farmos-${{ matrix.platform }}.tar
+          key: farmos-${{ matrix.platform }}-${{ github.run_id }}
       - name: Cache the farmOS dev Docker image
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev.tar
-          key: farmos-dev-${{ github.run_id }}
+          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
+          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
     outputs:
       farmos_version: ${{ env.FARMOS_VERSION }}
+
   sniff:
     name: Run PHP Codesniffer and PHPStan
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      matrix:
+        platform:
+        # The PHP code we're scanning is the same for all platforms so scan the copy
+        # from the amd64 Docker image since that one will start up fastest
+         - amd64
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev.tar
-          key: farmos-dev-${{ github.run_id }}
+          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
+          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
       - name: Load the Docker dev image
-        run: docker load < /tmp/farmos-dev.tar
+        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
       - name: Run PHP CodeSniffer
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev phpcs /opt/drupal/web/profiles/farm
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs /opt/drupal/web/profiles/farm
       - name: Run PHPStan
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings)
         run: |
-          docker run $DOCKER_IMG_PREFIX:3.x-dev phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules
-          docker run $DOCKER_IMG_PREFIX:3.x-dev phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/themes
+          docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules
+          docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/themes
+
   test:
     name: Run PHPUnit tests
     runs-on: ubuntu-latest
@@ -92,6 +121,8 @@ jobs:
          - pgsql
          - mariadb
          - sqlite
+        platform:
+         - amd64
         include:
           - dbms: pgsql
             DB_URL: pgsql://farm:farm@db/farm
@@ -104,16 +135,19 @@ jobs:
             processes: 1
     steps:
       - name: Print test matrix variables
-        run: echo "matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
+        run: echo "matrix.platform=${{ matrix.platform }}, matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev.tar
-          key: farmos-dev-${{ github.run_id }}
+          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
+          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
       - name: Load the Docker dev image
-        run: docker load < /tmp/farmos-dev.tar
+        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
       # Build a new docker-compose.yml file from docker-compose.testing.common + docker-compose.testing.{dbms}.yml.
       # Copy to the current directory so that farmOS volume mounts don't change to the docker/www folder.
       - name: Create docker-compose.yml
@@ -123,7 +157,7 @@ jobs:
           cp docker/docker-compose.testing.* .
           docker compose -f docker-compose.testing.common.yml -f docker-compose.testing.${{ matrix.dbms }}.yml config > docker-compose.yml
           # Replace the generic 'farmos/farmos:3.x-dev' image name/tag with the reference to our local platform-specific tagged image
-          sed -i 's%farmos/farmos:3.x-dev%'$DOCKER_IMG_PREFIX:3.x-dev'%g' docker-compose.yml
+          sed -i 's%farmos/farmos:3.x-dev%'$DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }}'%g' docker-compose.yml
       - name: Start containers
         run: docker compose up -d
       - name: Wait until www container is ready
@@ -138,6 +172,7 @@ jobs:
         run: docker compose exec -u www-data -T www paratest -vv --processes=${{ matrix.processes }} /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules
         run: docker compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'
+
   release:
     name: Create release
     # We only create a release if this is a tag push event to the official
@@ -148,18 +183,24 @@ jobs:
       - build
       - sniff
       - test
+    strategy:
+      matrix:
+        platform:
+        # The .tar.gz with the farmOS PHP code is the same for all platforms so we just publish the copy
+        # from the amd64 Docker image since that one will start up fastest
+         - amd64
     steps:
       - name: Set FARMOS_VERSION from previous output
         run: echo "FARMOS_VERSION=${{ needs.build.outputs.farmos_version }}" >> $GITHUB_ENV
       - name: Restore the farmOS Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos.tar
-          key: farmos-${{ github.run_id }}
+          path: /tmp/farmos-${{ matrix.platform }}.tar
+          key: farmos-${{ matrix.platform }}-${{ github.run_id }}
       - name: Load the Docker image
-        run: docker load < /tmp/farmos.tar
+        run: docker load < /tmp/farmos-${{ matrix.platform }}.tar
       - name: Run the farmOS Docker container
-        run: docker run --rm -v /tmp/farmOS:/opt/drupal $DOCKER_IMG_PREFIX:3.x true
+        run: docker run --rm -v /tmp/farmOS:/opt/drupal $DOCKER_IMG_PREFIX:3.x-${{ matrix.platform }} true
       - name: Create artifact
         run: cd /tmp && tar -czf farmOS-${FARMOS_VERSION}.tar.gz farmOS
       - name: Create GitHub release
@@ -170,7 +211,8 @@ jobs:
           files: /tmp/farmOS-${{ env.FARMOS_VERSION }}.tar.gz
           draft: false
           prerelease: false
-  publish:
+
+  publish-multi-arch-images:
     name: Publish to Docker Hub
     # We only publish to Docker Hub if this is a tag or 3.x branch push event
     # to the official repository.
@@ -180,23 +222,29 @@ jobs:
       - build
       - sniff
       - test
+    strategy:
+      matrix:
+        platform:
+         - amd64
+         - arm32v7
+         - arm64v8
     steps:
       - name: Set FARMOS_VERSION from previous output
         run: echo "FARMOS_VERSION=${{ needs.build.outputs.farmos_version }}" >> $GITHUB_ENV
       - name: Restore the farmOS Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos.tar
-          key: farmos-${{ github.run_id }}
-      - name: Load the Docker image
-        run: docker load < /tmp/farmos.tar
+          path: /tmp/farmos-${{ matrix.platform }}.tar
+          key: farmos-${{ matrix.platform }}-${{ github.run_id }}
+      - name: Load the farmOS Docker image
+        run: docker load < /tmp/farmos-${{ matrix.platform }}.tar
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev.tar
-          key: farmos-dev-${{ github.run_id }}
-      - name: Load the Docker dev image
-        run: docker load < /tmp/farmos-dev.tar
+          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
+          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+      - name: Load the farmOS dev Docker image
+        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -205,48 +253,90 @@ jobs:
       # If the 3.x branch was pushed...
       - name: Publish the farmOS image to Docker Hub
         if: github.ref_type == 'branch' && env.FARMOS_VERSION == '3.x'
-        run: docker push $DOCKER_IMG_PREFIX:3.x
+        run: docker push $DOCKER_IMG_PREFIX:3.x-${{ matrix.platform }}
       - name: Publish the farmOS dev Docker image to Docker Hub
         if: github.ref_type == 'branch' && env.FARMOS_VERSION == '3.x'
-        run: docker push $DOCKER_IMG_PREFIX:3.x-dev
+        run: docker push $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }}
       # If a tag was pushed, tag the Docker image and push to Docker Hub.
       # If the tag is a valid semantic versioning string, also tag "latest".
       # Semver regex from https://github.com/semver/semver/issues/199#issuecomment-43640395
-      # If "latest" is tagged, we will also announce the release in a followup job.
       - name: Tag and publish {DOCKER_IMG_PREFIX}:{tag} image to Docker Hub
         if: github.ref_type == 'tag'
         run: |
-          docker tag $DOCKER_IMG_PREFIX:3.x $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}
-          docker push $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}
+          docker tag $DOCKER_IMG_PREFIX:3.x-${{ matrix.platform }} $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-${{ matrix.platform }}
+          docker push $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-${{ matrix.platform }}
           if echo ${{ env.FARMOS_VERSION }} | grep -Pq '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'; then
-            docker tag $DOCKER_IMG_PREFIX:3.x $DOCKER_IMG_PREFIX:latest
-            docker push $DOCKER_IMG_PREFIX:latest
+            docker tag $DOCKER_IMG_PREFIX:3.x-${{ matrix.platform }} $DOCKER_IMG_PREFIX:latest-${{ matrix.platform }}
+            docker push $DOCKER_IMG_PREFIX:latest-${{ matrix.platform }}
+          fi
+
+  publish-manifest:
+    name: Publish a multi-arch manifest to Docker Hub
+    # We only publish to Docker Hub if this is a tag or 3.x branch push event
+    # to the official repository.
+    if: github.repository == 'farmOS/farmOS' && github.event_name == 'push' && (github.ref_type == 'tag' || (github.ref_type == 'branch' && needs.build.outputs.farmos_version == '3.x'))
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - publish-multi-arch-images
+    steps:
+      - name: Set FARMOS_VERSION from previous output
+        run: echo "FARMOS_VERSION=${{ needs.build.outputs.farmos_version }}" >> $GITHUB_ENV
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      # If the 3.x branch was pushed...
+      - name: Create and publish the {DOCKER_IMG_PREFIX}:3.x manifest to Docker Hub
+        if: github.ref_type == 'branch' && env.FARMOS_VERSION == '3.x'
+        run: |
+          docker manifest create $DOCKER_IMG_PREFIX:3.x --amend $DOCKER_IMG_PREFIX:3.x-amd64 --amend $DOCKER_IMG_PREFIX:3.x-arm32v7 --amend $DOCKER_IMG_PREFIX:3.x-arm64v8
+          docker manifest push $DOCKER_IMG_PREFIX:3.x
+      - name: Create and publish the {DOCKER_IMG_PREFIX}:3.x-dev manifest to Docker Hub
+        if: github.ref_type == 'branch' && env.FARMOS_VERSION == '3.x'
+        run: |
+          docker manifest create $DOCKER_IMG_PREFIX:3.x-dev --amend $DOCKER_IMG_PREFIX:3.x-dev-amd64 --amend $DOCKER_IMG_PREFIX:3.x-dev-arm32v7 --amend $DOCKER_IMG_PREFIX:3.x-dev-arm64v8
+          docker manifest push $DOCKER_IMG_PREFIX:3.x-dev
+      # Same conditional logic as in the publish-multi-arch-images step, except here we
+      # are creating the multi-arch manifest pointing at the previously pushed image tags.
+      # If "latest" is tagged, we will also announce the release in a followup job.
+      - name: Create and publish the {DOCKER_IMG_PREFIX}:{tag} manifest to Docker Hub
+        if: github.ref_type == 'tag'
+        run: |
+          docker manifest create $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }} --amend $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-amd64 --amend $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-arm32v7 --amend $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-arm64v8
+          docker manifest push $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}
+          if echo ${{ env.FARMOS_VERSION }} | grep -Pq '^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'; then
+            docker manifest create $DOCKER_IMG_PREFIX:latest --amend $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-amd64 --amend $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-arm32v7 --amend $DOCKER_IMG_PREFIX:${{ env.FARMOS_VERSION }}-arm64v8
+            docker manifest push $DOCKER_IMG_PREFIX:latest
             echo "ANNOUNCE_RELEASE=1" >> $GITHUB_ENV
           else
             echo "ANNOUNCE_RELEASE=0" >> $GITHUB_ENV
           fi
     outputs:
       announce: ${{ env.ANNOUNCE_RELEASE }}
+
   announce-microblog:
     name: Announce new release on farmOS-microblog
-    if: needs.publish.outputs.announce
+    if: needs.publish-manifest.outputs.announce
     needs:
       - build
       - release
-      - publish
+      - publish-manifest
     uses: farmOS/farmOS-microblog/.github/workflows/create-message.yml@main
     with:
       message: '#farmOS ${{ needs.build.outputs.farmos_version }} has been released! https://github.com/farmOS/farmOS/releases/${{ needs.build.outputs.farmos_version }}'
     secrets:
       MICROBLOG_DEPLOY_KEY: ${{ secrets.MICROBLOG_DEPLOY_KEY }}
+
   announce-discourse:
     name: Announce new release on farmOS.discourse.group
-    if: needs.publish.outputs.announce
+    if: needs.publish-manifest.outputs.announce
     runs-on: ubuntu-latest
     needs:
       - build
       - release
-      - publish
+      - publish-manifest
     steps:
       - name: Discourse API request
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add geometry/location fields to CSV importers #815](https://github.com/farmOS/farmOS/pull/815)
 - [Add an asset.logs service for retrieving logs that reference an asset #850](https://github.com/farmOS/farmOS/pull/850)
 - [Add farmOS-timeline library (experimental) #862](https://github.com/farmOS/farmOS/pull/862)
+- [Build multi-platform Docker images/manifests #864](https://github.com/farmOS/farmOS/pull/864)
 
 ### Changed
 


### PR DESCRIPTION
The goal of this change is to make it trivial to run farmOS on the most common ARM architectures without the need for a local `docker build` step.

Unfortunately, the change is fairly involved in order to keep the caching and testing working the same way.

Ideally, we'd be able to do a single `docker buildx build --push --platform COMMA_SEPARATED_PLATFORMS_HERE --tag` command, but that wouldn't work for how we test pull requests and handle creating the various tags conditionally - in addition to making sure our test workflows run against the same images prior to actually pushing them to Docker hub.

Instead, we have to do the more manual strategy of using `docker buildx` to build/cache each platform's image individually, then only at the end do we create the final multi-architecture manifest.

The other thing that makes this change slightly larger is that the existing workflow hard-codes the Docker image name `farmos/farmos` so in order to test that has to be changed in many places. This change has moved that prefix into a variable so it can be changed in a single place to make verifying the changes easier.

References:

* https://www.docker.com/blog/multi-arch-build-and-images-the-simple-way/
* https://github.com/docker/setup-qemu-action
* https://github.com/docker/setup-buildx-action