### PR TITLE
Allow modules to alter dashboard panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Add bulk delete action to farm_log_quantity View #860](https://github.com/farmOS/farmOS/pull/860)
 - [Add an "Export Quantity CSV" bulk action to Log Views](https://github.com/farmOS/farmOS/pull/861)
+- [Allow modules to alter dashboard panes #868](https://github.com/farmOS/farmOS/pull/868)
 
 ### Changed
 

--- a/modules/core/ui/dashboard/farm_ui_dashboard.api.php
+++ b/modules/core/ui/dashboard/farm_ui_dashboard.api.php
@@ -58,6 +58,21 @@ function hook_farm_dashboard_panes() {
 }
 
 /**
+ * Alter farm dashboard panes.
+ *
+ * @param array $panes
+ *   An array of farm dashboard pane configurations to alter.
+ */
+function hook_farm_dashboard_panes_alter(array &$panes) {
+  // Remove all panes not provide by my_module.
+  foreach (array_keys($panes) as $pane) {
+    if (!str_contains($pane, 'my_module')) {
+      unset($panes[$pane]);
+    }
+  }
+}
+
+/**
  * Defines farm dashboard groups.
  *
  * @return array

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -74,6 +74,7 @@ class DashboardController extends ControllerBase {
 
     // Ask modules for dashboard panes.
     $panes = $this->moduleHandler()->invokeAll('farm_dashboard_panes');
+    $this->moduleHandler()->alter('farm_dashboard_panes', $panes);
 
     // Add each pane to the dashboard.
     foreach ($panes as $id => $pane) {


### PR DESCRIPTION
Simple PR to invoke the alter hook for dashboard panes `hook_farm_dashboard_panes_alter(array &$panes)`.

The motivation for this PR is to provide an easy way for other modules to customize the dashboard, specifically the ability to remove dashboard panes provided by other modules, although this hook could be used to alter dashboard panes in many ways. https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/748