### PR TITLE
Do not delete quantities when they are removed from a log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Do not delete quantities when they are removed from a log #882](https://github.com/farmOS/farmOS/pull/882)
+
 ### Fixed
 
 - [Remove dependency on admin_toolbar:admin_toolbar_links_access_filter #881](https://github.com/farmOS/farmOS/pull/881)

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -567,7 +567,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
             'allow_existing' => FALSE,
             'match_operator' => 'CONTAINS',
             'allow_duplicate' => FALSE,
-            'removed_reference' => InlineEntityFormComplex::REMOVED_DELETE,
+            'removed_reference' => InlineEntityFormComplex::REMOVED_KEEP,
           ],
           'weight' => $options['weight']['form'] ?? 0,
         ];

--- a/modules/core/log/modules/quantity/farm_log_quantity.module
+++ b/modules/core/log/modules/quantity/farm_log_quantity.module
@@ -40,6 +40,22 @@ function farm_log_quantity_entity_base_field_info(EntityTypeInterface $entity_ty
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function farm_log_quantity_form_quantity_delete_multiple_confirm_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // Add a warning to bulk quantity delete confirmation form, to emphasize that
+  // the quantity will be deleted from all log revisions.
+  $message = t('Warning: Deleting quantities will remove them from all revisions of records that reference them.');
+  $form['warning'] = [
+    '#type' => 'html_tag',
+    '#tag' => 'strong',
+    '#value' => $message,
+    '#weight' => -10,
+  ];
+}
+
+/**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function farm_log_quantity_form_log_form_alter(&$form, FormStateInterface $form_state, $form_id) {


### PR DESCRIPTION
When quantity entities are deleted, they are deleted from all revisions of a log.

This might not be expected behavior, if you want a log to keep old revisions of quantities, but you want to remove the quantity only from the final version of the log.

This PR makes a small change to the Inline Entity Form configuration that we use for Log Quantity reference fields. When a quantity is removed from a log, now it will only remove the reference, but it will not delete the quantity entity itself.

This preserves the quantity reference on previous log revisions.

However, it does mean that there is the potential for orphaned quantity entities in the system. We've discussed this as a broader issue that need to be resolved itself (eg: #775). For now, we decided that orphaned quantities are better than lost log revision data.

Notably, farmOS 3.3.0 included a change that hides orphaned quantities from the Records > Log Quantities list. This makes orphaned quantities slightly less of an issue. They are still visible in the API, however.