### PR TITLE
Remove dependency on admin_toolbar:admin_toolbar_links_access_filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Remove dependency on admin_toolbar:admin_toolbar_links_access_filter #881](https://github.com/farmOS/farmOS/pull/881)
+
 ## [3.3.0] 2024-09-24
 
 ### Added

--- a/modules/core/ui/menu/farm_ui_menu.info.yml
+++ b/modules/core/ui/menu/farm_ui_menu.info.yml
@@ -5,5 +5,4 @@ package: farmOS UI
 core_version_requirement: ^10
 dependencies:
   - admin_toolbar:admin_toolbar
-  - admin_toolbar:admin_toolbar_links_access_filter
   - drupal:toolbar


### PR DESCRIPTION
I discovered an issue with the upgrade path to farmOS 3.3.0. I'm still figuring out exactly why this is happening (and why it didn't happen in local testing), but basically the `admin_toolbar:admin_toolbar_links_access_filter` has been deprecated, and our `farm_ui_menu` module depends on it. For some reason, during the update, that module gets uninstalled automatically, which then uninstalls `farm_ui_menu` (which depends on it), and `farm_ui` (which depends on `farm_ui_menu`, along with some other `farm_ui_*` modules (which also depend on `farm_ui_menu`). After that , the upgrade throws an error when it is trying to revert Views configuration that no longer exists.

Removing the dependency on `admin_toolbar:admin_toolbar_links_access_filter` seems to fix the issue. I tested two site upgrades with the dependency, and they both broke. I tested one without the dependency and it worked.

More details to come... just wanted to get this PR opened to share with people ASAP.