### PR TITLE
Update Drupal core to 10.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix config export via UI #883](https://github.com/farmOS/farmOS/pull/883)
 
+### Security
+
+- [Update Drupal core to 10.3.9 #892](https://github.com/farmOS/farmOS/pull/892)
+
 ## [3.3.1] 2024-09-26
 
 This fixes a critical issue in the upgrade path from farmOS 3.2.x to 3.3.x. For

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.3",
-        "drupal/core": "10.3.8",
+        "drupal/core": "10.3.9",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.19",
         "drupal/csv_serialization": "^4.0.1",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.3",
-        "drupal/core": "10.3.5",
+        "drupal/core": "10.3.8",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.19",
         "drupal/csv_serialization": "^4.0.1",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "10.3.5"
+        "drupal/core-composer-scaffold": "10.3.8"
     },
     "require-dev": {
         "behat/mink": "^1.10",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "10.3.8"
+        "drupal/core-composer-scaffold": "10.3.9"
     },
     "require-dev": {
         "behat/mink": "^1.10",


### PR DESCRIPTION
Multiple security advisories fixed by 10.3.9. None of them are directly relevant to farmOS, because they require conditions not present in farmOS. In theory a user who has customized farmOS may be affected, and should therefore review the advisories.

More information: https://www.drupal.org/project/drupal/releases/10.3.9