### PR TITLE
Fix "explode: NULL is not a string" when multi-value CSV columns are omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Fix config export via UI #883](https://github.com/farmOS/farmOS/pull/883)
 - [Fix group location logic #888](https://github.com/farmOS/farmOS/pull/888)
 - [Fix farm_log_quantity View alterations by farm_ui_views #891](https://github.com/farmOS/farmOS/pull/891)
+- [Fix "explode: NULL is not a string" when multi-value CSV columns are omitted #895](https://github.com/farmOS/farmOS/pull/895)
 
 ### Security
 

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -256,6 +256,7 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
     // as a first step and describe how to format values.
     if ($field_definition->getCardinality() === -1 || $field_definition->getCardinality() > 1) {
       array_unshift($process, ['plugin' => 'explode', 'delimiter' => ',']);
+      array_unshift($process, ['plugin' => 'skip_on_empty', 'method' => 'process']);
       $description[] = $this->t('Multiple values can be separated by commas with the whole cell wrapped in quotes.');
     }
 


### PR DESCRIPTION
This fixes an error that occurs during CSV import if a column that processes multiple comma-separated values is omitted from the imported CSV.

The error that appears in the migrate messages when this happens looks like this:

`csv_asset:equipment:equipment_type:explode: NULL is not a string`

(I ran into that one specifically testing #894)

We made a similar change to the explicitly defined columns here: https://github.com/farmOS/farmOS/pull/815/commits/9069e787603271eb62f26de2f60d4e1b332f2517

But the same issue affects columns that are dynamically added by the CSV import module's logic, which detects and creates columns for bundle fields.

This simply adds a `skip_on_empty` process plugin to the pipeline before the `explode` plugin.