### PR TITLE
Add support for geometry fields in CSV exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Add Equipment type field to Equipment assets #894](https://github.com/farmOS/farmOS/pull/894)
+- [Add support for geometry fields in CSV exports #884](https://github.com/farmOS/farmOS/pull/884)
 
 ### Changed
 

--- a/modules/core/csv/farm_csv.services.yml
+++ b/modules/core/csv/farm_csv.services.yml
@@ -12,6 +12,10 @@ services:
     class: Drupal\farm_csv\Normalizer\FractionFieldItemNormalizer
     tags:
       - { name: normalizer, priority: 10 }
+  farm_csv.normalizer.geofield_item:
+    class: Drupal\farm_csv\Normalizer\GeofieldItemNormalizer
+    tags:
+      - { name: normalizer, priority: 10 }
   farm_csv.normalizer.text_long_field_item:
     class: Drupal\farm_csv\Normalizer\TextLongFieldItemNormalizer
     tags:

--- a/modules/core/csv/src/Normalizer/GeofieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/GeofieldItemNormalizer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_csv\Normalizer;
+
+use Drupal\geofield\Plugin\Field\FieldType\GeofieldItem;
+use Drupal\serialization\Normalizer\FieldItemNormalizer;
+
+/**
+ * Normalizes Geofields for farmOS CSV exports.
+ */
+class GeofieldItemNormalizer extends FieldItemNormalizer {
+
+  /**
+   * The supported format.
+   */
+  const FORMAT = 'csv';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+    $data = parent::normalize($object, $format, $context);
+
+    // Return the WKT value, if desired.
+    if (isset($context['wkt']) && $context['wkt'] === TRUE) {
+      return $data['value'];
+    }
+
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsNormalization($data, ?string $format = NULL, array $context = []): bool {
+    return $data instanceof GeofieldItem && $format == static::FORMAT;
+  }
+
+}

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -327,6 +327,9 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       // Return RFC3339 dates.
       'rfc3339_dates' => TRUE,
 
+      // Return WKT geometry.
+      'wkt' => TRUE,
+
       // CSV encoder settings.
       'csv_settings' => [
         'sanitize' => $form_state->getValue('sanitize'),
@@ -408,6 +411,7 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       'changed',
       'entity_reference',
       'fraction',
+      'geofield',
       'list_string',
       'state',
       'string',


### PR DESCRIPTION
Following on #815, this adds similar support for geometry fields in CSV exports.