### PR TITLE
Fixed: value active in the status element is not allowed

### DIFF
--- a/modules/core/comment/modules/plan/farm_comment_plan.module
+++ b/modules/core/comment/modules/plan/farm_comment_plan.module
@@ -20,3 +20,22 @@ function farm_comment_plan_entity_base_field_info(EntityTypeInterface $entity_ty
 
   return $fields;
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function farm_comment_plan_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
+  // Target the module installation form.
+  if ($form_id === 'system_modules') {
+    // Check if there are any plan bundles.
+    $plan_bundles = \Drupal::entityTypeManager()->getStorage('plan_type')->loadMultiple();
+
+    // If no plan bundles exist, hide farm_comment_plan and its dependencies.
+    if (empty($plan_bundles)) {
+      if (isset($form['modules']['farm_comment_plan'])) {
+        $form['modules']['farm_comment_plan']['#access'] = FALSE;
+        drupal_set_message(t('The farm_comment_plan module is hidden because there are no plan entity bundles. Please create a plan type before enabling this module.'), 'warning');
+      }
+    }
+  }
+}


### PR DESCRIPTION
The updated farm_comment_plan.module file introduces a new function, farm_comment_plan_form_alter(), which dynamically modifies the module installation form (/setup/modules) to hide the farm_comment_plan module if no plan entity bundles are present. This enhancement leverages the entityTypeManager service to check for existing plan bundles, ensuring that the module cannot be enabled prematurely, which could lead to errors. If no bundles are found, the module is hidden, and a warning message is displayed, guiding users to create a plan bundle first. This change improves the user experience by preventing misconfigurations, aligns with observed issues on Farmier-hosted instances, and ensures the module is only activated when its dependencies are met.