### PR TITLE
Convert Drupal core annotations to attributes

### DIFF
--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -8,6 +8,8 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinderComposerRuntime;
+use DrupalRector\Drupal10\Rector\Deprecation\AnnotationToAttributeRector;
+use DrupalRector\Drupal10\Rector\ValueObject\AnnotationToAttributeConfiguration;
 use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
 use DrupalRector\Set\Drupal10SetList;
 use Rector\Config\RectorConfig;
@@ -39,5 +41,20 @@ return static function (RectorConfig $rectorConfig): void {
     ShouldCallParentMethodsRector::class => [
       '*/modules/core/location/tests/src/Functional/LocationTest.php',
     ],
+  ]);
+
+  // Ensure that annotations are not used when attributes are available.
+  // @todo Remove this if/when PHPStan or PHP CodeSniffer can check for it.
+  $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'Action', 'Drupal\Core\Action\Attribute\Action'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'Block', 'Drupal\Core\Block\Attribute\Block'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'Constraint', 'Drupal\Core\Validation\Attribute\Constraint'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'DataType', 'Drupal\Core\TypedData\Attribute\DataType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'FieldFormatter', 'Drupal\Core\Field\Attribute\FieldFormatter'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'FieldType', 'Drupal\Core\Field\Attribute\FieldType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'FieldWidget', 'Drupal\Core\Field\Attribute\FieldWidget'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateDestination', 'Drupal\migrate\Attribute\MigrateDestination'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateProcessPlugin', 'Drupal\migrate\Attribute\MigrateProcess'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsDisplayExtender', 'Drupal\views\Attribute\ViewsDisplayExtender'),
   ]);
 };

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraint.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraint.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group\Plugin\Validation\Constraint;
 
-use Symfony\Component\Validator\Constraint;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
 
 /**
  * Checks that a log is not creating a circular group membership.
- *
- * @Constraint(
- *   id = "CircularGroupMembership",
- *   label = @Translation("Circular group membership", context = "Validation"),
- * )
  */
-class CircularGroupMembershipConstraint extends Constraint {
+#[Constraint(
+  id: 'CircularGroupMembership',
+  label: new TranslatableMarkup('Circular group membership', ['context' => 'Validation']),
+)]
+class CircularGroupMembershipConstraint extends SymfonyConstraint {
 
   /**
    * The default violation message.

--- a/modules/core/asset/src/Plugin/Action/AssetActivate.php
+++ b/modules/core/asset/src/Plugin/Action/AssetActivate.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\asset\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Action that makes an asset active.
- *
- * @Action(
- *   id = "asset_activate_action",
- *   label = @Translation("Makes an Asset active"),
- *   type = "asset"
- * )
  */
+#[Action(
+  id: 'asset_activate_action',
+  label: new TranslatableMarkup('Makes an Asset active'),
+  type: 'asset',
+)]
 class AssetActivate extends AssetStateChangeBase {
 
   /**

--- a/modules/core/asset/src/Plugin/Action/AssetArchive.php
+++ b/modules/core/asset/src/Plugin/Action/AssetArchive.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\asset\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Action that archives an asset.
- *
- * @Action(
- *   id = "asset_archive_action",
- *   label = @Translation("Archive an asset"),
- *   type = "asset"
- * )
  */
+#[Action(
+  id: 'asset_archive_action',
+  label: new TranslatableMarkup('Archive an asset'),
+  type: 'asset',
+)]
 class AssetArchive extends AssetStateChangeBase {
 
   /**

--- a/modules/core/asset/src/Plugin/Action/AssetClone.php
+++ b/modules/core/asset/src/Plugin/Action/AssetClone.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\asset\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\asset\Entity\AssetInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Action that clones an asset.
- *
- * @Action(
- *   id = "asset_clone_action",
- *   label = @Translation("Clone an asset"),
- *   type = "asset"
- * )
  */
+#[Action(
+  id: 'asset_clone_action',
+  label: new TranslatableMarkup('Clone an asset'),
+  type: 'asset',
+)]
 class AssetClone extends EntityActionBase {
 
   /**

--- a/modules/core/data_stream/src/Plugin/migrate/destination/DataStream.php
+++ b/modules/core/data_stream/src/Plugin/migrate/destination/DataStream.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\data_stream\Plugin\migrate\destination;
 
+use Drupal\migrate\Attribute\MigrateDestination;
 use Drupal\migrate\Plugin\migrate\destination\EntityContentBase;
 use Drupal\migrate\Row;
 
@@ -14,12 +15,10 @@ use Drupal\migrate\Row;
  * to assets that provide data streams. This is necessary because there was
  * no concept of data streams in farmOS 1.x. When creating a data stream from a
  * sensor asset, we need to reference the asset at this time.
- *
- * @MigrateDestination(
- *   id = "data_stream",
- *   provider = "data_stream"
- * )
  */
+#[MigrateDestination(
+  id: 'data_stream',
+)]
 class DataStream extends EntityContentBase {
 
   /**

--- a/modules/core/data_stream/src/Plugin/migrate/process/DataStreamFromAsset.php
+++ b/modules/core/data_stream/src/Plugin/migrate/process/DataStreamFromAsset.php
@@ -6,6 +6,7 @@ namespace Drupal\data_stream\Plugin\migrate\process;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -16,11 +17,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * This is helpful in migrating data that was previously associated with
  * a sensor asset ID.
- *
- * @MigrateProcessPlugin(
- *   id = "data_stream_from_asset"
- * )
  */
+#[MigrateProcess(
+  id: 'data_stream_from_asset',
+)]
 class DataStreamFromAsset extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
