### PR TITLE
Contextual API

### DIFF
--- a/modules/core/asset/asset.services.yml
+++ b/modules/core/asset/asset.services.yml
@@ -1,0 +1,6 @@
+services:
+  asset.asset_route_context:
+    class: Drupal\asset\ContextProvider\AssetRouteContext
+    arguments: [ '@current_route_match' ]
+    tags:
+      - { name: 'context_provider' }

--- a/modules/core/asset/src/ContextProvider/AssetRouteContext.php
+++ b/modules/core/asset/src/ContextProvider/AssetRouteContext.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\asset\ContextProvider;
+
+use Drupal\asset\Entity\Asset;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Sets the current asset as a context on asset routes.
+ */
+class AssetRouteContext implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new AssetRouteContext.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match object.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $result = [];
+    $context_definition = EntityContextDefinition::create('asset')->setRequired(FALSE);
+    $value = NULL;
+    if (($route_object = $this->routeMatch->getRouteObject())) {
+      $route_contexts = $route_object->getOption('parameters');
+      // Check for an asset revision parameter first.
+      if (isset($route_contexts['asset_revision']) && $revision = $this->routeMatch->getParameter('asset_revision')) {
+        $value = $revision;
+      }
+      elseif (isset($route_contexts['asset']) && $asset = $this->routeMatch->getParameter('asset')) {
+        $value = $asset;
+      }
+      elseif ($this->routeMatch->getRouteName() == 'asset.add') {
+        $asset_type = $this->routeMatch->getParameter('asset_type');
+        $value = Asset::create(['type' => $asset_type->id()]);
+      }
+    }
+
+    $cacheability = new CacheableMetadata();
+    $cacheability->setCacheContexts(['route']);
+
+    $context = new Context($context_definition, $value);
+    $context->addCacheableDependency($cacheability);
+    $result['asset'] = $context;
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityTypeId('asset', $this->t('Asset from URL'));
+    return ['asset' => $context];
+  }
+
+}

--- a/modules/core/data_stream/src/Plugin/FarmContext/DataStreamAssetFarmContext.php
+++ b/modules/core/data_stream/src/Plugin/FarmContext/DataStreamAssetFarmContext.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\data_stream\Plugin\FarmContext;
+
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
+use Drupal\data_stream\Entity\DataStreamInterface;
+use Drupal\farm_ui_context\Plugin\FarmContext\FarmContextBase;
+
+/**
+ * Provides context when an asset is associated with a data stream.
+ *
+ * @FarmContext(
+ *   id = "data_stream_asset_farm_context",
+ *   admin_label = @Translation("Data stream asset farm context"),
+ *   context_definitions = {
+ *     "asset" = @ContextDefinition("entity:asset", label = @Translation("Asset")),
+ *   },
+ * )
+ */
+class DataStreamAssetFarmContext extends FarmContextBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMessages(): array {
+    $messages = [];
+
+    /** @var \Drupal\asset\Entity\AssetInterface $asset */
+    if ($asset = $this->getContextValue('asset')) {
+
+      // Query for plans the asset might be a part of.
+      $data_streams = \Drupal::entityTypeManager()->getStorage('data_stream')->loadByProperties([
+        'asset' => $asset->id(),
+      ]);
+
+      // Bail if no data streams.
+      $count = count($data_streams);
+      if ($count === 0) {
+        return $messages;
+      }
+
+      // Build a message summarizing the associated plans.
+      $message = "Data Streams ($count)";
+
+      $links = array_map(function (DataStreamInterface $data_stream) {
+        return $data_stream->toLink()->toString();
+      }, $data_streams);
+
+      $long_message = new PluralTranslatableMarkup(
+        $count,
+        'This asset is associated with @count data stream.',
+        'This asset is associated with @count data streams.',
+      );
+      $messages[] = [
+        'type' => 'info',
+        'message' => $message,
+        'long_message' => $long_message,
+        'links' => $links,
+      ];
+    }
+
+    return $messages;
+  }
+
+}

--- a/modules/core/plan/plan.services.yml
+++ b/modules/core/plan/plan.services.yml
@@ -1,0 +1,6 @@
+services:
+  plan.plan_route_context:
+    class: Drupal\plan\ContextProvider\PlanRouteContext
+    arguments: [ '@current_route_match' ]
+    tags:
+      - { name: 'context_provider' }

