### PR TITLE
Fix farm_log_quantity View alterations by farm_ui_views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix config export via UI #883](https://github.com/farmOS/farmOS/pull/883)
 - [Fix group location logic #888](https://github.com/farmOS/farmOS/pull/888)
+- [Fix farm_log_quantity View alterations by farm_ui_views #891](https://github.com/farmOS/farmOS/pull/891)
 
 ### Security
 

--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -15,7 +15,7 @@ use Drupal\views\Views;
 function farm_ui_views_views_pre_view(ViewExecutable $view, $display_id, array &$args) {
 
   // We only want to alter the Views we provide.
-  if (!in_array($view->id(), ['farm_asset', 'farm_log', 'farm_plan', 'farm_quantity'])) {
+  if (!in_array($view->id(), ['farm_asset', 'farm_log', 'farm_log_quantity', 'farm_plan'])) {
     return;
   }
 
@@ -104,7 +104,7 @@ function farm_ui_views_views_pre_view(ViewExecutable $view, $display_id, array &
 function farm_ui_views_views_pre_render(ViewExecutable $view) {
 
   // We only want to alter the Views we provide.
-  if (!in_array($view->id(), ['farm_asset', 'farm_log', 'farm_plan', 'farm_quantity'])) {
+  if (!in_array($view->id(), ['farm_asset', 'farm_log', 'farm_log_quantity', 'farm_plan'])) {
     return;
   }
 


### PR DESCRIPTION
#858 changed the ID of the Quantity View provided by the `farm_ui_views` module from `farm_quantity` to `farm_log_quantity`, but did not update the implementations of `hook_views_pre_view()` and `hook_views_pre_render()` to use the new ID, so all the alterations performed by those hooks are no longer happening. This includes adding bundle-specific fields and filters, and overriding the page title.

Below are screenshots before and after this fix is applied. Notice how the page title is not being overridden in the first one, and the "Material type" exposed filter is not being added.

Before:

![Screenshot from 2024-11-19 15-20-26](https://github.com/user-attachments/assets/78dfb354-04f3-49e6-aa5e-5e90e8b3f022)

After:

![Screenshot from 2024-11-19 15-20-36](https://github.com/user-attachments/assets/4f1d8cf1-7150-4d4a-b808-d5708e3a72b3)