@@ -4,21 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_export_csv\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\farm_export_csv\Plugin\Action\Derivative\EntityCsvDeriver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Action that exports a CSV file of entities.
- *
- * @Action(
- *   id = "entity:csv_action",
- *   action_label = @Translation("Export entity as CSV"),
- *   deriver = "Drupal\farm_export_csv\Plugin\Action\Derivative\EntityCsvDeriver",
- * )
  */
+#[Action(
+  id: 'entity:csv_action',
+  action_label: new TranslatableMarkup('Export entity as CSV'),
+  deriver: EntityCsvDeriver::class,
+)]
 class EntityCsv extends EntityActionBase {
 
   /**

--- a/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_export_csv\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Action that exports a CSV file of log quantities.
- *
- * @Action(
- *   id = "farm_export_csv:log_quantity",
- *   action_label = @Translation("Export Quantities CSV"),
- *   type = "log",
- *   confirm_form_route_name = "entity.quantity.csv_form",
- * )
  */
+#[Action(
+  id: 'farm_export_csv:log_quantity',
+  action_label: new TranslatableMarkup('Export Quantities CSV'),
+  type: 'log',
+  confirm_form_route_name: 'entity.quantity.csv_form',
+)]
 class LogQuantityCsv extends EntityActionBase {
 
   /**

--- a/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
+++ b/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
@@ -4,25 +4,27 @@ declare(strict_types=1);
 
 namespace Drupal\farm_export_kml\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\File\FileUrlGeneratorInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_export_kml\Plugin\Action\Derivative\EntityKmlDeriver;
 use Drupal\file\FileRepositoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
  * Action that exports KML from an entity geofield.
- *
- * @Action(
- *   id = "entity:kml_action",
- *   action_label = @Translation("Export entity geometry as KML"),
- *   deriver = "Drupal\farm_export_kml\Plugin\Action\Derivative\EntityKmlDeriver",
- * )
  */
+#[Action(
+  id: 'entity:kml_action',
+  action_label: new TranslatableMarkup('Export entity geometry as KML'),
+  deriver: EntityKmlDeriver::class,
+)]
 class EntityKml extends EntityActionBase {
 
   /**

--- a/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
+++ b/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
@@ -4,24 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_field\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldFormatter\BooleanFormatter;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Plugin implementation of the 'hideable_boolean' formatter.
  *
  * Extends the core BooleanFormatter to provide settings to conditionally hide
  * a field.
- *
- * @FieldFormatter(
- *   id = "hideable_boolean",
- *   label = @Translation("Hideable Boolean"),
- *   field_types = {
- *     "boolean",
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'hideable_boolean',
+  label: new TranslatableMarkup('Hideable Boolean'),
+  field_types: ['boolean'],
+)]
 class HideableBoolean extends BooleanFormatter {
 
   /**

--- a/modules/core/field/src/Plugin/Field/FieldFormatter/UrlLinkFormatter.php
+++ b/modules/core/field/src/Plugin/Field/FieldFormatter/UrlLinkFormatter.php
@@ -4,21 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\farm_field\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 
 /**
  * Plugin implementation of the 'url_link' formatter.
- *
- * @FieldFormatter(
- *   id = "url_link",
- *   label = @Translation("Link to URL"),
- *   field_types = {
- *     "uri",
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'url_link',
+  label: new TranslatableMarkup('Link to URL'),
+  field_types: ['uri'],
+)]
 class UrlLinkFormatter extends FormatterBase {
 
   /**

--- a/modules/core/field/src/Plugin/Field/FieldWidget/TimestampDatetimeOptionalWidget.php
+++ b/modules/core/field/src/Plugin/Field/FieldWidget/TimestampDatetimeOptionalWidget.php
@@ -6,7 +6,9 @@ namespace Drupal\farm_field\Plugin\Field\FieldWidget;
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Datetime\Plugin\Field\FieldWidget\TimestampDatetimeWidget;
+use Drupal\Core\Field\Attribute\FieldWidget;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Plugin implementation of the 'datetime timestamp optional' widget.
@@ -14,15 +16,12 @@ use Drupal\Core\Form\FormStateInterface;
  * Extends the core datetime_timestamp widget to not default to current time.
  * This is useful when a timestamp field is optional and should not default
  * to the current time, such as the animal birthdate.
- *
- * @FieldWidget(
- *   id = "datetime_timestamp_optional",
- *   label = @Translation("Datetime Timestamp Optional"),
- *   field_types = {
- *     "timestamp",
- *   }
- * )
  */
+#[FieldWidget(
+  id: 'datetime_timestamp_optional',
+  label: new TranslatableMarkup('Datetime Timestamp Optional'),
+  field_types: ['timestamp'],
+)]
 class TimestampDatetimeOptionalWidget extends TimestampDatetimeWidget {
 
   /**

--- a/modules/core/field/src/Plugin/Field/FieldWidget/UriStringWidget.php
+++ b/modules/core/field/src/Plugin/Field/FieldWidget/UriStringWidget.php
@@ -4,21 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\farm_field\Plugin\Field\FieldWidget;
 
+use Drupal\Core\Field\Attribute\FieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldWidget\UriWidget;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Plugin implementation of the 'uri_string' widget.
- *
- * @FieldWidget(
- *   id = "uri_string",
- *   label = @Translation("URI string field"),
- *   field_types = {
- *     "uri",
- *   }
- * )
  */
+#[FieldWidget(
+  id: 'uri_string',
+  label: new TranslatableMarkup('URI string field'),
+  field_types: ['uri'],
+)]
 class UriStringWidget extends UriWidget {
 
   /**

--- a/modules/core/field/src/Plugin/Validation/Constraint/Uri.php
+++ b/modules/core/field/src/Plugin/Validation/Constraint/Uri.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_field\Plugin\Validation\Constraint;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
 use Symfony\Component\Validator\Constraints\Url;
 
 /**
  * Checks that a URI is valid.
- *
- * @Constraint(
- *   id = "Uri",
- *   label = @Translation("Valid URI", context = "Validation"),
- * )
  */
+#[Constraint(
+  id: 'Uri',
+  label: new TranslatableMarkup('Valid URI', ['context' => 'Validation']),
+)]
 class Uri extends Url {
 
   /**

--- a/modules/core/flag/src/Plugin/Action/EntityFlag.php
+++ b/modules/core/flag/src/Plugin/Action/EntityFlag.php
@@ -4,21 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_flag\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\farm_flag\Plugin\Action\Derivative\EntityFlagDeriver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Redirects to a form to add flags to the entity.
- *
- * @Action(
- *   id = "entity:flag_action",
- *   action_label = @Translation("Flag an entity"),
- *   deriver = "Drupal\farm_flag\Plugin\Action\Derivative\EntityFlagDeriver",
- * )
  */
+#[Action(
+  id: 'entity:flag_action',
+  action_label: new TranslatableMarkup('Flag an entity'),
+  deriver: EntityFlagDeriver::class,
+)]
 class EntityFlag extends EntityActionBase {
 
   /**

--- a/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
@@ -5,22 +5,21 @@ declare(strict_types=1);
 namespace Drupal\farm_id_tag\Plugin\Field\FieldFormatter;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the 'id tag' formatter.
- *
- * @FieldFormatter(
- *   id = "id_tag",
- *   label = @Translation("ID tag"),
- *   field_types = {
- *     "id_tag"
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'id_tag',
+  label: new TranslatableMarkup('ID tag'),
+  field_types: ['id_tag'],
+)]
 class IdTagFormatter extends FormatterBase {
 
   /**

--- a/modules/core/id_tag/src/Plugin/Field/FieldType/IdTagItem.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldType/IdTagItem.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_id_tag\Plugin\Field\FieldType;
 
+use Drupal\Core\Field\Attribute\FieldType;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TypedData\DataDefinition;
 
 /**
  * Plugin implementation of the 'ID tag' field type.
- *
- * @FieldType(
- *   id = "id_tag",
- *   label = @Translation("ID tag"),
- *   description = @Translation("This field stores a combination of id, tag type and location."),
- *   no_ui = TRUE,
- *   default_widget = "id_tag",
- *   default_formatter = "id_tag"
- * )
  */
+#[FieldType(
+  id: 'id_tag',
+  label: new TranslatableMarkup('ID tag'),
+  description: new TranslatableMarkup('This field stores a combination of id, tag type and location.'),
+  default_widget: 'id_tag',
+  default_formatter: 'id_tag',
+  no_ui: TRUE,
+)]
 class IdTagItem extends FieldItemBase {
 
   /**

--- a/modules/core/id_tag/src/Plugin/Field/FieldWidget/IdTagWidget.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldWidget/IdTagWidget.php
@@ -4,21 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\farm_id_tag\Plugin\Field\FieldWidget;
 
+use Drupal\Core\Field\Attribute\FieldWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Plugin implementation of the 'id tag' widget.
- *
- * @FieldWidget(
- *   id = "id_tag",
- *   label = @Translation("ID tag"),
- *   field_types = {
- *     "id_tag"
- *   }
- * )
  */
+#[FieldWidget(
+  id: 'id_tag',
+  label: new TranslatableMarkup('ID tag'),
+  field_types: ['id_tag'],
+)]
 class IdTagWidget extends WidgetBase {
 
   /**

--- a/modules/core/id_tag/src/Plugin/Validation/Constraint/IdTagTypeConstraint.php
+++ b/modules/core/id_tag/src/Plugin/Validation/Constraint/IdTagTypeConstraint.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_id_tag\Plugin\Validation\Constraint;
 
-use Symfony\Component\Validator\Constraint;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
 
 /**
  * Checks that ID tag type is valid.
- *
- * @Constraint(
- *   id = "IdTagType",
- *   label = @Translation("Valid ID tag type", context = "Validation"),
- * )
  */
-class IdTagTypeConstraint extends Constraint {
+#[Constraint(
+  id: 'IdTagType',
+  label: new TranslatableMarkup('Valid ID tag type', ['context' => 'Validation']),
+)]
+class IdTagTypeConstraint extends SymfonyConstraint {
 
   /**
    * The default violation message.

--- a/modules/core/inventory/src/Plugin/Field/FieldFormatter/InventoryFormatter.php
+++ b/modules/core/inventory/src/Plugin/Field/FieldFormatter/InventoryFormatter.php
@@ -4,20 +4,19 @@ declare(strict_types=1);
 
 namespace Drupal\farm_inventory\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Plugin implementation of the 'inventory' formatter.
- *
- * @FieldFormatter(
- *   id = "inventory",
- *   label = @Translation("Inventory"),
- *   field_types = {
- *     "inventory"
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'inventory',
+  label: new TranslatableMarkup('Inventory'),
+  field_types: ['inventory'],
+)]
 class InventoryFormatter extends FormatterBase {
 
   /**

--- a/modules/core/inventory/src/Plugin/Field/FieldType/InventoryItem.php
+++ b/modules/core/inventory/src/Plugin/Field/FieldType/InventoryItem.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\farm_inventory\Plugin\Field\FieldType;
 
+use Drupal\Core\Field\Attribute\FieldType;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TypedData\DataDefinition;
 
 /**
  * Plugin implementation of the 'Inventory' field type.
- *
- * @FieldType(
- *   id = "inventory",
- *   label = @Translation("Inventory"),
- *   description = @Translation("This field stores asset inventory information."),
- *   category = @Translation("farmOS"),
- *   no_ui = TRUE,
- * )
  */
+#[FieldType(
+  id: 'inventory',
+  label: new TranslatableMarkup('Inventory'),
+  description: new TranslatableMarkup('This field stores asset inventory information.'),
+  category: 'farmOS',
+  no_ui: TRUE,
+)]
 class InventoryItem extends FieldItemBase {
 
   /**

--- a/modules/core/location/src/Plugin/Field/FieldFormatter/AssetCurrentLocationFormatter.php
+++ b/modules/core/location/src/Plugin/Field/FieldFormatter/AssetCurrentLocationFormatter.php
@@ -4,22 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\Plugin\Field\FieldFormatter\EntityReferenceLabelFormatter;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Field formatter for the current location asset field.
- *
- * @FieldFormatter(
- *   id = "asset_current_location",
- *   label = @Translation("Asset current location"),
- *   description = @Translation("Display the label of the referenced entities."),
- *   field_types = {
- *     "entity_reference"
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'asset_current_location',
+  label: new TranslatableMarkup('Asset current location'),
+  description: new TranslatableMarkup('Display the label of the referenced entities.'),
+  field_types: ['entity_reference'],
+)]
 class AssetCurrentLocationFormatter extends EntityReferenceLabelFormatter {
 
   /**

--- a/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraint.php
+++ b/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraint.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location\Plugin\Validation\Constraint;
 
-use Symfony\Component\Validator\Constraint;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
 
 /**
  * Checks that a log is not creating a circular asset location.
- *
- * @Constraint(
- *   id = "CircularAssetLocation",
- *   label = @Translation("Circular asset location", context = "Validation"),
- * )
  */
-class CircularAssetLocationConstraint extends Constraint {
+#[Constraint(
+  id: 'CircularAssetLocation',
+  label: new TranslatableMarkup('Circular asset location', ['context' => 'Validation']),
+)]
+class CircularAssetLocationConstraint extends SymfonyConstraint {
 
   /**
    * The default violation message.

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Action that adds a log referencing assets.
- *
- * @Action(
- *   id = "asset_add_log_action",
- *   label = @Translation("Add a log referencing assets."),
- *   type = "asset",
- *   confirm_form_route_name = "farm_log.asset_add_log_action_form"
- * )
  */
+#[Action(
+  id: 'asset_add_log_action',
+  label: new TranslatableMarkup('Add a log referencing assets.'),
+  type: 'asset',
+  confirm_form_route_name: 'farm_log.asset_add_log_action_form',
+)]
 class AssetAddLog extends EntityActionBase {
 
   /**

--- a/modules/core/map/src/Plugin/Block/MapBlock.php
+++ b/modules/core/map/src/Plugin/Block/MapBlock.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\farm_map\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginDependencyTrait;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a map block.
- *
- * @Block(
- *   id = "map_block",
- *   admin_label = @Translation("Map block"),
- * )
  */
+#[Block(
+  id: 'map_block',
+  admin_label: new TranslatableMarkup('Map block'),
+)]
 class MapBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   use PluginDependencyTrait;