--- a/modules/core/plan/src/ContextProvider/PlanRouteContext.php
+++ b/modules/core/plan/src/ContextProvider/PlanRouteContext.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\plan\ContextProvider;
+
+use Drupal\plan\Entity\Plan;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Sets the current plan as a context on plan routes.
+ */
+class PlanRouteContext implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new PlanRouteContext.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match object.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $result = [];
+    $context_definition = EntityContextDefinition::create('plan')->setRequired(FALSE);
+    $value = NULL;
+    if (($route_object = $this->routeMatch->getRouteObject())) {
+      $route_contexts = $route_object->getOption('parameters');
+      // Check for a plan revision parameter first.
+      if (isset($route_contexts['plan_revision']) && $revision = $this->routeMatch->getParameter('plan_revision')) {
+        $value = $revision;
+      }
+      elseif (isset($route_contexts['plan']) && $plan = $this->routeMatch->getParameter('plan')) {
+        $value = $plan;
+      }
+      elseif ($this->routeMatch->getRouteName() == 'plan.add') {
+        $plan_type = $this->routeMatch->getParameter('plan_type');
+        $value = Plan::create(['type' => $plan_type->id()]);
+      }
+    }
+
+    $cacheability = new CacheableMetadata();
+    $cacheability->setCacheContexts(['route']);
+
+    $context = new Context($context_definition, $value);
+    $context->addCacheableDependency($cacheability);
+    $result['plan'] = $context;
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityTypeId('plan', $this->t('Plan from URL'));
+    return ['plan' => $context];
+  }
+
+}

--- a/modules/core/plan/src/Plugin/FarmContext/PlanAssetFarmContext.php
+++ b/modules/core/plan/src/Plugin/FarmContext/PlanAssetFarmContext.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\plan\Plugin\FarmContext;
+
+use Drupal\farm_ui_context\Plugin\FarmContext\FarmContextBase;
+
+/**
+ * Provides context when an asset in a part of a plan.
+ *
+ * @todo Move to a module with a better dependency on the plan.asset field.
+ *
+ * @FarmContext(
+ *   id = "plan_asset_farm_context",
+ *   admin_label = @Translation("Plan asset farm context"),
+ *   context_definitions = {
+ *     "asset" = @ContextDefinition("entity:asset", label = @Translation("Asset")),
+ *   },
+ * )
+ */
+class PlanAssetFarmContext extends FarmContextBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMessages(): array {
+    $messages = [];
+
+    /** @var \Drupal\asset\Entity\AssetInterface $asset */
+    if ($asset = $this->getContextValue('asset')) {
+
+      // Query for plans the asset might be a part of.
+      $plans = \Drupal::entityTypeManager()->getStorage('plan')->loadByProperties([
+        'asset' => $asset->id(),
+      ]);
+
+      // Build a message for each plan the asset is a part of.
+      foreach ($plans as $plan) {
+        $messages[] = [
+          'type' => 'info',
+          'message' => $this->t(
+            'This asset is a part of the plan: <a href="@plan_uri">@plan_label</a>',
+            [
+              '@plan_uri' => $plan->toUrl()->setAbsolute()->toString(),
+              '@plan_label' => $plan->label(),
+            ],
+          ),
+        ];
+      }
+    }
+
+    return $messages;
+  }
+
+}

--- a/modules/core/plan/src/Plugin/FarmContext/PlanAssetFarmContext.php
+++ b/modules/core/plan/src/Plugin/FarmContext/PlanAssetFarmContext.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\plan\Plugin\FarmContext;
 
+use Drupal\Core\StringTranslation\PluralTranslatableMarkup;
 use Drupal\farm_ui_context\Plugin\FarmContext\FarmContextBase;
