### PR TITLE
Run phpcs, phpstan and rector in separate jobs

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -88,74 +88,56 @@ jobs:
     name: PHP Codesniffer
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      matrix:
-        platform:
-        # The PHP code we're scanning is the same for all platforms so scan the copy
-        # from the amd64 Docker image since that one will start up fastest
-         - amd64
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
-          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+          path: /tmp/farmos-dev-amd64.tar
+          key: farmos-dev-amd64-${{ github.run_id }}
       - name: Load the Docker dev image
-        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
+        run: docker load < /tmp/farmos-dev-amd64.tar
       - name: Run PHP CodeSniffer
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs /opt/drupal/web/profiles/farm
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-amd64 phpcs /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings)
         run: |
-          docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/modules
-          docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/themes
+          docker run $DOCKER_IMG_PREFIX:3.x-dev-amd64 phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/modules
+          docker run $DOCKER_IMG_PREFIX:3.x-dev-amd64 phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/themes
 
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      matrix:
-        platform:
-        # The PHP code we're scanning is the same for all platforms so scan the copy
-        # from the amd64 Docker image since that one will start up fastest
-         - amd64
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
-          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+          path: /tmp/farmos-dev-amd64.tar
+          key: farmos-dev-amd64-${{ github.run_id }}
       - name: Load the Docker dev image
-        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
+        run: docker load < /tmp/farmos-dev-amd64.tar
       - name: Run PHPStan
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-amd64 phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
 
   rector:
     name: Rector
     runs-on: ubuntu-latest
     needs: build
-    strategy:
-      matrix:
-        platform:
-          # The PHP code we're scanning is the same for all platforms so scan the copy
-          # from the amd64 Docker image since that one will start up fastest
-          - amd64
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
-          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
-          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+          path: /tmp/farmos-dev-amd64.tar
+          key: farmos-dev-amd64-${{ github.run_id }}
       - name: Load the Docker dev image
-        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
+        run: docker load < /tmp/farmos-dev-amd64.tar
       - name: Run Rector
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} rector process --dry-run /opt/drupal/web/profiles/farm
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-amd64 rector process --dry-run /opt/drupal/web/profiles/farm
 
   test:
     name: Run PHPUnit tests

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -89,8 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
@@ -110,8 +108,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:
@@ -127,8 +123,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout the repository
-        uses: actions/checkout@v4
       - name: Restore the farmOS dev Docker image from cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -84,8 +84,8 @@ jobs:
     outputs:
       farmos_version: ${{ env.FARMOS_VERSION }}
 
-  sniff:
-    name: Run PHP Codesniffer, PHPStan, and Rector
+  phpcs:
+    name: PHP Codesniffer
     runs-on: ubuntu-latest
     needs: build
     strategy:
@@ -106,14 +106,56 @@ jobs:
         run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
       - name: Run PHP CodeSniffer
         run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs /opt/drupal/web/profiles/farm
-      - name: Run PHPStan
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
-      - name: Run Rector
-        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} rector process --dry-run /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings)
         run: |
           docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/modules
           docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/themes
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        platform:
+        # The PHP code we're scanning is the same for all platforms so scan the copy
+        # from the amd64 Docker image since that one will start up fastest
+         - amd64
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Restore the farmOS dev Docker image from cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
+          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+      - name: Load the Docker dev image
+        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
+      - name: Run PHPStan
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} phpstan analyze --memory-limit 1G /opt/drupal/web/profiles/farm
+
+  rector:
+    name: Rector
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        platform:
+          # The PHP code we're scanning is the same for all platforms so scan the copy
+          # from the amd64 Docker image since that one will start up fastest
+          - amd64
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      - name: Restore the farmOS dev Docker image from cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
+          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+      - name: Load the Docker dev image
+        run: docker load < /tmp/farmos-dev-${{ matrix.platform }}.tar
+      - name: Run Rector
+        run: docker run $DOCKER_IMG_PREFIX:3.x-dev-${{ matrix.platform }} rector process --dry-run /opt/drupal/web/profiles/farm
 
   test:
     name: Run PHPUnit tests
@@ -186,7 +228,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - sniff
+      - phpcs
+      - phpstan
+      - rector
       - test
     strategy:
       matrix:
@@ -225,7 +269,9 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - sniff
+      - phpcs
+      - phpstan
+      - rector
       - test
     strategy:
       matrix:


### PR DESCRIPTION
I don't think there is any reason that a failed phpcs needs to prevent phpstan and rector from running. With it taking longer to run our tests (mostly building the docker images) it can save lots of debugging time to run all these checks at the same time.

I think this will become especially useful for contributors as we start leveraging stricter PHPStan rules, see #906 - In this PR I've been battling some phpcs while really wanting to just test the PHPStan test :-)