### PR TITLE
Add Equipment type field to Equipment assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add Equipment type field to Equipment assets #894](https://github.com/farmOS/farmOS/pull/894)
+
 ### Changed
 
 - [Pin PHP version to 8.3 in Dockerfile #923](https://github.com/farmOS/farmOS/pull/923)

--- a/docs/model/type/asset.md
+++ b/docs/model/type/asset.md
@@ -254,6 +254,10 @@ Equipment Assets have the following additional attributes:
 - Model (string)
 - Serial number (string)
 
+And the following additional relationships:
+
+- Equipment type (References a Term in the "Equipment type" vocabulary)
+
 #### Land Assets
 
 Land Assets have the following additional attributes:

--- a/docs/model/type/term.md
+++ b/docs/model/type/term.md
@@ -17,6 +17,7 @@ in. Vocabularies are defined by modules, and are only available if their module
 is enabled. The modules included with farmOS define the following vocabularies:
 
 - Animal type
+- Equipment type
 - Log category
 - Material type
 - Plant type

--- a/modules/asset/equipment/farm_equipment.info.yml
+++ b/modules/asset/equipment/farm_equipment.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^10
 dependencies:
   - farm:asset
   - farm:farm_entity
+  - farm:farm_equipment_type

--- a/modules/asset/equipment/farm_equipment.post_update.php
+++ b/modules/asset/equipment/farm_equipment.post_update.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the farm_equipment module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Add "Equipment type" field to Equipment assets.
+ */
+function farm_equipment_post_update_install_equipment_type(&$sandbox) {
+
+  // Install the farm_equipment_type taxonomy module.
+  if (!\Drupal::service('module_handler')->moduleExists('farm_equipment_type')) {
+    \Drupal::service('module_installer')->install(['farm_equipment_type']);
+  }
+
+  // Install the equipment_type reference field on equipment assets.
+  $options = [
+    'type' => 'entity_reference',
+    'label' => t('Equipment type'),
+    'description' => t("Enter the type of equipment."),
+    'target_type' => 'taxonomy_term',
+    'target_bundle' => 'equipment_type',
+    'auto_create' => TRUE,
+    'weight' => [
+      'form' => -90,
+      'view' => -50,
+    ],
+  ];
+  $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('equipment_type', 'asset', 'farm_equipment', $field_definition);
+}

--- a/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
+++ b/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
@@ -22,6 +22,19 @@ class Equipment extends FarmAssetType {
   public function buildFieldDefinitions() {
     $fields = parent::buildFieldDefinitions();
     $field_info = [
+      'equipment_type' => [
+        'type' => 'entity_reference',
+        'label' => $this->t('Equipment type'),
+        'description' => $this->t("Enter the type of equipment."),
+        'target_type' => 'taxonomy_term',
+        'target_bundle' => 'equipment_type',
+        'auto_create' => TRUE,
+        'multiple' => TRUE,
+        'weight' => [
+          'form' => -90,
+          'view' => -50,
+        ],
+      ],
       'manufacturer' => [
         'type' => 'string',
         'label' => $this->t('Manufacturer'),

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/equipment.csv
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/equipment.csv
@@ -1,4 +1,4 @@
-name,parents,notes,status,manufacturer,model,serial number,id tag,id tag type,id tag location
-Old tractor,,Inherited from Grandpa,archived,,,,12345,,
-New tractor,,Purchased recently,active,,,,67890,eid,trunk
-Baler,Test parent,Makes big bales,,New Idea,483 Round Baler,1234567890,,,
+name,parents,notes,status,equipment type,manufacturer,model,serial number,id tag,id tag type,id tag location
+Old tractor,,Inherited from Grandpa,archived,Tractor,,,,12345,,
+New tractor,,Purchased recently,active,Tractor,,,,67890,eid,trunk
+Baler,Test parent,Makes big bales,,,New Idea,483 Round Baler,1234567890,,,

--- a/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
+use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
 
 /**
@@ -22,6 +23,7 @@ class AssetCsvImportTest extends CsvImportTestBase {
     'entity',
     'farm_entity',
     'farm_equipment',
+    'farm_equipment_type',
     'farm_id_tag',
     'farm_land',
     'farm_land_types',
@@ -29,6 +31,7 @@ class AssetCsvImportTest extends CsvImportTestBase {
     'farm_map',
     'farm_parent',
     'geofield',
+    'taxonomy',
   ];
 
   /**
@@ -39,6 +42,7 @@ class AssetCsvImportTest extends CsvImportTestBase {
     $this->installConfig([
       'farm_id_tag',
       'farm_equipment',
+      'farm_equipment_type',
       'farm_land',
       'farm_land_types',
     ]);
@@ -52,6 +56,13 @@ class AssetCsvImportTest extends CsvImportTestBase {
    * Test asset CSV importer.
    */
   public function testAssetCsvImport() {
+
+    // Create a Tractor equipment type term.
+    $term = Term::create([
+      'name' => 'Tractor',
+      'vid' => 'equipment_type',
+    ]);
+    $term->save();
 
     // Run the CSV import.
     $this->importCsv('equipment.csv', 'csv_asset:equipment');
@@ -71,6 +82,9 @@ class AssetCsvImportTest extends CsvImportTestBase {
           'type' => '',
           'location' => '',
         ],
+        'equipment_types' => [
+          'Tractor',
+        ],
         'parents' => [],
         'notes' => 'Inherited from Grandpa',
         'status' => 'archived',
@@ -84,6 +98,9 @@ class AssetCsvImportTest extends CsvImportTestBase {
           'id' => '67890',
           'type' => 'eid',
           'location' => 'trunk',
+        ],
+        'equipment_types' => [
+          'Tractor',
         ],
         'parents' => [],
         'notes' => 'Purchased recently',
@@ -99,6 +116,7 @@ class AssetCsvImportTest extends CsvImportTestBase {
           'type' => '',
           'location' => '',
         ],
+        'equipment_types' => [],
         'parents' => [
           'Test parent',
         ],
@@ -111,12 +129,17 @@ class AssetCsvImportTest extends CsvImportTestBase {
       if ($id <= 1) {
         continue;
       }
+
+      // Confirm bundle and name are correct.
       $this->assertEquals('equipment', $asset->bundle());
       $this->assertEquals($expected_values[$id]['name'], $asset->label());
+
+      // Confirm manufacturer, model, and serial_number are set.
       $this->assertEquals($expected_values[$id]['manufacturer'], $asset->get('manufacturer')->value);
       $this->assertEquals($expected_values[$id]['model'], $asset->get('model')->value);
       $this->assertEquals($expected_values[$id]['serial_number'], $asset->get('serial_number')->value);
 
+      // Confirm ID tag is set.
       // If no tag ID is provided ensure we have an empty field.
       if (empty($expected_values[$id]['id_tag']['id'])) {
         $this->assertTrue($asset->get('id_tag')->isEmpty());
@@ -130,15 +153,27 @@ class AssetCsvImportTest extends CsvImportTestBase {
         $this->assertEquals($expected_values[$id]['id_tag']['location'], $id_tag->location);
       }
 
+      // Confirm that equipment type is set.
+      $equipment_types = $asset->get('equipment_type')->referencedEntities();
+      $this->assertEquals(count($expected_values[$id]['equipment_types']), count($equipment_types));
+      foreach ($equipment_types as $equipment_type) {
+        $this->assertContains($equipment_type->label(), $expected_values[$id]['equipment_types']);
+      }
+
+      // Confirm that parent is set.
       $parents = $asset->get('parent')->referencedEntities();
       $this->assertEquals(count($expected_values[$id]['parents']), count($parents));
       foreach ($parents as $parent) {
         $this->assertContains($parent->label(), $expected_values[$id]['parents']);
       }
+
+      // Confirm notes and status are set.
       $this->assertEquals($expected_values[$id]['notes'], $asset->get('notes')->value);
       $this->assertInstanceOf(TextLongItem::class, $asset->get('notes')->first());
       $this->assertEquals('default', $asset->get('notes')->first()->format);
       $this->assertEquals($expected_values[$id]['status'], $asset->get('status')->value);
+
+      // Confirm revision message is set.
       $this->assertEquals('Imported via CSV.', $asset->getRevisionLogMessage());
     }
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportMigrationGroupTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportMigrationGroupTest.php
@@ -17,8 +17,10 @@ class CsvImportMigrationGroupTest extends CsvImportTestBase {
   protected static $modules = [
     'farm_animal_type',
     'farm_equipment',
+    'farm_equipment_type',
     'farm_harvest',
     'farm_id_tag',
+    'taxonomy',
   ];
 
   /**
@@ -27,6 +29,7 @@ class CsvImportMigrationGroupTest extends CsvImportTestBase {
   public function setUp(): void {
     parent::setUp();
     $this->installConfig(['farm_animal_type']);
+    $this->installConfig(['farm_equipment_type']);
     $this->installConfig(['farm_equipment']);
     $this->installConfig(['farm_harvest']);
     $this->installConfig(['farm_import_csv_test']);

--- a/modules/quick/group/tests/src/Kernel/QuickGroupTest.php
+++ b/modules/quick/group/tests/src/Kernel/QuickGroupTest.php
@@ -27,9 +27,11 @@ class QuickGroupTest extends QuickFormTestBase {
    */
   protected static $modules = [
     'farm_equipment',
+    'farm_equipment_type',
     'farm_group',
     'farm_observation',
     'farm_quick_group',
+    'taxonomy',
   ];
 
   /**
@@ -38,6 +40,7 @@ class QuickGroupTest extends QuickFormTestBase {
   protected function setUp(): void {
     parent::setUp();
     $this->installConfig([
+      'farm_equipment_type',
       'farm_equipment',
       'farm_group',
       'farm_observation',

--- a/modules/quick/inventory/tests/src/Kernel/QuickInventoryTest.php
+++ b/modules/quick/inventory/tests/src/Kernel/QuickInventoryTest.php
@@ -29,6 +29,7 @@ class QuickInventoryTest extends QuickFormTestBase {
   protected static $modules = [
     'farm_activity',
     'farm_equipment',
+    'farm_equipment_type',
     'farm_inventory',
     'farm_observation',
     'farm_quantity_standard',
@@ -43,6 +44,7 @@ class QuickInventoryTest extends QuickFormTestBase {
     parent::setUp();
     $this->installConfig([
       'farm_activity',
+      'farm_equipment_type',
       'farm_equipment',
       'farm_observation',
       'farm_quantity_standard',

--- a/modules/quick/movement/tests/src/Kernel/QuickMovementTest.php
+++ b/modules/quick/movement/tests/src/Kernel/QuickMovementTest.php
@@ -27,9 +27,11 @@ class QuickMovementTest extends QuickFormTestBase {
    */
   protected static $modules = [
     'farm_equipment',
+    'farm_equipment_type',
     'farm_activity',
     'farm_land',
     'farm_quick_movement',
+    'taxonomy',
   ];
 
   /**
@@ -39,6 +41,7 @@ class QuickMovementTest extends QuickFormTestBase {
     parent::setUp();
     $this->installConfig([
       'farm_activity',
+      'farm_equipment_type',
       'farm_equipment',
       'farm_land',
     ]);

--- a/modules/taxonomy/equipment_type/config/install/taxonomy.vocabulary.equipment_type.yml
+++ b/modules/taxonomy/equipment_type/config/install/taxonomy.vocabulary.equipment_type.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - farm_equipment_type
+name: 'Equipment type'
+vid: equipment_type
+description: 'A list of equipment types.'
+weight: 0
+new_revision: false

--- a/modules/taxonomy/equipment_type/farm_equipment_type.info.yml
+++ b/modules/taxonomy/equipment_type/farm_equipment_type.info.yml
@@ -1,0 +1,7 @@
+name: Equipment type vocabulary
+description: Provides an Equipment type vocabulary.
+type: module
+package: farmOS Taxonomies
+core_version_requirement: ^10
+dependencies:
+  - drupal:taxonomy


### PR DESCRIPTION
This adds a new "Equipment type" taxonomy, with a new `equipment_type` term reference field on `equipment` assets. This allows categorizing equipment. It follows the same pattern as `animal_type`, `material_type`, `plant_type`, and `product_type`.

Forum topic for general discussion (reserve this PR for technical review): https://farmos.discourse.group/t/equipment-types/2158