### PR TITLE
Do not strip html tags when encoding csv exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Update drupal/consumers to ^1.19 and fix kernel API tests](https://github.com/farmOS/farmOS/pull/857)
 - [When a quantity is deleted, clean up log references to it #859](https://github.com/farmOS/farmOS/pull/859)
 
+### Security
+
+- [Sanitize CSV exports against formula injection #871](https://github.com/farmOS/farmOS/pull/871)
+
 ## [3.2.3] 2024-07-21
 
 ### Fixed

--- a/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
@@ -21,9 +21,9 @@ class TextLongFieldItemNormalizer extends FieldItemNormalizer {
   public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
     /** @var \Drupal\text\Plugin\Field\FieldType\TextLongItem $field_item */
 
-    // Return processed text, if desired.
-    if (isset($context['processed_text']) && $context['processed_text'] === TRUE) {
-      return $field_item->get('processed')->getValue();
+    // Return raw text, if desired.
+    if (isset($context['raw_text']) && $context['raw_text'] === TRUE) {
+      return $field_item->get('value')->getValue();
     }
 
     // Delegate to the parent method.

--- a/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
@@ -21,9 +21,15 @@ class TextLongFieldItemNormalizer extends FieldItemNormalizer {
   public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
     /** @var \Drupal\text\Plugin\Field\FieldType\TextLongItem $field_item */
 
-    // Return raw text, if desired.
-    if (isset($context['raw_text']) && $context['raw_text'] === TRUE) {
-      return $field_item->get('value')->getValue();
+    // If processed_text is explicitly set, return processed or raw user input
+    // accordingly.
+    if (isset($context['processed_text'])) {
+      if ($context['processed_text']) {
+        return $field_item->get('processed')->getValue();
+      }
+      else {
+        return $field_item->get('value')->getValue();
+      }
     }
 
     // Delegate to the parent method.

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -319,6 +319,7 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       // CSV encoder settings.
       'csv_settings' => [
         'sanitize' => $form_state->getValue('sanitize'),
+        'strip_tags' => FALSE,
       ],
     ];
     $output = $this->serializer->serialize($accessible_entities, 'csv', $context);

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -306,8 +306,8 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       // Define the columns to include.
       'include_columns' => $form_state->getValue(['columns', 'include']),
 
-      // Return processed text from long text fields.
-      'processed_text' => TRUE,
+      // Return raw text from long text fields.
+      'raw_text' => TRUE,
 
       // Return content entity labels and config entity IDs.
       'content_entity_labels' => TRUE,

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -272,6 +272,14 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       '#title' => $this->t('Advanced'),
     ];
 
+    // Export unprocessed text.
+    $form['advanced']['processed_text'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Export processed text'),
+      '#description' => $this->t('Some long text fields can be passed through processing filters to remove disallowed HTML tags, convert line breaks into HTML, etc. This processing is disabled by default in CSV exports so that the raw user input is exported. Enable processing if you plan to embed CSV data directly in HTML documents.'),
+      '#default_value' => FALSE,
+    ];
+
     // Sanitize against CSV formula injection.
     $form['advanced']['sanitize'] = [
       '#type' => 'checkbox',
@@ -306,8 +314,9 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       // Define the columns to include.
       'include_columns' => $form_state->getValue(['columns', 'include']),
 
-      // Return raw text from long text fields.
-      'raw_text' => TRUE,
+      // Return processed text, if desired. Otherwise, raw user input will be
+      // exported.
+      'processed_text' => $form_state->getValue('processed_text'),
 
       // Return content entity labels and config entity IDs.
       'content_entity_labels' => TRUE,


### PR DESCRIPTION
This fixes the "notes text truncated in export" issue identified here: https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/733#issuecomment-2313106176

At first I thought it was truncating based on text length. Turns out it's actually because there is a single `<` in the notes text this is considered an "open" html tag that is never closed, and thus all text following the `<` gets truncated. Other special characters seem to work, it's just these html tags.

This also means that all valid or intentional HTML tags will get stripped from the export. This seems like a significant bug, too?

Turns out there is a simple fix, passing the `'strip_tags' = FALSE` option via `csv_settings` (it defaults to TRUE). However... this then means that the export is wrapped in HTML paragraphs by default, as documented by the default text format's help text:

> Lines and paragraphs break automatically.

![text_format](https://github.com/user-attachments/assets/952c2c65-917e-4dec-a4a3-5341025d8ae5)

### Example

Notes test
![notes](https://github.com/user-attachments/assets/bea83e53-1522-489a-94c8-1e33cf658717)


Strip tags = TRUE
![html_strip](https://github.com/user-attachments/assets/0cab88e9-0fa8-4371-b4ba-9678c50a6251)


Strip tags = FALSE
![keep_html](https://github.com/user-attachments/assets/98bc95bb-57a6-4fbf-991f-0d85ee922307)
