### PR TITLE
Fix config export via UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix config export via UI #883](https://github.com/farmOS/farmOS/pull/883)
+
 ## [3.3.1] 2024-09-26
 
 This fixes a critical issue in the upgrade path from farmOS 3.2.x to 3.3.x. For

--- a/modules/core/import/modules/csv/farm_import_csv.module
+++ b/modules/core/import/modules/csv/farm_import_csv.module
@@ -20,6 +20,11 @@ function farm_import_csv_file_download($uri) {
   /** @var \Drupal\file\FileInterface|null $file */
   $file = reset($files) ?: NULL;
 
+  // If a file was not found, return NULL.
+  if (is_null($file)) {
+    return NULL;
+  }
+
   // Get file usage.
   /** @var \Drupal\file\FileUsage\FileUsageInterface $file_usage */
   $usage_service = \Drupal::service('file.usage');


### PR DESCRIPTION
I discovered a minor issue caused by one of the farmOS modules. If you enable the Drupal core `config` module and attempt to download a full export of the site's configuration via the UI (in `/admin/config/development/configuration/full/export`), the export fails with the following error:

`TypeError: Drupal\file\FileUsage\DatabaseFileUsageBackend::listUsage(): Argument #1 ($file) must be of type Drupal\file\FileInterface, null given, called in /opt/drupal/web/profiles/farm/modules/core/import/modules/csv/farm_import_csv.module on line 26 in Drupal\file\FileUsage\DatabaseFileUsageBackend->listUsage() (line 101 of /opt/drupal/web/core/modules/file/src/FileUsage/DatabaseFileUsageBackend.php).`

This is due to bad logic in the `farm_import_csv` module. This PR fixes that.