### PR TITLE
Sanitize CSV exports against formula injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Update Drupal core to 10.3 #872](https://github.com/farmOS/farmOS/pull/872)
 
+### Security
+
+- [Sanitize CSV exports against formula injection #871](https://github.com/farmOS/farmOS/pull/871)
+
 ## [3.2.4] 2024-09-18
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "drupal/core": "10.3.5",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.19",
-        "drupal/csv_serialization": "^4.0",
+        "drupal/csv_serialization": "^4.0.1",
         "drupal/date_popup": "^1.3",
         "drupal/entity": "1.5",
         "drupal/entity_browser": "^2.10",

--- a/modules/core/csv/farm_csv.services.yml
+++ b/modules/core/csv/farm_csv.services.yml
@@ -1,4 +1,8 @@
 services:
+  farm_csv.encoder.csv:
+    class: Drupal\farm_csv\Encoder\CsvEncoder
+    tags:
+      - { name: encoder, format: csv, priority: 10 }
   farm_csv.normalizer.content_entity_normalizer:
     class: Drupal\farm_csv\Normalizer\ContentEntityNormalizer
     tags:

--- a/modules/core/csv/src/Encoder/CsvEncoder.php
+++ b/modules/core/csv/src/Encoder/CsvEncoder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\farm_csv\Encoder;
+
+use Drupal\csv_serialization\Encoder\CsvEncoder as ContribCsvEncoder;
+
+/**
+ * Adds CSV encoder support for the Serialization API.
+ */
+class CsvEncoder extends ContribCsvEncoder {
+
+  /**
+   * Whether to sanitize cell values.
+   *
+   * @var bool
+   */
+  protected $sanitize = TRUE;
+
+  /**
+   * Constructs the class.
+   *
+   * @param string $delimiter
+   *   Indicates the character used to delimit fields. Defaults to ",".
+   * @param string $enclosure
+   *   Indicates the character used for field enclosure. Defaults to '"'.
+   * @param string $escape_char
+   *   Indicates the character used for escaping. Defaults to "\".
+   * @param bool $strip_tags
+   *   Whether to strip tags from values or not. Defaults to TRUE.
+   * @param bool $trim_values
+   *   Whether to trim values or not. Defaults to TRUE.
+   * @param bool $sanitize
+   *   Whether to sanitize values against formula injection. Defaults to TRUE.
+   */
+  public function __construct($delimiter = ",", $enclosure = '"', $escape_char = "\\", $strip_tags = TRUE, $trim_values = TRUE, $sanitize = TRUE) {
+    parent::__construct($delimiter, $enclosure, $escape_char, $strip_tags, $trim_values);
+    $this->sanitize = $sanitize;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function formatValue($value) {
+    $value = parent::formatValue($value);
+
+    // Sanitize against CSV injection vectors by prefixing cells that start with
+    // suspicious characters (=, -, +, or @) with a tab.
+    // @see https://georgemauer.net/2017/10/07/csv-injection.html
+    if ($this->sanitize) {
+      if (preg_match('/^[=@\-+]/', $value)) {
+        $value = "\t" . $value;
+      }
+    }
+
+    return $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setSettings(array $settings) {
+    parent::setSettings($settings);
+    $this->sanitize = $settings['sanitize'] ?? $this->sanitize;
+  }
+
+}

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -266,6 +266,20 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       '#required' => TRUE,
     ];
 
+    // Add a section for advanced options.
+    $form['advanced'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Advanced'),
+    ];
+
+    // Sanitize against CSV formula injection.
+    $form['advanced']['sanitize'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Sanitize against formula injection'),
+      '#description' => $this->t('Prepend cells that start with @, =, +, or - characters with a tab to prevent them from being interpreted as a formula. <strong>Warning: Opening unsanitized CSV files with spreadsheet applications may expose you to <a href=":link">formula injection</a> or other security vulnerabilities.</strong>', [':link' => 'https://owasp.org/www-community/attacks/CSV_Injection']),
+      '#default_value' => TRUE,
+    ];
+
     // Delegate to the parent method.
     return parent::buildForm($form, $form_state);
   }
@@ -301,6 +315,11 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
 
       // Return RFC3339 dates.
       'rfc3339_dates' => TRUE,
+
+      // CSV encoder settings.
+      'csv_settings' => [
+        'sanitize' => $form_state->getValue('sanitize'),
+      ],
     ];
     $output = $this->serializer->serialize($accessible_entities, 'csv', $context);
 


### PR DESCRIPTION
This adds some basic protection against CSV injection exploits when exporting CSVs from farmOS containing data from untrusted/malicious users.

See:

- https://owasp.org/www-community/attacks/CSV_Injection
- https://georgemauer.net/2017/10/07/csv-injection.html

Note that this is NOT considered a security vulnerability of farmOS itself. It is an existing attack vector in spreadsheet applications like Microsoft Excel. Similar issues have been filed against Drupal modules in the past, and the Drupal security team has come to that conclusion. Reference: https://www.drupal.org/project/webform/issues/2788591

> Spreadsheets are vulnerable to hidden formulas in CSV files. If webform data is submitted by untrusted users, and the submissions are downloaded in CSV format, maliciously-formatted submission data may be used to create a security vulnerability. The Drupal security team has concluded that this vulnerability does not rest in webform, but rather in the spreadsheets. Nonetheless, a warning about opening downloaded submissions in CSV format with spreadsheets should be added to the webform download page.

This pull request take a pro-active step by prepending cells that begin with suspicious characters (=, @, +, -) with a tab character, as described in https://georgemauer.net/2017/10/07/csv-injection.html

The plan is to merge this as "default behavior" in farmOS first, and then add an option (with a visible warning) that allows users to disable it. Thus we'll be able to offer a base level of protection by default, but also allow raw export of text data when necessary.