### PR TITLE
Simplify recommendation for XDEBUG_CONFIG in local development environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Single Dockerfile using multi-stages for production and dev image #855](https://github.com/farmOS/farmOS/pull/855)
+- [Simplify recommendation for XDEBUG_CONFIG in local development environments #870](https://github.com/farmOS/farmOS/pull/870)
 
 ### Fixed
 

--- a/docker/docker-compose.development.yml
+++ b/docker/docker-compose.development.yml
@@ -18,9 +18,11 @@ services:
       - './www:/opt/drupal'
     ports:
       - '80:80'
+    extra_hosts:
+      - host.docker.internal:host-gateway
     environment:
       XDEBUG_MODE: debug
-      XDEBUG_CONFIG: discover_client_host=yes
+      XDEBUG_CONFIG: client_host=host.docker.internal
       # Enable this for PHPStorm:
       #XDEBUG_SESSION: PHPSTORM
       #PHP_IDE_CONFIG: serverName=localhost

--- a/docs/development/environment/debug.md
+++ b/docs/development/environment/debug.md
@@ -4,55 +4,36 @@ The farmOS development Docker image comes pre-installed with
 [XDebug](https://xdebug.org) 3, which allows debugger connections on port 9003.
 
 XDebug can be configured to discover the client host automatically with the
-following environment variables in `docker-compose.yml`:
+following `extra_hosts` and `environment` configuration in `docker-compose.yml`:
 
+    extra_hosts:
+    - host.docker.internal:host-gateway
     environment:
       XDEBUG_MODE: debug
-      XDEBUG_CONFIG: discover_client_host=yes
+      XDEBUG_CONFIG: client_host=host.docker.internal
 
 ## PHPStorm
 
-If you are using the PHPStorm IDE, an additional `XDEBUG_SESSION: PHPSTORM`
-environment variable is necessary.
+If you are using the PHPStorm IDE, some additional environment variables are
+necessary:
+
+    XDEBUG_SESSION: PHPSTORM
+    PHP_IDE_CONFIG: serverName=localhost
 
 For example:
 
+    extra_hosts:
+    - host.docker.internal:host-gateway
     environment:
       XDEBUG_MODE: debug
-      XDEBUG_CONFIG: discover_client_host=yes
+      XDEBUG_CONFIG: client_host=host.docker.internal
       XDEBUG_SESSION: PHPSTORM
+      PHP_IDE_CONFIG: serverName=localhost
 
 With this configuration in place, enable the "Start listening for PHP Debug
 Connections" option. Add a breakpoint in your code, load the page in your
 browser, and you should see a prompt appear in PHPStorm that will begin the
 debugging session and pause execution at your breakpoint.
 
-### Drush + PHPStorm
-
-Debugging code that is run via [Drush](/development/environment/drush) commands
-requires additional configuration.
-
-The `discover_client_host=yes` configuration used above will not work when code
-is executed via the command line. The Docker host IP must be set explicitly.
-
-With the containers running, this command will print the gateway IP:
-
-    docker inspect farmos_www_1 | grep -o '"Gateway": ".*\..*\..*\..*"'
-
-Edit `docker-compose.yml` and set the `client_host` setting in the `XDEBUG_CONFIG`
-environment variable to the gateway IP.
-
-It is also necessary to add a `PHP_IDE_CONFIG` environment variable with a
-value of `serverName=localhost`.
-
-For example:
-
-    environment:
-      XDEBUG_MODE: debug
-      XDEBUG_CONFIG: client_host=192.168.128.1
-      XDEBUG_SESSION: PHPSTORM
-      PHP_IDE_CONFIG: serverName=localhost
-
-Run a `drush` command and a prompt should appear in PHPStorm. You will need to
-map the path to Drush (`vendor/drush`) in the PHPStorm debugger config. Then
-you can set breakpoints in the Drush code you want to test.
+This also works with command-line scripts like `drush`. You may need to map the
+path to Drush (`vendor/drush`) in the PHPStorm debugger config.


### PR DESCRIPTION
We currently provide some guidance on how to set up XDebug in local development environments: https://farmos.org/development/environment/debug/

For browser-based debugging, it works fine to set the `XDEBUG_CONFIG: discover_client_host=yes` environment variable, which tells XDebug to automatically figure out how to connect to a client host outside of the Docker container for debugging purposes. However, this does not work for debugging code that is run via command-line (eg: `drush`), so we provide additional guidance on how to find the IP address of the client host manually and set `XDEBUG_CONFIG: client_host=192.168.128.1`.

This is not ideal, because the `client_host` IP address changes whenever Docker containers are rebuilt (every time you run `docker compose down` and then `docker compose up` again).

Docker provides a `host.docker.internal` hostname that resolves to the host machine's IP address, but it is only available on Mac and Windows hosts, and not on Linux. So we haven't recommended that as a solution, and instead opted for documenting how to update the IP address manually (for consistency across platforms).

I recently learned that we can add this `extra_hosts` configuration to set `host.docker.internal` on Linux hosts:

```
extra_hosts:
  - host.docker.internal:host-gateway
```

Adding the above to our `docker-compose.development.yml` file allows us to use `XDEBUG_CONFIG: client_host=host.docker.internal` regardless of the host operating system, and thus our XDebug documentation can be simplified!