+use Drupal\plan\Entity\PlanInterface;
 
 /**
  * Provides context when an asset in a part of a plan.
@@ -33,19 +35,29 @@ class PlanAssetFarmContext extends FarmContextBase {
         'asset' => $asset->id(),
       ]);
 
-      // Build a message for each plan the asset is a part of.
-      foreach ($plans as $plan) {
-        $messages[] = [
-          'type' => 'info',
-          'message' => $this->t(
-            'This asset is a part of the plan: <a href="@plan_uri">@plan_label</a>',
-            [
-              '@plan_uri' => $plan->toUrl()->setAbsolute()->toString(),
-              '@plan_label' => $plan->label(),
-            ],
-          ),
-        ];
+      // Bail if no plans.
+      $count = count($plans);
+      if ($count === 0) {
+        return $messages;
       }
+
+      // Build a message summarizing the associated plans.
+      $message = "Plans ($count)";
+      $links = array_map(function (PlanInterface $plan) {
+        return $plan->toLink()->toString();
+      }, $plans);
+
+      $long_message = new PluralTranslatableMarkup(
+        $count,
+        'This asset is associated with @count plan.',
+        'This asset is associated with @count plans.',
+      );
+      $messages[] = [
+        'type' => 'info',
+        'message' => $message,
+        'long_message' => $long_message,
+        'links' => $links,
+      ];
     }
 
     return $messages;

--- a/modules/core/plan/src/Plugin/FarmContext/PlanLogFarmContext.php
+++ b/modules/core/plan/src/Plugin/FarmContext/PlanLogFarmContext.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\plan\Plugin\FarmContext;
+
+use Drupal\farm_ui_context\Plugin\FarmContext\FarmContextBase;
+
+/**
+ * Provides context when a log in a part of a plan.
+ *
+ * @todo Move to a module with a better dependency on the plan.log field.
+ *
+ * @FarmContext(
+ *   id = "plan_log_farm_context",
+ *   admin_label = @Translation("Plan log farm context"),
+ *   context_definitions = {
+ *     "log" = @ContextDefinition("entity:log", label = @Translation("Log")),
+ *   },
+ * )
+ */
+class PlanLogFarmContext extends FarmContextBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMessages(): array {
+    $messages = [];
+
+    /** @var \Drupal\log\Entity\LogInterface $log */
+    if ($log = $this->getContextValue('log')) {
+
+      // Query for plans the log might be a part of.
+      $plans = \Drupal::entityTypeManager()->getStorage('plan')->loadByProperties([
+        'log' => $log->id(),
+      ]);
+
+      // Build a message for each plan the log is a part of.
+      foreach ($plans as $plan) {
+        $messages[] = [
+          'type' => 'info',
+          'message' => $this->t(
+            'This log is a part of the plan: <a href="@plan_uri">@plan_label</a>',
+            [
+              '@plan_uri' => $plan->toUrl()->setAbsolute()->toString(),
+              '@plan_label' => $plan->label(),
+            ],
+          ),
+        ];
+      }
+    }
+
+    return $messages;
+  }
+
+}

--- a/modules/core/ui/context/config/optional/block.block.farm_context.yml
+++ b/modules/core/ui/context/config/optional/block.block.farm_context.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - farm_ui_context
+  theme:
+    - gin
+id: farm_context
+theme: gin
+region: help
+weight: 0
+provider: null
+plugin: farm_context_block
+settings:
+  id: farm_context_block
+  label: 'Farm Context'
+  label_display: '0'
+  provider: farm_ui_context
+  context_mapping:
+    asset: '@asset.asset_route_context:asset'
+    log: '@farm_ui_context.log_route_context:log'
+    term: '@taxonomy_term.taxonomy_term_route_context:taxonomy_term'
+visibility: {  }

--- a/modules/core/ui/context/farm_ui_context.info.yml
+++ b/modules/core/ui/context/farm_ui_context.info.yml
@@ -1,0 +1,5 @@
+name: farmOS UI Context
+description: Allows modules to display contextual information.
+type: module
+package: farmOS UI
+core_version_requirement: ^10

--- a/modules/core/ui/context/farm_ui_context.info.yml
+++ b/modules/core/ui/context/farm_ui_context.info.yml
@@ -3,3 +3,8 @@ description: Allows modules to display contextual information.
 type: module
 package: farmOS UI
 core_version_requirement: ^10
+dependencies:
+  - drupal:block
+  - drupal:taxonomy
+  - farm:asset
+  - log:log

--- a/modules/core/ui/context/farm_ui_context.services.yml
+++ b/modules/core/ui/context/farm_ui_context.services.yml
@@ -1,0 +1,4 @@
+services:
+  plugin.manager.farm_context:
+    class: Drupal\farm_ui_context\FarmContextManager
+    parent: default_plugin_manager

--- a/modules/core/ui/context/farm_ui_context.services.yml
+++ b/modules/core/ui/context/farm_ui_context.services.yml
@@ -2,3 +2,10 @@ services:
   plugin.manager.farm_context:
     class: Drupal\farm_ui_context\FarmContextManager
     parent: default_plugin_manager