--- a/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
+++ b/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\farm_map\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\geofield\GeoPHP\GeoPHPInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the map 'geofield' formatter.
- *
- * @FieldFormatter(
- *   id = "farm_map_geofield",
- *   label = @Translation("farmOS Map"),
- *   field_types = {
- *     "geofield"
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'farm_map_geofield',
+  label: new TranslatableMarkup('farmOS Map'),
+  field_types: ['geofield'],
+)]
 class GeofieldFormatter extends FormatterBase {
 
   /**

--- a/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
+++ b/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
@@ -7,10 +7,12 @@ namespace Drupal\farm_map\Plugin\Field\FieldWidget;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\Attribute\FieldWidget;
 use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\File\FileSystem;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\file\FileInterface;
 use Drupal\geofield\GeoPHP\GeoPHPInterface;
@@ -21,15 +23,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Plugin implementation of the map 'geofield' widget.
- *
- * @FieldWidget(
- *   id = "farm_map_geofield",
- *   label = @Translation("farmOS Map"),
- *   field_types = {
- *     "geofield"
- *   }
- * )
  */
+#[FieldWidget(
+  id: 'farm_map_geofield',
+  label: new TranslatableMarkup('farmOS Map'),
+  field_types: ['geofield'],
+)]
 class GeofieldWidget extends GeofieldBaseWidget {
 
   use WktTrait;

--- a/modules/core/migrate/src/Plugin/migrate/process/AssetLookup.php
+++ b/modules/core/migrate/src/Plugin/migrate/process/AssetLookup.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_migrate\Plugin\migrate\process;
 
 use Drupal\Component\Uuid\Uuid;
+use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\MigrateSkipRowException;
 use Drupal\migrate\Row;
@@ -32,14 +33,12 @@ use Drupal\migrate_plus\Plugin\migrate\process\EntityLookup;
  *     plugin: asset_lookup
  *     source: asset
  * @endcode
-
  * @codingStandardsIgnoreEnd
- *
- * @MigrateProcessPlugin(
- *   id = "asset_lookup",
- *   handle_multiples = FALSE
- * )
  */
+#[MigrateProcess(
+  id: 'asset_lookup',
+  handle_multiples: FALSE,
+)]
 class AssetLookup extends EntityLookup {
 
   /**

--- a/modules/core/migrate/src/Plugin/migrate/process/Boolean.php
+++ b/modules/core/migrate/src/Plugin/migrate/process/Boolean.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_migrate\Plugin\migrate\process;
 
+use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
@@ -22,13 +23,11 @@ use Drupal\migrate\Row;
  *     plugin: boolean
  *     source: is_movement
  * @endcode
-
  * @codingStandardsIgnoreEnd
- *
- * @MigrateProcessPlugin(
- *   id = "boolean"
- * )
  */
+#[MigrateProcess(
+  id: 'boolean',
+)]
 class Boolean extends ProcessPluginBase {
 
   /**

--- a/modules/core/migrate/src/Plugin/migrate/process/TermLookup.php
+++ b/modules/core/migrate/src/Plugin/migrate/process/TermLookup.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_migrate\Plugin\migrate\process;
 
+use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\MigrateSkipRowException;
 use Drupal\migrate\Row;
@@ -23,14 +24,12 @@ use Drupal\migrate_plus\Plugin\migrate\process\EntityLookup;
  *     plugin: term_lookup
  *     source: term
  * @endcode
-
  * @codingStandardsIgnoreEnd
- *
- * @MigrateProcessPlugin(
- *   id = "term_lookup",
- *   handle_multiples = FALSE
- * )
  */
+#[MigrateProcess(
+  id: 'term_lookup',
+  handle_multiples: FALSE,
+)]
 class TermLookup extends EntityLookup {
 
   /**

--- a/modules/core/owner/src/Plugin/Action/AssetAssign.php
+++ b/modules/core/owner/src/Plugin/Action/AssetAssign.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_owner\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Action that assigns users to assets.
- *
- * @Action(
- *   id = "asset_assign_action",
- *   label = @Translation("Assign assets to users."),
- *   type = "asset",
- *   confirm_form_route_name = "farm_owner.asset_assign_action_form"
- * )
  */
+#[Action(
+  id: 'asset_assign_action',
+  label: new TranslatableMarkup('Assign assets to users.'),
+  type: 'asset',
+  confirm_form_route_name: 'farm_owner.asset_assign_action_form',
+)]
 class AssetAssign extends AssignBase {
 
 }

