### PR TITLE
Do not run SQLite3 tests with paratest

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -126,13 +126,13 @@ jobs:
         include:
           - dbms: pgsql
             DB_URL: pgsql://farm:farm@db/farm
-            processes: auto
+            test_cmd: paratest -vv --processes=auto
           - dbms: mariadb
             DB_URL: mysql://farm:farm@db/farm
-            processes: auto
+            test_cmd: paratest -vv --processes=auto
           - dbms: sqlite
             DB_URL: sqlite://localhost/sites/default/files/db.sqlite
-            processes: 1
+            test_cmd: phpunit --verbose --debug
     steps:
       - name: Print test matrix variables
         run: echo "matrix.platform=${{ matrix.platform }}, matrix.dbms=${{ matrix.dbms }}, matrix.DB_URL=${{ matrix.DB_URL }}"
@@ -169,7 +169,7 @@ jobs:
         if: matrix.dbms == 'pgsql'
         run: docker compose exec -T db psql -U farm -c 'CREATE EXTENSION IF NOT EXISTS pg_trgm;'
       - name: Run PHPUnit tests
-        run: docker compose exec -u www-data -T www paratest -vv --processes=${{ matrix.processes }} /opt/drupal/web/profiles/farm
+        run: docker compose exec -u www-data -T www ${{ matrix.test_cmd }} /opt/drupal/web/profiles/farm
       - name: Test Drush site install with all modules
         run: docker compose exec -u www-data -T www drush site-install --db-url=${{ matrix.DB_URL }} farm farm.modules='all'
 


### PR DESCRIPTION
We've had issues for a while with SQlite3 test failures (see #767), and after the update to Drupal 10.3 (see #872) there is a new failure that is happening consistently:

```
Run docker compose exec -u www-data -T www paratest -vv --processes=1 /opt/drupal/web/profiles/farm
ParaTest v6.11.1 upon PHPUnit 9.6.21 by Sebastian Bergmann and contributors.

Processes:     1
Runtime:       PHP 8.2.23
Configuration: /opt/drupal/phpunit.xml

E................................................................ 65 / 95 ( 68%)
..............................                                    95 / 95 (100%)

Time: 08:23.584, Memory: 12.00 MB

There was 1 error:

1) Drupal\Tests\farm_group\Kernel\GroupTest::testGroupMembership
Exception: Exception when installing config for module farm_group, message was: No schema for asset.type.group

/opt/drupal/web/core/tests/Drupal/KernelTests/KernelTestBase.php:770
/opt/drupal/web/profiles/farm/modules/asset/group/tests/src/Kernel/GroupTest.php:85
/opt/drupal/vendor/phpunit/phpunit/src/Framework/TestResult.php:729

FAILURES!
Tests: 95, Assertions: 3140, Errors: 1.
Error: Process completed with exit code 2.
```

I have tried repeatedly to replicate this locally with `phpunit` (not `paratest`), to no avail. It happens consistently in the GitHub Actions runner context with `paratest` though.

I tested with `phpunit` instead of `paratest` and that seems to resolve both failures. So this PR changes the way that tests are run in our GitHub workflow `deliver.yml`, so that SQLite3 tests are run via `phpunit` instead of `paratest`. It replaces the `${{ matrix.processes }}` variable with a `${{ matrix.test_cmd }}` variable, and configures SQlite3 to use `test_cmd: phpunit --verbose --debug`, while PostgreSQL and MariaDB use `paratest -vv --processes=auto`.

I've tested this twice, and all tests passed. Opening this PR will trigger a third test. If that passes then I think we can be confident that this fixes #767 and the new one.

The downside of this is that SQLite3 tests take roughly twice as long to run as PostgreSQL/MariaDB (~10 minutes instead of ~5). At this point I'm willing to accept that. I spend more time re-running the SQLite3 tests hoping for a random pass.