### PR TITLE
Require that PHP use statements are sorted alphabetically

### DIFF
--- a/docker/dev/files/phpcs.xml
+++ b/docker/dev/files/phpcs.xml
@@ -19,6 +19,12 @@
   <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing">
     <severity>5</severity>
   </rule>
+  # @todo https://www.drupal.org/project/coding_standards/issues/1624564
+  <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses">
+    <properties>
+      <property name="caseSensitive" value="true"/>
+    </properties>
+  </rule>
   <rule ref="PHPCompatibility"/>
   <config name="testVersion" value="8.2-"/>
   <rule ref="Internal.Tokenizer.Exception"><severity>0</severity></rule>


### PR DESCRIPTION
#686 fixed PHP CodeSniffer errors that started showing up when a new rule was introduced upstream to enforce that `use` statements are sorted alphabetically.

Sounds like there was disagreement about that, so the `coder` module removed it (https://www.drupal.org/project/coder/issues/3483028) pending further discussion in the Drupal coding standards group (https://www.drupal.org/project/coding_standards/issues/1624564).

So even though we went to the effort of sorting our `use` statements, it's now possible that unsorted statements could be added and the tests would pass.

This PR re-enables this check so that we can continue to enforce that our `use` statements are sorted alphabetically.