+  # TODO: Move log route context to log module.
+  # TODO: Update log context_mapping in farm_context block.
+  farm_ui_context.log_route_context:
+    class: Drupal\farm_ui_context\ContextProvider\LogRouteContext
+    arguments: ['@current_route_match']
+    tags:
+      - { name: 'context_provider' }

--- a/modules/core/ui/context/src/Annotation/FarmContext.php
+++ b/modules/core/ui/context/src/Annotation/FarmContext.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\farm_ui_context\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a FarmContext annotation object.
+ *
+ * @Annotation
+ */
+class FarmContext extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The administrative label of the block.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $admin_label = '';
+
+  /**
+   * An array of context definitions describing the context used by the plugin.
+   *
+   * The array is keyed by context names.
+   *
+   * @var \Drupal\Core\Annotation\ContextDefinition[]
+   */
+  public $context_definitions = [];
+
+}

--- a/modules/core/ui/context/src/ContextProvider/LogRouteContext.php
+++ b/modules/core/ui/context/src/ContextProvider/LogRouteContext.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Drupal\farm_ui_context\ContextProvider;
+
+use Drupal\log\Entity\Log;
+use Drupal\Core\Cache\CacheableMetadata;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextProviderInterface;
+use Drupal\Core\Plugin\Context\EntityContext;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Sets the current log as a context on log routes.
+ */
+class LogRouteContext implements ContextProviderInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The route match object.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  /**
+   * Constructs a new LogRouteContext.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match object.
+   */
+  public function __construct(RouteMatchInterface $route_match) {
+    $this->routeMatch = $route_match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRuntimeContexts(array $unqualified_context_ids) {
+    $result = [];
+    $context_definition = EntityContextDefinition::create('log')->setRequired(FALSE);
+    $value = NULL;
+    if (($route_object = $this->routeMatch->getRouteObject())) {
+      $route_contexts = $route_object->getOption('parameters');
+      // Check for a log revision parameter first.
+      if (isset($route_contexts['log_revision']) && $revision = $this->routeMatch->getParameter('log_revision')) {
+        $value = $revision;
+      }
+      elseif (isset($route_contexts['log']) && $log = $this->routeMatch->getParameter('log')) {
+        $value = $log;
+      }
+      elseif ($this->routeMatch->getRouteName() == 'log.add') {
+        $log_type = $this->routeMatch->getParameter('log_type');
+        $value = Log::create(['type' => $log_type->id()]);
+      }
+    }
+
+    $cacheability = new CacheableMetadata();
+    $cacheability->setCacheContexts(['route']);
+
+    $context = new Context($context_definition, $value);
+    $context->addCacheableDependency($cacheability);
+    $result['log'] = $context;
+
+    return $result;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAvailableContexts() {
+    $context = EntityContext::fromEntityTypeId('log', $this->t('Log from URL'));
+    return ['log' => $context];
+  }
+
+}

--- a/modules/core/ui/context/src/FarmContextManager.php
+++ b/modules/core/ui/context/src/FarmContextManager.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\farm_ui_context;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Plugin\FilteredPluginManagerTrait;
+
+/**
+ * Managed discovery and instantiation of FarmContext plugins.
+ *
+ * @see \Drupal\farm_ui_context\Plugin\FarmContext\FarmContextInterface
+ */
+class FarmContextManager extends DefaultPluginManager implements FarmContextManagerInterface {
+
+  use FilteredPluginManagerTrait;
+
+  /**
+   * Constructs a FarmContextManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/FarmContext',
+      $namespaces,
+      $module_handler,
+      'Drupal\farm_ui_context\Plugin\FarmContext\FarmContextInterface',
+      'Drupal\farm_ui_context\Annotation\FarmContext',
+    );
+    $this->alterInfo($this->getType());
+    $this->setCacheBackend($cache_backend, 'farm_context');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getType() {
+    return 'farm_context';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMessages(string $consumer, array $contexts = NULL, array $extra = []): array {
+
+    // Get applicable farm context plugins.
+    $definitions = $this->getFilteredDefinitions($consumer, $contexts);
+
+    // Collect messages from each plugin.
+    $messages = [];
+    foreach (array_keys($definitions) as $plugin_id) {
+      /** @var \Drupal\farm_ui_context\Plugin\FarmContext\FarmContextInterface $plugin */
+      $plugin = $this->createInstance($plugin_id);
+
+      // Set the plugin contexts.
+      if ($plugin instanceof ContextAwarePluginInterface) {
+        $this->contextHandler()->applyContextMapping($plugin, $contexts);
+      }
+
+      // Include the messages.
+      array_push($messages, ...$plugin->getMessages());
+    }
+
+    return $messages;
+  }
+
+}

