### PR TITLE
Use Rector to scan for code upgrades

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -83,7 +83,7 @@ jobs:
       farmos_version: ${{ env.FARMOS_VERSION }}
 
   sniff:
-    name: Run PHP Codesniffer and PHPStan
+    name: Run PHP Codesniffer, PHPStan, and Rector
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -106,6 +106,8 @@ jobs:
         run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs /opt/drupal/web/profiles/farm
       - name: Run PHPStan
         run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
+      - name: Run Rector
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} rector process --dry-run /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings)
         run: |
           docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.2- --warning-severity=0 /opt/drupal/web/modules

--- a/composer.project.json
+++ b/composer.project.json
@@ -11,6 +11,7 @@
         "drupal/coder": "^8.3",
         "mglaman/phpstan-drupal": "^1.1",
         "mikey179/vfsstream": "^1.6",
+        "palantirnet/drupal-rector": "^0.20.3",
         "phpstan/extension-installer": "^1.1",
         "phpcompatibility/php-compatibility": "^9",
         "phpstan/phpstan": "^1.8",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -119,7 +119,7 @@ USER www-data
 # Build the farmOS codebase in ${BUILD_PATH}.
 RUN /usr/local/bin/build-farmOS.sh
 
-# Add dev configurartions for PHP CodeSniffer and PHPStan.
+# Add dev configurations for PHP CodeSniffer, PHPStan, and Rector.
 COPY --chown=www-data ./dev/files/ ${BUILD_PATH}/
 
 # Configure PHPUnit.

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -27,7 +27,6 @@ return static function (RectorConfig $rectorConfig): void {
     $drupalRoot . '/themes',
   ]);
 
-  $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);
   $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
   $rectorConfig->importNames(TRUE, FALSE);
   $rectorConfig->importShortClasses(FALSE);

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
+use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
 use DrupalRector\Set\Drupal10SetList;
 use Rector\Config\RectorConfig;
 
@@ -30,4 +31,13 @@ return static function (RectorConfig $rectorConfig): void {
   $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
   $rectorConfig->importNames(TRUE, FALSE);
   $rectorConfig->importShortClasses(FALSE);
+
+  // Temporarily disable ShouldCallParentMethodsRector in LocationTest.
+  // @todo Issue #3494872: Remove farm_install_modules() installation task
+  // @see https://www.drupal.org/project/farm/issues/3183739
+  $rectorConfig->skip([
+    ShouldCallParentMethodsRector::class => [
+      '*/modules/core/location/tests/src/Functional/LocationTest.php',
+    ],
+  ]);
 };

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Rector configuration for farmOS.
+ */
+
+declare(strict_types=1);
+
+use DrupalFinder\DrupalFinderComposerRuntime;
+use DrupalRector\Set\Drupal10SetList;
+use DrupalRector\Set\Drupal8SetList;
+use DrupalRector\Set\Drupal9SetList;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+  // Adjust the set lists to be more granular to your Drupal requirements.
+  // @todo find out how to only load the relevant rector rules.
+  //   Should we try and load \Drupal::VERSION and check?
+  $rectorConfig->sets([
+    Drupal8SetList::DRUPAL_8,
+    Drupal9SetList::DRUPAL_9,
+    Drupal10SetList::DRUPAL_10,
+  ]);
+
+  $drupalFinder = new DrupalFinderComposerRuntime();
+  $drupalRoot = $drupalFinder->getDrupalRoot();
+  $rectorConfig->autoloadPaths([
+    $drupalRoot . '/core',
+    $drupalRoot . '/modules',
+    $drupalRoot . '/profiles',
+    $drupalRoot . '/themes',
+  ]);
+
+  $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);
+  $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
+  $rectorConfig->importNames(TRUE, FALSE);
+  $rectorConfig->importShortClasses(FALSE);
+};

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -9,17 +9,12 @@ declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
 use DrupalRector\Set\Drupal10SetList;
-use DrupalRector\Set\Drupal8SetList;
-use DrupalRector\Set\Drupal9SetList;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-  // Adjust the set lists to be more granular to your Drupal requirements.
-  // @todo find out how to only load the relevant rector rules.
-  //   Should we try and load \Drupal::VERSION and check?
+
+  // Check against the Drupal 10 set list.
   $rectorConfig->sets([
-    Drupal8SetList::DRUPAL_8,
-    Drupal9SetList::DRUPAL_9,
     Drupal10SetList::DRUPAL_10,
   ]);
 

--- a/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
@@ -61,7 +61,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       LogEvent::DELETE => 'logDelete',
       LogEvent::PRESAVE => 'logPresave',

--- a/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -48,7 +48,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       MapRenderEvent::EVENT_NAME => ['onMapRender', -100],
     ];

--- a/modules/asset/material/src/EventSubscriber/QuantityEventSubscriber.php
+++ b/modules/asset/material/src/EventSubscriber/QuantityEventSubscriber.php
@@ -18,7 +18,7 @@ class QuantityEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       QuantityEvent::PRESAVE => 'quantityPresave',
     ];

--- a/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -48,7 +48,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       MapRenderEvent::EVENT_NAME => ['onMapRender', -100],
     ];

--- a/modules/core/api/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/modules/core/api/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -37,7 +37,7 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[KernelEvents::RESPONSE][] = ['addCorsHeaders'];
     return $events;
   }

