### PR TITLE
Update to stable gin 4.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Update Drupal core to 10.4.0 #900](https://github.com/farmOS/farmOS/pull/900)
+- [Update to stable Gin 4.0.0 #903](https://github.com/farmOS/farmOS/pull/903)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "drupal/exif_orientation": "^1.2",
         "drupal/fraction": "^2.3.1",
         "drupal/geofield": "^1.40",
-        "drupal/gin": "3.0-rc16",
+        "drupal/gin": "4.0.0",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",
         "drupal/jsonapi_extras": "^3.22",

--- a/modules/core/ui/theme/css/views.css
+++ b/modules/core/ui/theme/css/views.css
@@ -60,7 +60,7 @@
 
 /* Specify gin variables for collapsible filter styles. */
 div.view-filters details > summary {
-  padding: var(--gin-spacing-m);
+  padding-block: var(--gin-spacing-s);
   font-weight: var(--gin-font-weight-semibold);
 }
 div.view-filters details > div {

--- a/modules/core/ui/theme/css/views.css
+++ b/modules/core/ui/theme/css/views.css
@@ -61,7 +61,6 @@
 /* Specify gin variables for collapsible filter styles. */
 div.view-filters details > summary {
   padding-block: var(--gin-spacing-s);
-  font-weight: var(--gin-font-weight-semibold);
 }
 div.view-filters details > div {
   margin: 0 0 0 var(--gin-spacing-s);

--- a/modules/core/ui/views/css/views_collapsible_filters.css
+++ b/modules/core/ui/views/css/views_collapsible_filters.css
@@ -3,7 +3,7 @@ div.view-filters details {
   margin: 0;
 }
 div.view-filters details > summary {
-  padding: 1rem;
+  padding-block: .75rem;
 }
 div.view-filters details > div {
   margin: 0 0 0 .75rem;


### PR DESCRIPTION
Gin has a stable release :partying_face: 

Also a couple commits to fix a minor thing with the views exposed filter details element.

I had thought the gin stable release would enable sticky action buttons by default but looks like this was only upgraded form "experimental" to "beta" and new users will not get this enabled by default. See [gin.settings.yml](https://git.drupalcode.org/project/gin/-/blob/4.0.0/config/install/gin.settings.yml?ref_type=tags#L12). So I don't think there is a need to do the update hook just yet - we had discussed: https://github.com/farmOS/farmOS/pull/852#issuecomment-2228571744