### PR TITLE
Update drupal/entity to ^1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/consumers": "^1.19",
         "drupal/csv_serialization": "^4.0",
         "drupal/date_popup": "^1.3",
-        "drupal/entity": "1.4",
+        "drupal/entity": "1.5",
         "drupal/entity_browser": "^2.10",
         "drupal/entity_reference_integrity": "1.2",
         "drupal/entity_reference_revisions": "1.11",
@@ -65,7 +65,7 @@
                 "Issue #3129179: Provide some way to rebuild the persistent bundle field map": "https://www.drupal.org/files/issues/2024-07-17/3129179-49.patch"
             },
             "drupal/entity": {
-                "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2022-05-11/3206703-10.patch"
+                "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2024-08-30/3206703-12.patch"
             },
             "drupal/entity_reference_integrity": {
               "Issue #3418000: Delete action only overridden on first entity type": "https://www.drupal.org/files/issues/2024-01-30/3418000-3.patch"


### PR DESCRIPTION
The upstream Entity API module merged @paul121's patch: https://www.drupal.org/project/entity/issues/3190436

This was the only patch we were applying for this package, so this PR updates our version constraint to `^1.5` (unpinned) and removes the patch.