--- a/modules/core/owner/src/Plugin/Action/LogAssign.php
+++ b/modules/core/owner/src/Plugin/Action/LogAssign.php
@@ -4,16 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_owner\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Action that assigns users to logs.
- *
- * @Action(
- *   id = "log_assign_action",
- *   label = @Translation("Assign logs to users."),
- *   type = "log",
- *   confirm_form_route_name = "farm_owner.log_assign_action_form"
- * )
  */
+#[Action(
+  id: 'log_assign_action',
+  label: new TranslatableMarkup('Assign logs to users.'),
+  type: 'log',
+  confirm_form_route_name: 'farm_owner.log_assign_action_form',
+)]
 class LogAssign extends AssignBase {
 
 }

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_parent\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Action that assigns asset parent.
- *
- * @Action(
- *   id = "asset_parent_action",
- *   label = @Translation("Assign asset parent."),
- *   type = "asset",
- *   confirm_form_route_name = "farm_parent.asset_parent_action_form"
- * )
  */
+#[Action(
+  id: 'asset_parent_action',
+  label: new TranslatableMarkup('Assign asset parent.'),
+  type: 'asset',
+  confirm_form_route_name: 'farm_parent.asset_parent_action_form',
+)]
 class AssetParent extends EntityActionBase {
 
   /**

--- a/modules/core/plan/src/Plugin/Action/PlanActivate.php
+++ b/modules/core/plan/src/Plugin/Action/PlanActivate.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\plan\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Action that marks a plan as active.
- *
- * @Action(
- *   id = "plan_activate_action",
- *   label = @Translation("Makes a Plan active"),
- *   type = "plan"
- * )
  */
+#[Action(
+  id: 'plan_activate_action',
+  label: new TranslatableMarkup('Makes a Plan active'),
+  type: 'plan',
+)]
 class PlanActivate extends PlanStateChangeBase {
 
   /**

--- a/modules/core/plan/src/Plugin/Action/PlanArchive.php
+++ b/modules/core/plan/src/Plugin/Action/PlanArchive.php
@@ -4,15 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\plan\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
 /**
  * Action that archives a plan.
- *
- * @Action(
- *   id = "plan_archive_action",
- *   label = @Translation("Archive a plan"),
- *   type = "plan"
- * )
  */
+#[Action(
+  id: 'plan_archive_action',
+  label: new TranslatableMarkup('Archive a plan'),
+  type: 'plan',
+)]
 class PlanArchive extends PlanStateChangeBase {
 
   /**

--- a/modules/core/quantity/src/Plugin/migrate/process/CreateQuantity.php
+++ b/modules/core/quantity/src/Plugin/migrate/process/CreateQuantity.php
@@ -6,6 +6,7 @@ namespace Drupal\quantity\Plugin\migrate\process;
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\MigrateSkipRowException;
 use Drupal\migrate\ProcessPluginBase;
@@ -19,13 +20,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * requires a "lookup" to happen before creating the entity. Since the quantity
  * value field is a Fraction field, it is easier to use our own process plugin.
  *
- * @MigrateProcessPlugin(
- *   id = "create_quantity",
- *   handle_multiples = TRUE
- * )
- *
  * @internal
  */
+#[MigrateProcess(
+  id: 'create_quantity',
+  handle_multiples: TRUE,
+)]
 class CreateQuantity extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/modules/core/timeline/src/Plugin/DataType/TimelineRow.php