--- a/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
+++ b/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
@@ -35,7 +35,7 @@ class DataStreamEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       DataStreamEvent::DATA_RECEIVE => 'onDataReceive',
     ];

--- a/modules/core/entity/farm_entity.api.php
+++ b/modules/core/entity/farm_entity.api.php
@@ -11,6 +11,8 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\EntityTypeInterface;
+
 /**
  * @addtogroup hooks
  * @{
@@ -29,7 +31,7 @@ declare(strict_types=1);
  * @return \Drupal\entity\BundleFieldDefinition[]
  *   Returns an array of BundleFieldDefinition objects.
  */
-function hook_farm_entity_bundle_field_info(\Drupal\Core\Entity\EntityTypeInterface $entity_type, string $bundle) {
+function hook_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, string $bundle) {
   $fields = [];
 
   // Add a new string field to Input Logs.

--- a/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
+++ b/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
@@ -44,7 +44,7 @@ class ContentEntityGeometryNormalizer implements NormalizerInterface, Serializer
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []) {
+  public function normalize($object, $format = NULL, array $context = []): array|bool|string|int|float|null|\ArrayObject {
 
     // Build GeometryWrapper objects.
     $geometries = [];
@@ -101,7 +101,7 @@ class ContentEntityGeometryNormalizer implements NormalizerInterface, Serializer
   /**
    * {@inheritdoc}
    */
-  public function supportsNormalization($data, $format = NULL) {
+  public function supportsNormalization($data, $format = NULL): bool {
 
     // Check that the data is a content entity.
     // Only formats that are prefixed with "geometry_" are supported.

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationConfigSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationConfigSubscriber.php
@@ -34,7 +34,7 @@ class CsvMigrationConfigSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[ConfigEvents::SAVE][] = ['rebuildRouter'];
     $events[ConfigEvents::DELETE][] = ['rebuildRouter'];
     return $events;

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
@@ -61,7 +61,7 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
    *
    * @inheritdoc
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     $events[MigrateEvents::POST_ROW_SAVE][] = ['onMigratePostRowSave'];
     $events[MigrateEvents::POST_IMPORT][] = ['onMigratePostImport'];
     return $events;

--- a/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
@@ -50,7 +50,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       LogEvent::DELETE => 'logDelete',
       LogEvent::PRESAVE => 'logPresave',

--- a/modules/core/kml/src/Normalizer/KmlNormalizer.php
+++ b/modules/core/kml/src/Normalizer/KmlNormalizer.php
@@ -46,7 +46,7 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []) {
+  public function normalize($object, $format = NULL, array $context = []): array|bool|string|int|float|null|\ArrayObject {
 
     /** @var \Drupal\farm_geo\GeometryWrapper $object */
     // Convert the geometry to KML.
@@ -85,7 +85,7 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
   /**
    * {@inheritdoc}
    */
-  public function supportsNormalization($data, $format = NULL) {
+  public function supportsNormalization($data, $format = NULL): bool {
     return $data instanceof GeometryWrapper && $format == static::FORMAT;
   }
 
@@ -136,7 +136,7 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
   /**
    * {@inheritdoc}
    */
-  public function supportsDenormalization($data, $type, $format = NULL) {
+  public function supportsDenormalization($data, $type, $format = NULL): bool {
     return $type === static::TYPE && $format === static::FORMAT;
   }
 

--- a/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
@@ -69,7 +69,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       LogEvent::DELETE => 'logDelete',
       LogEvent::PRESAVE => 'logPresave',

--- a/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
+++ b/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
@@ -37,7 +37,7 @@ class LogQuantityEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       LogEvent::CLONE => 'logClone',
       LogEvent::DELETE => 'logDelete',

--- a/modules/core/map/modules/mapbox/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/modules/mapbox/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -35,7 +35,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       MapRenderEvent::EVENT_NAME => 'onMapRender',
     ];

--- a/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -35,7 +35,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       MapRenderEvent::EVENT_NAME => 'onMapRender',
     ];

--- a/modules/core/owner/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/owner/src/EventSubscriber/LogEventSubscriber.php
@@ -36,7 +36,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       LogEvent::PRESAVE => 'setLogOwner',
     ];

--- a/modules/core/quantity/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/quantity/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -35,7 +35,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       MapRenderEvent::EVENT_NAME => 'onMapRender',
     ];

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -49,7 +49,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       MapRenderEvent::EVENT_NAME => 'onMapRender',
     ];

--- a/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
@@ -39,7 +39,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
    * @return array
    *   The event names to listen for, and the methods that should be executed.
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       LogEvent::INSERT => 'syncBirthChildren',
       LogEvent::UPDATE => 'syncBirthChildren',


### PR DESCRIPTION
This PR adds Rector to the farmOS Docker dev image and runs `rector process --dry-run` on the farmOS codebase during our `delivery.yml` workflow on GitHub Actions. Rector identifies code that can be upgraded/refactored for new versions of Drupal and Symfony, and also helps find other general PHP coding improvements (alongside our current PHP CodeSniffer and PHPStan analysis).

We can also use it to automatically upgrade code for Drupal 11 (see https://www.drupal.org/project/farm/issues/3488916).

This PR also implements the changes recommended by Rector, which allows the new step in `deliver.yml` to pass.