### PR TITLE
Configure Inline Entity Form widget to automatically delete entities

### DIFF
--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -6,6 +6,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldException;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\entity\BundleFieldDefinition;
+use Drupal\inline_entity_form\Plugin\Field\FieldWidget\InlineEntityFormComplex;
 
 /**
  * Factory for generating farmOS field definitions.
@@ -491,6 +492,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
             'allow_existing' => FALSE,
             'match_operator' => 'CONTAINS',
             'allow_duplicate' => FALSE,
+            'removed_reference' => InlineEntityFormComplex::REMOVED_DELETE,
           ],
           'weight' => $options['weight']['form'] ?? 0,
         ];
@@ -565,6 +567,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
             'allow_existing' => FALSE,
             'match_operator' => 'CONTAINS',
             'allow_duplicate' => FALSE,
+            'removed_reference' => InlineEntityFormComplex::REMOVED_DELETE,
           ],
           'weight' => $options['weight']['form'] ?? 0,
         ];


### PR DESCRIPTION
I noticed recently that when you delete a quantity through the farmOS UI, you have to explicitly tell it to delete the quantity entity and not just the reference to it.

![Screenshot from 2024-09-19 10-47-32](https://github.com/user-attachments/assets/bfc7cce2-aec9-4a42-9bd0-8be63e9a7563)

This feature was added to Inline Entity Form in the [8.x-1.0-rc15](https://www.drupal.org/project/inline_entity_form/releases/8.x-1.0-rc15) release: https://www.drupal.org/project/inline_entity_form/issues/2875716

In farmOS, we always want to delete quantity entities when the reference to them is deleted, otherwise it results in orphaned quantities (see related: #775). This PR configures the new Inline Entity Form widget setting to ensure that quantities are deleted.

It also makes the same change for `data_stream` reference widgets (the only other Inline Entity Form widget we provide default configuration for in our `farm.field_factory` logic. @paul121 does this make sense? I forget what all the possible use-cases of data stream references might be... If not, we can set that one to `REMOVED_OPTIONAL`.