### PR TITLE
Add a Soil texture field to Lab test logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add an asset.logs service for retrieving logs that reference an asset #850](https://github.com/farmOS/farmOS/pull/850)
 - [Add farmOS-timeline library (experimental) #862](https://github.com/farmOS/farmOS/pull/862)
 - [Build multi-platform Docker images/manifests #864](https://github.com/farmOS/farmOS/pull/864)
+- [Add a Soil texture field to Lab test logs #873](https://github.com/farmOS/farmOS/pull/873)
 
 ### Changed
 

--- a/modules/log/lab_test/farm_lab_test.module
+++ b/modules/log/lab_test/farm_lab_test.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Lab test type options helper.
@@ -39,4 +40,15 @@ function farm_lab_test_type_options() {
  */
 function farm_lab_test_type_field_allowed_values(FieldStorageDefinitionInterface $definition, ?ContentEntityInterface $entity = NULL, bool &$cacheable = TRUE) {
   return farm_lab_test_type_options();
+}
+
+/**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ */
+function farm_lab_test_form_log_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // Only show the "Soil texture" field if the lab test type is "soil".
+  if (isset($form['lab_test_type']) && isset($form['soil_texture'])) {
+    $form['soil_texture']['#states']['visible'] = [':input[name="lab_test_type"]' => ['value' => 'soil']];
+  }
 }

--- a/modules/log/lab_test/farm_lab_test.post_update.php
+++ b/modules/log/lab_test/farm_lab_test.post_update.php
@@ -193,3 +193,19 @@ function farm_lab_test_post_update_override_lab_test_timestamp_label_description
     $config->save();
   }
 }
+
+/**
+ * Add "Soil texture" field to lab test logs.
+ */
+function farm_lab_test_post_update_soil_texture(&$sandbox) {
+  $options = [
+    'type' => 'string',
+    'label' => t('Soil texture'),
+    'weight' => [
+      'form' => -45,
+      'view' => -45,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('soil_texture', 'log', 'farm_lab_test', $field_definition);
+}

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -56,6 +56,17 @@ class LabTest extends FarmLogType {
     ];
     $fields['lab_test_type'] = $this->farmFieldFactory->bundleFieldDefinition($options);
 
+    // Soil texture.
+    $options = [
+      'type' => 'string',
+      'label' => $this->t('Soil texture'),
+      'weight' => [
+        'form' => -45,
+        'view' => -45,
+      ],
+    ];
+    $fields['soil_texture'] = $this->farmFieldFactory->bundleFieldDefinition($options);
+
     // Lab.
     $options = [
       'type' => 'entity_reference',


### PR DESCRIPTION
This adds a "Soil texture" field to Lab test logs.

As simple as this seems, we debated it for a while simply because Lab test logs are used to represent more than just soil tests. They can be used for water tests, tissue tests, and other types where "soil texture" isn't applicable. We discussed a longer-term solution, which is to add a more flexible key/value field to logs (and assets) more generally, which would allow soil texture to be added where necessary, without being strictly defined. The scope of that feature is much larger, however, and in the meantime there is a real need for storing soil texture right now. So the compromise decision was to add this simple text field to lab test logs in the short term, and deprecate/migrate it when a more flexible solution is added in the future.

This PR also adds some code to automatically hide the field in the lab test log form if the lab test type is not "soil". This is what it looks like for soil test types:

![Screenshot from 2024-09-03 13-15-53](https://github.com/user-attachments/assets/64490d2c-a855-4007-b966-0c30cbce758a)

And this is what it looks like for other test types:

![Screenshot from 2024-09-03 13-16-07](https://github.com/user-attachments/assets/c898e0bf-492d-446d-81fe-b19d53ce29f8)

But notably, "Soil texture" still appears in the list of all Lab test logs (because farmOS automatically adds columns for fields and there isn't a way to disable that currently):

![Screenshot from 2024-09-03 13-15-29](https://github.com/user-attachments/assets/da1e70d1-c9ee-4a7d-9caf-2859e8c586f1)

This is a small price to pay, and perhaps we can explore adding more options for hiding that in the future, if necessary.