+++ b/modules/core/timeline/src/Plugin/DataType/TimelineRow.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\farm_timeline\Plugin\DataType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\Attribute\DataType;
 use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\Core\TypedData\Plugin\DataType\Map;
 
 /**
  * Timeline row data type.
- *
- * @DataType(
- *   id = "farm_timeline_row",
- *   label = @Translation("Timeline row"),
- *   description = @Translation("Data definition for a timeline row."),
- *   definition_class = "\Drupal\farm_timeline\TypedData\TimelineRowDefinition"
- * )
  */
+#[DataType(
+  id: 'farm_timeline_row',
+  label: new TranslatableMarkup('Timeline row'),
+  description: new TranslatableMarkup('Data definition for a timeline row.'),
+  definition_class: '\Drupal\farm_timeline\TypedData\TimelineRowDefinition',
+)]
 class TimelineRow extends Map implements ComplexDataInterface {
 
   /**

--- a/modules/core/timeline/src/Plugin/DataType/TimelineTask.php
+++ b/modules/core/timeline/src/Plugin/DataType/TimelineTask.php
@@ -4,19 +4,20 @@ declare(strict_types=1);
 
 namespace Drupal\farm_timeline\Plugin\DataType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\TypedData\Attribute\DataType;
 use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\Core\TypedData\Plugin\DataType\ItemList;
 use Drupal\Core\TypedData\Plugin\DataType\Map;
 
 /**
  * Timeline task data type.
- *
- * @DataType(
- *   id = "farm_timeline_task",
- *   label = @Translation("Timeline Task"),
- *   definition_class = "\Drupal\farm_timeline\TypedData\TimelineTaskDefinition"
- * )
  */
+#[DataType(
+  id: 'farm_timeline_task',
+  label: new TranslatableMarkup('Timeline Task'),
+  definition_class: '\Drupal\farm_timeline\TypedData\TimelineTaskDefinition',
+)]
 class TimelineTask extends Map implements ComplexDataInterface {
 
   /**

--- a/modules/core/ui/dashboard/tests/modules/dashboard_test/src/Plugin/Block/DashboardTestBlock.php
+++ b/modules/core/ui/dashboard/tests/modules/dashboard_test/src/Plugin/Block/DashboardTestBlock.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_dashboard_test\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Provides a dashboard test block.
- *
- * @Block(
- *   id = "dashboard_test_block",
- *   admin_label = @Translation("Dashboard test block")
- * )
  */
+#[Block(
+  id: 'dashboard_test_block',
+  admin_label: new TranslatableMarkup('Dashboard test block'),
+)]
 class DashboardTestBlock extends BlockBase {
 
   /**

--- a/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -4,21 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_metrics\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a 'Metrics' block.
- *
- * @Block(
- *   id = "farm_metrics_block",
- *   admin_label = @Translation("Farm Metrics")
- * )
  */
+#[Block(
+  id: 'farm_metrics_block',
+  admin_label: new TranslatableMarkup('Farm Metrics'),
+)]
 class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/modules/core/ui/theme/src/Plugin/Block/FarmLocalActionsBlock.php