--- a/modules/core/ui/context/src/FarmContextManagerInterface.php
+++ b/modules/core/ui/context/src/FarmContextManagerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\farm_ui_context;
+
+use Drupal\Core\Plugin\Context\ContextAwarePluginManagerInterface;
+use Drupal\Core\Plugin\FilteredPluginManagerInterface;
+
+/**
+ * Provides an interface the FarmContextManager.
+ */
+interface FarmContextManagerInterface extends ContextAwarePluginManagerInterface, FilteredPluginManagerInterface {
+
+  /**
+   * Return messages provided by farm context plugins.
+   *
+   * @param string $consumer
+   *   A string identifying the consumer of these farm context messages.
+   * @param array|null $contexts
+   *   (optional) Either an array of contexts to use for filtering, or NULL to
+   *   not filter by contexts.
+   * @param array $extra
+   *   (optional) An associative array containing additional information
+   *   provided by the code requesting the filtered definitions.
+   *
+   * @return array
+   *   An array of messages provided by farm context plugins.
+   *
+   * @see \Drupal\farm_ui_context\Plugin\FarmContext\FarmContextInterface::getMessages()
+   */
+  public function getMessages(string $consumer, array $contexts = NULL, array $extra = []): array;
+
+}

--- a/modules/core/ui/context/src/Plugin/Block/FarmContextBlock.php
+++ b/modules/core/ui/context/src/Plugin/Block/FarmContextBlock.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\farm_ui_context\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\farm_ui_context\FarmContextManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a farm context block.
+ *
+ * @Block(
+ *   id = "farm_context_block",
+ *   admin_label = @Translation("Farm Context"),
+ *   category = @Translation("Farm"),
+ *   context_definitions = {
+ *     "asset" = @ContextDefinition(
+ *        "entity:asset",
+ *        label = @Translation("Asset"),
+ *        required = FALSE
+ *     ),
+ *     "log" = @ContextDefinition(
+ *        "entity:log",
+ *        label = @Translation("Log"),
+ *        required = FALSE
+ *      ),
+ *     "plan" = @ContextDefinition(
+ *        "entity:plan",
+ *        label = @Translation("Plan"),
+ *        required = FALSE
+ *      ),
+ *     "term" = @ContextDefinition(
+ *        "entity:taxonomy_term",
+ *        label = @Translation("Term"),
+ *        required = FALSE
+ *     ),
+ *   }
+ * )
+ */
+class FarmContextBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * The farm context manager.
+   *
+   * @var \Drupal\farm_ui_context\FarmContextManagerInterface
+   */
+  protected $farmContextManager;
+
+  /**
+   * Constructs a new FarmContextBlock object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   * @param \Drupal\farm_ui_context\FarmContextManagerInterface $farm_context_manager
+   *   The farm context manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ModuleHandlerInterface $module_handler, FarmContextManagerInterface $farm_context_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->moduleHandler = $module_handler;
+    $this->farmContextManager = $farm_context_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('module_handler'),
+      $container->get('plugin.manager.farm_context'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContextDefinitions() {
+    $definitions = parent::getContextDefinitions();
+
+    // Remove the plan context definition if the plan module does not exist.
+    // This is a workaround so this module does not need to depend on plan.
+    if (!$this->moduleHandler->moduleExists('plan')) {
+      unset($definitions['plan']);
+    }
+    return $definitions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getContextMapping() {
+    $mapping = parent::getContextMapping();
+
+    // Add a default context mapping for plan entities. This is needed because
+    // we don't want to save the plan context mapping by default, but we do
+    // want plan entities to be included if the module is later enabled.
+    if ($this->moduleHandler->moduleExists('plan') && !isset($mapping['plan'])) {
+      $mapping['plan'] = "@plan.plan_route_context:plan";
+    }
+    // Ensure there is no context mapping if the plan module does not exist.
+    else {
+      unset($mapping['plan']);
+    }
+
+    return $mapping;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    // Filter out contexts that do not have a value.
+    // We need to define all entity contexts as optional for the block,
+    // but only pass on contexts that returned a value.
+    $contexts = $this->getContexts();
+    $valid_contexts = array_filter($contexts, function ($context) {
+      return $context->hasContextValue();
+    });
+
+    // Gather all farm context messages.
+    $messages = $this->farmContextManager->getMessages('farm_context_block', $valid_contexts);
+
+    // Return a build array with the context messages.
+    $build = [];
+    foreach ($messages as $message) {
+      $build[] = [
+        '#markup' => $this->t('@type: @message - @long_message', ['@type' => $message['type'], '@message' => $message['message'], '@long_message' => $message['long_message'] ?? '']),
+        '#prefix' => '<p>',
+        '#suffix' => '</p>',
+        '#weight' => $message['weight'] ?? 0,
+      ];
+    }
+
+    return $build;
+  }
+
+}

--- a/modules/core/ui/context/src/Plugin/Block/FarmContextBlock.php
+++ b/modules/core/ui/context/src/Plugin/Block/FarmContextBlock.php
@@ -138,17 +138,52 @@ class FarmContextBlock extends BlockBase implements ContainerFactoryPluginInterf
     // Gather all farm context messages.
     $messages = $this->farmContextManager->getMessages('farm_context_block', $valid_contexts);
 
+    // Bail if no messages.
+    if (count($messages) === 0) {
+      return [];
+    }
+
     // Return a build array with the context messages.
-    $build = [];
+    $title = [
+      '#theme' => 'item_list',
+      '#type' => 'ul',
+      '#attributes' => [
+      ],
+      '#items' => [],
+    ];
+    $body = [
+      '#theme' => 'item_list',
+      '#type' => 'ul',
+      '#attributes' => [
+      ],
+      '#items' => [],
+    ];
     foreach ($messages as $message) {
-      $build[] = [
-        '#markup' => $this->t('@type: @message - @long_message', ['@type' => $message['type'], '@message' => $message['message'], '@long_message' => $message['long_message'] ?? '']),
-        '#prefix' => '<p>',
-        '#suffix' => '</p>',
-        '#weight' => $message['weight'] ?? 0,
+      $link_string = implode(', ', $message['links'] ?? []);
+      $title['#items'][] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => "({$message['type']}) {$message['message']} $link_string",
+      ];
+      $body['#items'][] = [
+        '#type' => 'html_tag',
+        '#tag' => 'p',
+        '#value' => "({$message['type']}) {$message['long_message']} $link_string",
       ];
     }
 
+    // Build a details element.
+    $build = [
+      '#type' => 'details',
+      '#title' => $title,
+      '#open' => FALSE,
+      'body' => $body,
+    ];
+
+    // @todo determine cache strategy.
+    $build['#cache'] = [
+      'max-age' => 0,
+    ];
     return $build;
   }
 

--- a/modules/core/ui/context/src/Plugin/FarmContext/FarmContextBase.php
+++ b/modules/core/ui/context/src/Plugin/FarmContext/FarmContextBase.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\farm_ui_context\Plugin\FarmContext;
+
+use Drupal\Core\Plugin\ContextAwarePluginAssignmentTrait;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+use Drupal\Core\Plugin\ContextAwarePluginTrait;
+use Drupal\Core\Plugin\PluginBase;
+
+/**
+ * Base implementation of the FarmContext plugin.
+ */
+abstract class FarmContextBase extends PluginBase implements FarmContextInterface, ContextAwarePluginInterface {
+
+  use ContextAwarePluginTrait;
+  use ContextAwarePluginAssignmentTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return [];
+  }
+
+}

