### PR TITLE
Fix warning message when loading values from empty form state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Remove dependency on admin_toolbar:admin_toolbar_links_access_filter #881](https://github.com/farmOS/farmOS/pull/881)
+- [Fix warning message when loading values from empty form state #880](https://github.com/farmOS/farmOS/pull/880)
 
 ## [3.3.0] 2024-09-24
 

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -410,7 +410,7 @@ class Planting extends QuickFormBase {
 
     // Get the season names.
     /** @var \Drupal\taxonomy\TermInterface[] $seasons */
-    $seasons = $form_state->getValue('seasons', []);
+    $seasons = $form_state->getValue('seasons') ?? [];
     $season_names = [];
     foreach ($seasons as $season) {
       if (!empty($season['target_id'])) {
@@ -426,7 +426,7 @@ class Planting extends QuickFormBase {
 
     // Get the crop/variety names.
     /** @var \Drupal\taxonomy\TermInterface[] $crops */
-    $crops = $form_state->getValue('crops', []);
+    $crops = $form_state->getValue('crops') ?? [];
     $crop_names = [];
     foreach ($crops as $crop) {
       if (is_numeric($crop)) {


### PR DESCRIPTION
This happens when toggling 'Customize plant asset name' in the planting quick form before entering a season or crop

> Warning: foreach() argument must be of type array|object, null given in Drupal\farm_quick_planting\Plugin\QuickForm\Planting->generatePlantName() (line 415 of /var/www/html/web/profiles/farm/modules/quick/planting/src/Plugin/QuickForm/Planting.php)