+++ b/modules/core/ui/theme/src/Plugin/Block/FarmLocalActionsBlock.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_theme\Plugin\Block;
 
 use Drupal\Component\Utility\SortArray;
+use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Menu\Plugin\Block\LocalActionsBlock;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
  * Provides a block to display the local actions.
- *
- * @Block(
- *   id = "farm_local_actions_block",
- *   admin_label = @Translation("Primary farm admin actions")
- * )
  */
+#[Block(
+  id: 'farm_local_actions_block',
+  admin_label: new TranslatableMarkup('Primary farm admin actions'),
+)]
 class FarmLocalActionsBlock extends LocalActionsBlock {
 
   /**

--- a/modules/core/ui/theme/src/Plugin/Block/FarmPoweredByBlock.php
+++ b/modules/core/ui/theme/src/Plugin/Block/FarmPoweredByBlock.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_theme\Plugin\Block;
 
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\system\Plugin\Block\SystemPoweredByBlock;
 
 /**
  * Provides a 'Powered by farmOS' block.
- *
- * @Block(
- *   id = "farm_powered_by_block",
- *   admin_label = @Translation("Powered by farmOS")
- * )
  */
+#[Block(
+  id: 'farm_powered_by_block',
+  admin_label: new TranslatableMarkup('Powered by farmOS'),
+)]
 class FarmPoweredByBlock extends SystemPoweredByBlock {
 
   /**

--- a/modules/core/ui/views/src/Plugin/views/display_extender/CollapsibleFilter.php
+++ b/modules/core/ui/views/src/Plugin/views/display_extender/CollapsibleFilter.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_views\Plugin\views\display_extender;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\views\Attribute\ViewsDisplayExtender;
 use Drupal\views\Plugin\views\display_extender\DisplayExtenderPluginBase;
 
 /**
  * Defines a display extender plugin to configure collapsible exposed filters.
- *
- * @ViewsDisplayExtender(
- *   id = "collapsible_filter",
- *   title = @Translation("Collapsible filter")
- * )
  */
+#[ViewsDisplayExtender(
+  id: 'collapsible_filter',
+  title: new TranslatableMarkup('Collapsible filter'),
+)]
 class CollapsibleFilter extends DisplayExtenderPluginBase {
 
   /**

--- a/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraint.php
+++ b/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraint.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_birth\Plugin\Validation\Constraint;
 
-use Symfony\Component\Validator\Constraint;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Validation\Attribute\Constraint;
+use Symfony\Component\Validator\Constraint as SymfonyConstraint;
 
 /**
  * Checks that only one birth log references an asset.
- *
- * @Constraint(
- *   id = "UniqueBirthLog",
- *   label = @Translation("Unique birth log", context = "Validation"),
- * )
  */
-class UniqueBirthLogConstraint extends Constraint {
+#[Constraint(
+  id: 'UniqueBirthLog',
+  label: new TranslatableMarkup('Unique birth log', ['context' => 'Validation']),
+)]
+class UniqueBirthLogConstraint extends SymfonyConstraint {
 
   /**
    * The default violation message.

--- a/modules/quick/group/src/Plugin/Action/Group.php
+++ b/modules/quick/group/src/Plugin/Action/Group.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_group\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_quick\Plugin\Action\QuickFormActionBase;
 
 /**
  * Action for recording group membership assignment.
- *
- * @Action(
- *   id = "quick_group",
- *   label = @Translation("Assign group membership"),
- *   type = "asset",
- *   confirm_form_route_name = "farm.quick.group"
- * )
  */
+#[Action(
+  id: 'quick_group',
+  label: new TranslatableMarkup('Assign group membership'),
+  type: 'asset',
+  confirm_form_route_name: 'farm.quick.group',
+)]
 class Group extends QuickFormActionBase {
 
   /**

--- a/modules/quick/movement/src/Plugin/Action/Movement.php
+++ b/modules/quick/movement/src/Plugin/Action/Movement.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_movement\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_quick\Plugin\Action\QuickFormActionBase;
 
 /**
  * Action for recording movements.
- *
- * @Action(
- *   id = "quick_movement",
- *   label = @Translation("Record movement"),
- *   type = "asset",
- *   confirm_form_route_name = "farm.quick.movement"
- * )
  */
+#[Action(
+  id: 'quick_movement',
+  label: new TranslatableMarkup('Record movement'),
+  type: 'asset',
+  confirm_form_route_name: 'farm.quick.movement',
+)]
 class Movement extends QuickFormActionBase {
 
   /**

--- a/modules/quick/movement/src/Plugin/Field/FieldFormatter/AssetCurrentLocationMoveFormatter.php
+++ b/modules/quick/movement/src/Plugin/Field/FieldFormatter/AssetCurrentLocationMoveFormatter.php
@@ -4,23 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_movement\Plugin\Field\FieldFormatter;
 
+use Drupal\Core\Field\Attribute\FieldFormatter;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\farm_location\Plugin\Field\FieldFormatter\AssetCurrentLocationFormatter;
 
 /**
  * Field formatter for the current location asset field with a move button.
- *
- * @FieldFormatter(
- *   id = "asset_current_location_move",
- *   label = @Translation("Asset current location (with Move button)"),
- *   description = @Translation("Display the label of the referenced entities with a button to move."),
- *   field_types = {
- *     "entity_reference"
- *   }
- * )
  */
+#[FieldFormatter(
+  id: 'asset_current_location_move',
+  label: new TranslatableMarkup('Asset current location (with Move button)'),
+  description: new TranslatableMarkup('Display the label of the referenced entities with a button to move.'),
+  field_types: ['entity_reference'],
+)]
 class AssetCurrentLocationMoveFormatter extends AssetCurrentLocationFormatter {
 
   /**

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -4,22 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log_category\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
 use Drupal\Core\Action\Plugin\Action\EntityActionBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Redirects to a form to add categories to a log.
- *
- * @Action(
- *   id = "log_categorize_action",
- *   action_label = @Translation("Categorize log"),
- *   type = "log",
- *   confirm_form_route_name = "farm_log_category.log_categorize_action_form"
- * )
  */
+#[Action(
+  id: 'log_categorize_action',
+  action_label: new TranslatableMarkup('Categorize log'),
+  type: 'log',
+  confirm_form_route_name: 'farm_log_category.log_categorize_action_form',
+)]
 class LogCategorize extends EntityActionBase {
 
   /**


### PR DESCRIPTION
This PR is a first step towards the work described in https://www.drupal.org/project/farm/issues/3461548

It converts all of the Drupal core plugins that we are implementing to use native PHP attributes instead of annotations, where available.

There are a few Drupal core plugin types that still use annotations in Drupal 10, so we won't be able to convert them until Drupal 11. This includes `ConfigEntityType`, `ContentEntityType`, and `MigrateSource`. I have started a `4.x-attributes` branch that makes these changes, which we can rebase onto my work-in-progress `4.x` branch after this PR is merged.

https://github.com/mstenta/farmOS/tree/4.x-attributes

We can also start to add support for attributes to the plugin types that farmOS provides. I started a `3.x-farm-attributes` branch for that purpose. It currently adds enforcement for them, but does not convert any yet.

https://github.com/mstenta/farmOS/tree/3.x-farm-attributes