--- a/modules/core/ui/context/src/Plugin/FarmContext/FarmContextInterface.php
+++ b/modules/core/ui/context/src/Plugin/FarmContext/FarmContextInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\farm_ui_context\Plugin\FarmContext;
+
+use Drupal\Component\Plugin\DependentPluginInterface;
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+
+/**
+ * Defines an interface for farm context plugins.
+ */
+interface FarmContextInterface extends CacheableDependencyInterface, DependentPluginInterface, PluginInspectionInterface {
+
+  /**
+   * Get the context messages provided by the plugin.
+   *
+   * @return array
+   *   An array of messages that match the plugin context. Each message is an
+   *   array containing the following keys:
+   *     type: The message type.
+   *     message: A message string.
+   *     long_message: (Optional) A longer message with more information.
+   *     weight: (Optional) The weight of the message when rendering.
+   */
+  public function getMessages(): array;
+
+}

--- a/modules/core/ui/context/src/Plugin/FarmContext/FarmContextInterface.php
+++ b/modules/core/ui/context/src/Plugin/FarmContext/FarmContextInterface.php
@@ -20,6 +20,7 @@ interface FarmContextInterface extends CacheableDependencyInterface, DependentPl
    *     type: The message type.
    *     message: A message string.
    *     long_message: (Optional) A longer message with more information.
