### PR TITLE
Update simple_oauth to 6.0.0-beta8 and unpin version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Update Drupal core to 10.4.0 #900](https://github.com/farmOS/farmOS/pull/900)
 - [Update to stable Gin 4.0.0 #903](https://github.com/farmOS/farmOS/pull/903)
-- [Update simple_oauth to 6.0.0-beta7 #893](https://github.com/farmOS/farmOS/pull/`893`)
+- [Update simple_oauth to 6.0.0-beta7 #893](https://github.com/farmOS/farmOS/pull/893)
+- [Update simple_oauth to 6.0.0-beta8 #905](https://github.com/farmOS/farmOS/pull/905)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Update Drupal core to 10.4.0 #900](https://github.com/farmOS/farmOS/pull/900)
 - [Update to stable Gin 4.0.0 #903](https://github.com/farmOS/farmOS/pull/903)
 - [Update simple_oauth to 6.0.0-beta7 #893](https://github.com/farmOS/farmOS/pull/893)
-- [Update simple_oauth to 6.0.0-beta8 #905](https://github.com/farmOS/farmOS/pull/905)
+- [Update simple_oauth to 6.0.0-beta8 and unpin version constraint #905](https://github.com/farmOS/farmOS/pull/905)
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "drupal/migrate_source_ui": "^1.0",
         "drupal/migrate_tools": "^6.0.3",
         "drupal/role_delegation": "^1.2",
-        "drupal/simple_oauth": "6.0.0-beta7",
+        "drupal/simple_oauth": "6.0.0-beta8",
         "drupal/simple_oauth_password_grant": "^1.0@RC",
         "drupal/state_machine": "^1.9",
         "drupal/subrequests": "^3.0.6",
@@ -82,9 +82,6 @@
                 "Issue #3322227: Document schema title wrong for multiple resource types": "https://www.drupal.org/files/issues/2022-11-17/3322227-0.patch",
                 "Issue #3397275: Use OptionsProviderInterface::getPossibleOptions() for allowed field values (anyOf / oneOf)": "https://www.drupal.org/files/issues/2024-03-29/3397275-5.patch",
                 "Issue #3390505: Error: uri is not a valid type for a JSON document": "https://www.drupal.org/files/issues/2024-04-11/3390505-3.patch"
-            },
-            "drupal/simple_oauth": {
-                "Issue #3322325: Cannot authorize clients with empty string set as secret": "https://www.drupal.org/files/issues/2024-05-07/3322325-13.patch"
             },
             "itamair/geophp": {
                 "Use BCMath (where available) for all float arithmetic #115": "https://patch-diff.githubusercontent.com/raw/phayes/geoPHP/pull/115.patch"

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "drupal/migrate_source_ui": "^1.0",
         "drupal/migrate_tools": "^6.0.3",
         "drupal/role_delegation": "^1.2",
-        "drupal/simple_oauth": "6.0.0-beta8",
+        "drupal/simple_oauth": "^6.0@beta",
         "drupal/simple_oauth_password_grant": "^1.0@RC",
         "drupal/state_machine": "^1.9",
         "drupal/subrequests": "^3.0.6",


### PR DESCRIPTION
With this [6.0.0-beta8 release](https://www.drupal.org/project/simple_oauth/releases/6.0.0-beta8) we can remove our patch for [issue #3322325](https://www.drupal.org/project/simple_oauth/issues/3322325)