+   *     links: (Optional) An array of links to display with the message.
    *     weight: (Optional) The weight of the message when rendering.
    */
   public function getMessages(): array;

--- a/modules/core/ui/farm_ui.info.yml
+++ b/modules/core/ui/farm_ui.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^10
 dependencies:
   - farm:farm_ui_action
   - farm:farm_ui_breadcrumb
+  - farm:farm_ui_context
   - farm:farm_ui_dashboard
   - farm:farm_ui_help
   - farm:farm_ui_location

--- a/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
@@ -40,9 +40,9 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
   public function access(RouteMatchInterface $route_match) {
 
     // If there is no "asset" or "log_type" parameter, bail.
-    $asset_id = $route_match->getParameter('asset');
+    $asset = $route_match->getParameter('asset');
     $log_type = $route_match->getParameter('log_type');
-    if (empty($asset_id) || empty($log_type)) {
+    if (empty($asset) || empty($log_type)) {
       return AccessResult::allowed();
     }
 
@@ -59,8 +59,8 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
 
     // Only include logs that reference the asset.
     $reference_condition = $query->orConditionGroup()
-      ->condition('asset.entity.id', $asset_id)
-      ->condition('location.entity.id', $asset_id);
+      ->condition('asset.entity.id', $asset->id())
+      ->condition('location.entity.id', $asset->id());
     $query->condition($reference_condition);
 
     // Determine access based on the log count.

--- a/modules/core/ui/views/src/Routing/RouteSubscriber.php
+++ b/modules/core/ui/views/src/Routing/RouteSubscriber.php
@@ -25,6 +25,16 @@ class RouteSubscriber extends RouteSubscriberBase {
 
       // Set default log_type to mark primary tab as active.
       $route->setDefault('log_type', 'all');
+
+      // @todo Fix so that an asset context message displays on views tabs.
+      // This is needed so that the asset route parameter can pick up the route.
+      // General issue: https://www.drupal.org/project/drupal/issues/2528166
+      // Specify the asset parameter's type.
+      $parameters = $route->getOption('parameters');
+      $parameters['asset'] = [
+        'type' => 'entity:asset',
+      ];
+      $route->setOption('parameters', $parameters);
     }
 
     // Add our _asset_children_access requirement to


### PR DESCRIPTION
See https://gitlab.com/OpenTEAMAg/feedback/support_requests/-/issues/208

I've just dusted off my previous [2.x-context branch](https://github.com/paul121/farmOS/tree/2.x-context) and rebased on latest 3.x. Opening a draft PR so this doesn't get lost going forward.

I want to review some of the implementation details, but here is the current status and quick notes:
- A new `FarmContext` plugin that is `ContextAware` to detect Asset, Log, Plan, etc entity types. Facilitate by `FarmContextManager` service.
  - Context aware plugins are a somewhat magical part of this. Initially, this allows us to easily get an entity based of the entity set in the route parameters/context + works nicely with Block plugin contexts.
  - But via the manager, this also provides a nice API of sorts to gather contextual information about an entity in other contexts, just set the necessary context and ask away. Could be useful for contextual information via API or other locations in UI
- Context plugins can provide an array of messages with: a type (info/warning/etc), short text, long text, array of related links and a weight.
- A new FarmContextBlock plugin that renders contextual info a `details` element. An instance of this block is configured to render in the `help` region (below task links and status messages).

It's been almost 2 years but all of the above was still working with minimal changes :D It definitely needs a through review and could possible use new Drupal core APIs/PHP language features (attributes vs annotation, etc) BUT I think I do still feel good about this general architecture. It feels quite robust and can be adapted to our needs, but should evaluate this again as well.