### PR TITLE
PHPStan level 5

### DIFF
--- a/docker/dev/files/phpstan.neon
+++ b/docker/dev/files/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 4
+  level: 5
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.

--- a/docker/dev/files/phpstan.neon
+++ b/docker/dev/files/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: 4
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.

--- a/docker/dev/files/phpstan.neon
+++ b/docker/dev/files/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 2
+  level: 3
   reportUnmatchedIgnoredErrors: true
   ignoreErrors:
     # new static() is a best practice in Drupal, so we cannot fix that.

--- a/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
+++ b/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
@@ -67,7 +67,7 @@ class EquipmentFieldTest extends FarmBrowserTestBase {
 
     // Create a log that references the equipment.
     $log = $log_storage->create(['type' => 'test']);
-    $log->equipment[] = ['target_id' => $asset->id()];
+    $log->get('equipment')->appendItem($asset->id());
     $log->save();
 
     // Go to the log view page.

--- a/modules/asset/group/src/Field/AssetGroupItemList.php
+++ b/modules/asset/group/src/Field/AssetGroupItemList.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_group\Field;
 
 use Drupal\Core\Field\EntityReferenceFieldItemList;
 use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\asset\Entity\AssetInterface;
 
 /**
  * Computes the current group value for assets.
@@ -23,6 +24,7 @@ class AssetGroupItemList extends EntityReferenceFieldItemList {
     $entity = $this->getEntity();
 
     // Get the asset's current groups.
+    assert($entity instanceof AssetInterface);
     $groups = \Drupal::service('group.membership')->getGroup($entity);
 
     // Update the assets current group values to match.

--- a/modules/asset/group/src/GroupMembership.php
+++ b/modules/asset/group/src/GroupMembership.php
@@ -133,17 +133,8 @@ class GroupMembership implements GroupMembershipInterface {
       return NULL;
     }
 
-    // Load the first log.
-    /** @var \Drupal\log\Entity\LogInterface $log */
-    $log = $this->entityTypeManager->getStorage('log')->load(reset($log_ids));
-
-    // Return the log, if available.
-    if (!is_null($log)) {
-      return $log;
-    }
-
-    // Otherwise, return NULL.
-    return NULL;
+    // Load the first log or return NULL.
+    return $this->entityTypeManager->getStorage('log')->load(reset($log_ids));
   }
 
   /**

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_group\Plugin\Validation\Constraint;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_group\GroupMembershipInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
@@ -76,6 +77,7 @@ class CircularGroupMembershipConstraintValidator extends ConstraintValidator imp
       }
 
       // Load members of this group (recursively).
+      assert($asset instanceof AssetInterface);
       $members = $this->groupMembership->getGroupMembers([$asset], TRUE, $timestamp);
 
       // Iterate through the groups and look for violations.

--- a/modules/asset/land/farm_land.views_execution.inc
+++ b/modules/asset/land/farm_land.views_execution.inc
@@ -31,12 +31,9 @@ function farm_land_views_pre_render(ViewExecutable $view) {
     $exposed_filters = $view->getExposedInput();
 
     // If the land type exposed filter is already in use remove land types
-    // that are not included.
-    if (!empty($exposed_filters['land_type_value'])) {
-      $land_types = array_filter($land_types, function ($key) use ($exposed_filters) {
-        return in_array($key, $exposed_filters['land_type_value']);
-      }, ARRAY_FILTER_USE_KEY);
-    }
+    // that are not specified by the filter value.
+    $land_type_filters = (array) $exposed_filters['land_type_value'];
+    $land_types = array_intersect_key($land_types, $land_type_filters);
 
     // Create a layer for each land type.
     $asset_layers = [];

--- a/modules/asset/land/farm_land.views_execution.inc
+++ b/modules/asset/land/farm_land.views_execution.inc
@@ -38,7 +38,7 @@ function farm_land_views_pre_render(ViewExecutable $view) {
     // Create a layer for each land type.
     $asset_layers = [];
     foreach ($land_types as $land_type) {
-      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|null $layer_style */
       if ($layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => 'land', 'land_type' => $land_type->id()])) {
         $color = $layer_style->get('color');
       }

--- a/modules/asset/land/farm_land.views_execution.inc
+++ b/modules/asset/land/farm_land.views_execution.inc
@@ -41,9 +41,8 @@ function farm_land_views_pre_render(ViewExecutable $view) {
     // Create a layer for each land type.
     $asset_layers = [];
     foreach ($land_types as $land_type) {
-      /** @var \Drupal\farm_map\Entity\LayerStyleInterface $layer_style */
-      $layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => 'land', 'land_type' => $land_type->id()]);
-      if (!is_null($layer_style)) {
+      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+      if ($layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => 'land', 'land_type' => $land_type->id()])) {
         $color = $layer_style->get('color');
       }
       $asset_layers['land_' . $land_type->id()] = [

--- a/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -28,7 +28,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * The layer style loader service.
    *
-   * @var \Drupal\farm_map\LayerStyleLoader
+   * @var \Drupal\farm_map\LayerStyleLoaderInterface
    */
   protected $layerStyleLoader;
 

--- a/modules/asset/sensor/src/Controller/SensorDataController.php
+++ b/modules/asset/sensor/src/Controller/SensorDataController.php
@@ -8,6 +8,7 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\data_stream\DataStreamTypeManager;
+use Drupal\data_stream\Entity\DataStreamInterface;
 use Drupal\jsonapi\Exception\UnprocessableHttpEntityException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -217,10 +218,10 @@ class SensorDataController extends ControllerBase {
    * @param string $name
    *   The data stream name.
    *
-   * @return \Drupal\Core\Entity\EntityInterface
+   * @return \Drupal\data_stream\Entity\DataStreamInterface
    *   The new data stream.
    */
-  protected function createDataStream(AssetInterface $asset, string $name) {
+  protected function createDataStream(AssetInterface $asset, string $name): DataStreamInterface {
 
     // Create new data stream.
     $new_data_stream = $this->entityTypeManager()->getStorage('data_stream')->create([

--- a/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
+++ b/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
@@ -76,7 +76,7 @@ class SensorDataApiTest extends FarmBrowserTestBase {
 
     // Assert valid response.
     $this->assertEquals(200, $response->getStatusCode());
-    $data = Json::decode($response->getBody());
+    $data = Json::decode((string) $response->getBody());
     $this->assertEquals(0, count($data));
 
     // Make the sensor public.
@@ -85,7 +85,7 @@ class SensorDataApiTest extends FarmBrowserTestBase {
     // Test that data can be accessed without the private key.
     $response = $this->processRequest('GET', $url);
     $this->assertEquals(200, $response->getStatusCode());
-    $data = Json::decode($response->getBody());
+    $data = Json::decode((string) $response->getBody());
     $this->assertEquals(0, count($data));
   }
 
@@ -125,7 +125,7 @@ class SensorDataApiTest extends FarmBrowserTestBase {
 
     // Assert that new data was saved in DB.
     $response = $this->processRequest('GET', $url);
-    $data = Json::decode($response->getBody());
+    $data = Json::decode((string) $response->getBody());
     $this->assertEquals(2, count($data));
 
     // More test data.
@@ -143,7 +143,7 @@ class SensorDataApiTest extends FarmBrowserTestBase {
 
     // Assert that new data was saved in DB.
     $response = $this->processRequest('GET', $url);
-    $data = Json::decode($response->getBody());
+    $data = Json::decode((string) $response->getBody());
     $this->assertEquals(4, count($data));
   }
 

--- a/modules/asset/structure/farm_structure.views_execution.inc
+++ b/modules/asset/structure/farm_structure.views_execution.inc
@@ -38,7 +38,7 @@ function farm_structure_views_pre_render(ViewExecutable $view) {
     // Create a layer for each structure type.
     $asset_layers = [];
     foreach ($structure_types as $structure_type) {
-      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|null $layer_style */
       if ($layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => 'structure', 'structure_type' => $structure_type->id()])) {
         $color = $layer_style->get('color');
       }

--- a/modules/asset/structure/farm_structure.views_execution.inc
+++ b/modules/asset/structure/farm_structure.views_execution.inc
@@ -31,12 +31,9 @@ function farm_structure_views_pre_render(ViewExecutable $view) {
     $exposed_filters = $view->getExposedInput();
 
     // If the structure type exposed filter is already in use remove structure
-    // types that are not included.
-    if (!empty($exposed_filters['structure_type_value'])) {
-      $structure_types = array_filter($structure_types, function ($key) use ($exposed_filters) {
-        return in_array($key, $exposed_filters['structure_type_value']);
-      }, ARRAY_FILTER_USE_KEY);
-    }
+    // types that are not specified in the filter value.
+    $structure_type_filters = (array) $exposed_filters['structure_type_value'];
+    $structure_types = array_intersect_key($structure_types, $structure_type_filters);
 
     // Create a layer for each structure type.
     $asset_layers = [];

--- a/modules/asset/structure/farm_structure.views_execution.inc
+++ b/modules/asset/structure/farm_structure.views_execution.inc
@@ -41,9 +41,8 @@ function farm_structure_views_pre_render(ViewExecutable $view) {
     // Create a layer for each structure type.
     $asset_layers = [];
     foreach ($structure_types as $structure_type) {
-      /** @var \Drupal\farm_map\Entity\LayerStyleInterface $layer_style */
-      $layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => 'structure', 'structure_type' => $structure_type->id()]);
-      if (!is_null($layer_style)) {
+      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+      if ($layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => 'structure', 'structure_type' => $structure_type->id()])) {
         $color = $layer_style->get('color');
       }
       $asset_layers['structure_' . $structure_type->id()] = [

--- a/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -28,7 +28,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * The layer style loader service.
    *
-   * @var \Drupal\farm_map\LayerStyleLoader
+   * @var \Drupal\farm_map\LayerStyleLoaderInterface
    */
   protected $layerStyleLoader;
 

--- a/modules/core/asset/src/Entity/AssetInterface.php
+++ b/modules/core/asset/src/Entity/AssetInterface.php
@@ -65,7 +65,7 @@ interface AssetInterface extends ContentEntityInterface, EntityChangedInterface,
   /**
    * Sets the asset archived timestamp.
    *
-   * @param int $timestamp
+   * @param int|string|null $timestamp
    *   Archived timestamp of the asset.
    *
    * @return \Drupal\asset\Entity\AssetInterface

--- a/modules/core/asset/src/Plugin/Action/AssetStateChangeBase.php
+++ b/modules/core/asset/src/Plugin/Action/AssetStateChangeBase.php
@@ -83,7 +83,7 @@ abstract class AssetStateChangeBase extends EntityActionBase {
     // Deny access if the workflow does not support the target state.
     if (empty($target_state)) {
       $result = $result->orIf(AccessResult::forbidden(
-        $this->t('The %workflow workflow does not support the %target_state state.', ['%workflow' => $workflow->getLabel(), '%target_state' => $this->targetState]),
+        $this->t('The %workflow workflow does not support the %target_state state.', ['%workflow' => $workflow->getLabel(), '%target_state' => $this->targetState])->render(),
       ));
     }
     // Else check that a transition exists to the desired target state.

--- a/modules/core/asset/tests/src/Functional/AssetTestBase.php
+++ b/modules/core/asset/tests/src/Functional/AssetTestBase.php
@@ -12,9 +12,7 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 abstract class AssetTestBase extends FarmBrowserTestBase {
 
   /**
-   * Modules to install.
-   *
-   * @var array
+   * {@inheritdoc}
    */
   protected static $modules = [
     'asset',

--- a/modules/core/csv/src/Normalizer/ContentEntityNormalizer.php
+++ b/modules/core/csv/src/Normalizer/ContentEntityNormalizer.php
@@ -20,7 +20,7 @@ class ContentEntityNormalizer extends CoreContentEntityNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($entity, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($entity, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
     $data = parent::normalize($entity, $format, $context);
 
     // If columns were explicitly included, remove others.

--- a/modules/core/csv/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -22,7 +22,7 @@ class EntityReferenceFieldItemNormalizer extends CoreEntityReferenceFieldItemNor
   /**
    * {@inheritdoc}
    */
-  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
 
     // Attempt to load the referenced entity.
     if ($entity = $field_item->get('entity')->getValue()) {

--- a/modules/core/csv/src/Normalizer/FractionFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/FractionFieldItemNormalizer.php
@@ -20,7 +20,7 @@ class FractionFieldItemNormalizer extends FieldItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
     /** @var \Drupal\fraction\Plugin\Field\FieldType\FractionItem $field_item */
     return $field_item->get('decimal')->getValue();
   }

--- a/modules/core/csv/src/Normalizer/GeofieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/GeofieldItemNormalizer.php
@@ -20,7 +20,7 @@ class GeofieldItemNormalizer extends FieldItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
     $data = parent::normalize($object, $format, $context);
 
     // Return the WKT value, if desired.

--- a/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
@@ -20,7 +20,7 @@ class TextLongFieldItemNormalizer extends FieldItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
     /** @var \Drupal\text\Plugin\Field\FieldType\TextLongItem $field_item */
 
     // If processed_text is explicitly set, return processed or raw user input

--- a/modules/core/csv/src/Normalizer/TimestampItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TimestampItemNormalizer.php
@@ -19,7 +19,7 @@ class TimestampItemNormalizer extends CoreTimestampItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
     $data = parent::normalize($object, $format, $context);
 
     // Return the RFC3339 formatted date, if desired.

--- a/modules/core/data_stream/modules/notification/src/DataStreamNotificationListBuilder.php
+++ b/modules/core/data_stream/modules/notification/src/DataStreamNotificationListBuilder.php
@@ -15,26 +15,6 @@ class DataStreamNotificationListBuilder extends ConfigEntityListBuilder {
   /**
    * {@inheritdoc}
    */
-  public function load() {
-    $entities = [
-      'enabled' => [],
-      'disabled' => [],
-    ];
-    /** @var \Drupal\data_stream_notification\Entity\DataStreamNotificationInterface $entity */
-    foreach (parent::load() as $entity) {
-      if ($entity->status()) {
-        $entities['enabled'][] = $entity;
-      }
-      else {
-        $entities['disabled'][] = $entity;
-      }
-    }
-    return $entities;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildRow(EntityInterface $notification) {
     /** @var \Drupal\data_stream_notification\Entity\DataStreamNotificationInterface $notification */
     $row = parent::buildRow($notification);
@@ -124,18 +104,22 @@ class DataStreamNotificationListBuilder extends ConfigEntityListBuilder {
     $list['disabled']['table']['#empty'] = $this->t('There are no disabled notifications.');
 
     // Build separate tables for enabled and disabled.
-    $entities = $this->load();
-    foreach (['enabled', 'disabled'] as $status) {
-      $list[$status]['table'] = [
-        '#type' => 'table',
-        '#header' => $this->buildHeader(),
-      ];
+    $list['enabled']['table'] = [
+      '#type' => 'table',
+      '#header' => $this->buildHeader(),
+    ];
+    $list['disabled']['table'] = [
+      '#type' => 'table',
+      '#header' => $this->buildHeader(),
+    ];
 
-      // Build a row for each entity.
-      foreach ($entities[$status] as $entity) {
-        if ($row = $this->buildRow($entity)) {
-          $list[$status]['table']['#rows'][$entity->id()] = $row;
-        }
+    // Build a row for each entity.
+    $entities = $this->load();
+    /** @var \Drupal\data_stream_notification\Entity\DataStreamNotificationInterface $entity */
+    foreach ($entities as $entity) {
+      if ($row = $this->buildRow($entity)) {
+        $status = $entity->status() ? 'enabled' : 'disabled';
+        $list[$status]['table']['#rows'][$entity->id()] = $row;
       }
     }
 

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/EmailDeliveryTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/EmailDeliveryTest.php
@@ -106,7 +106,7 @@ class EmailDeliveryTest extends DataStreamTestBase {
 
     // Get the first configured email delivery plugin.
     $collections = $this->dataStreamNotification->getPluginCollections();
-    $email_delivery = $collections['delivery']->get(0);
+    $email_delivery = $collections['delivery']->get((string) 0);
 
     // Build a list of condition summaries to test against.
     $condition_summaries = array_map(function ($condition) {

--- a/modules/core/data_stream/src/Plugin/migrate/destination/DataStream.php
+++ b/modules/core/data_stream/src/Plugin/migrate/destination/DataStream.php
@@ -50,7 +50,7 @@ class DataStream extends EntityContentBase {
     if ($row->hasDestinationProperty('providing_asset')) {
       $providing_asset = $row->getDestinationProperty('providing_asset');
 
-      /** @var \Drupal\asset\Entity\AssetInterface|NULL $asset */
+      /** @var \Drupal\asset\Entity\AssetInterface|null $asset */
       $asset = $this->storage->load($providing_asset);
 
       // Update the assets data_stream field if the asset was found

--- a/modules/core/data_stream/src/Plugin/migrate/destination/DataStream.php
+++ b/modules/core/data_stream/src/Plugin/migrate/destination/DataStream.php
@@ -50,7 +50,7 @@ class DataStream extends EntityContentBase {
     if ($row->hasDestinationProperty('providing_asset')) {
       $providing_asset = $row->getDestinationProperty('providing_asset');
 
-      /** @var \Drupal\asset\Entity\AssetInterface $asset */
+      /** @var \Drupal\asset\Entity\AssetInterface|NULL $asset */
       $asset = $this->storage->load($providing_asset);
 
       // Update the assets data_stream field if the asset was found

--- a/modules/core/data_stream/tests/src/Kernel/DataStreamTest.php
+++ b/modules/core/data_stream/tests/src/Kernel/DataStreamTest.php
@@ -48,7 +48,7 @@ class DataStreamTest extends DataStreamTestBase {
     ]);
 
     // Create 100 data points over the next 100 days.
-    $this->mockBasicData($this->dataStream, 100, $this->startTime);
+    $this->mockBasicData($this->dataStream, 100, (string) $this->startTime);
   }
 
   /**

--- a/modules/core/entity/modules/fields/farm_entity_fields.module
+++ b/modules/core/entity/modules/fields/farm_entity_fields.module
@@ -90,15 +90,18 @@ function farm_entity_fields_entity_base_field_info_alter(&$fields, EntityTypeInt
 
     // Hide the field, if desired.
     if (!empty($options['hidden'])) {
+      // @phpstan-ignore booleanOr.alwaysTrue
       if ($options['hidden'] === TRUE || $options['hidden'] === 'form') {
         $form_display_options['region'] = 'hidden';
       }
+      // @phpstan-ignore identical.alwaysFalse
       if ($options['hidden'] === TRUE || $options['hidden'] === 'view') {
         $view_display_options['region'] = 'hidden';
       }
     }
 
     // Hide the label, if desired.
+    // @phpstan-ignore booleanAnd.rightAlwaysTrue
     if (!empty($options['label']) && $options['label'] == 'hidden') {
       $view_display_options['label'] = 'hidden';
     }

--- a/modules/core/entity/modules/fields/farm_entity_fields.module
+++ b/modules/core/entity/modules/fields/farm_entity_fields.module
@@ -101,8 +101,7 @@ function farm_entity_fields_entity_base_field_info_alter(&$fields, EntityTypeInt
     }
 
     // Hide the label, if desired.
-    // @phpstan-ignore booleanAnd.rightAlwaysTrue
-    if (!empty($options['label']) && $options['label'] == 'hidden') {
+    if (!empty($options['label']) && $options['label'] === 'hidden') {
       $view_display_options['label'] = 'hidden';
     }
 

--- a/modules/core/entity/modules/fields/farm_entity_fields.module
+++ b/modules/core/entity/modules/fields/farm_entity_fields.module
@@ -90,13 +90,23 @@ function farm_entity_fields_entity_base_field_info_alter(&$fields, EntityTypeInt
 
     // Hide the field, if desired.
     if (!empty($options['hidden'])) {
-      // @phpstan-ignore booleanOr.alwaysTrue
-      if ($options['hidden'] === TRUE || $options['hidden'] === 'form') {
-        $form_display_options['region'] = 'hidden';
-      }
-      // @phpstan-ignore identical.alwaysFalse
-      if ($options['hidden'] === TRUE || $options['hidden'] === 'view') {
-        $view_display_options['region'] = 'hidden';
+      switch ($options['hidden']) {
+
+        // Only hide in the entity form.
+        case 'form':
+          $form_display_options['region'] = 'hidden';
+          break;
+
+        // Only hide in the entity view.
+        case 'view':
+          $view_display_options['region'] = 'hidden';
+          break;
+
+        // Hide in both the entity form and view.
+        case TRUE:
+          $form_display_options['region'] = 'hidden';
+          $view_display_options['region'] = 'hidden';
+          break;
       }
     }
 

--- a/modules/core/entity/modules/views/src/FarmLogViewsData.php
+++ b/modules/core/entity/modules/views/src/FarmLogViewsData.php
@@ -27,6 +27,7 @@ class FarmLogViewsData extends LogViewsData {
     // Entity Reference Revisions field.
     // @todo Patch Entity to support Entity Reference Revisions instead?
     $entity_type_id = $this->entityType->id();
+    /** @var \Drupal\Core\Field\BaseFieldDefinition[] $base_fields */
     $base_fields = $this->getEntityFieldManager()->getBaseFieldDefinitions($entity_type_id);
     $entity_reference_fields = array_filter($base_fields, function (BaseFieldDefinition $field) {
       return !$field->isComputed() && $field->getType() == 'entity_reference_revisions';

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -29,9 +29,9 @@ use Symfony\Component\Serializer\SerializerInterface;
 class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface {
 
   /**
-   * The tempstore factory.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -205,15 +205,12 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL): array|RedirectResponse {
 
     // If we don't have an entity type or list of entities, redirect.
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type_id);
     $this->entities = $this->tempStore->get($this->user->id() . ':' . $entity_type_id);
     if (empty($entity_type_id) || empty($this->entities)) {
-      // Ignore PHPstan error for incorrect return type.
-      // Forms can return a RedirectResponse.
-      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -211,6 +211,9 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type_id);
     $this->entities = $this->tempStore->get($this->user->id() . ':' . $entity_type_id);
     if (empty($entity_type_id) || empty($this->entities)) {
+      // Ignore PHPstan error for incorrect return type.
+      // Forms can return a RedirectResponse.
+      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -198,13 +198,6 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfirmText() {
     return $this->t('Export');
   }
@@ -291,7 +284,12 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
     ];
 
     // Delegate to the parent method.
-    return parent::buildForm($form, $form_state);
+    $form = parent::buildForm($form, $form_state);
+
+    // Remove form description text.
+    unset($form['description']);
+
+    return $form;
   }
 
   /**

--- a/modules/core/export/modules/csv/src/Normalizer/QuantityCsvNormalizer.php
+++ b/modules/core/export/modules/csv/src/Normalizer/QuantityCsvNormalizer.php
@@ -15,7 +15,7 @@ class QuantityCsvNormalizer extends ContentEntityNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($entity, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|NULL {
+  public function normalize($entity, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
     $data = parent::normalize($entity, $format, $context);
 
     // Query the log associated with the quantity.

--- a/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityCsv extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LogQuantityCsv extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -212,39 +212,38 @@ class EntityFlagActionForm extends ConfirmFormBase {
     // Update flags on accessible entities.
     $total_count = 0;
     foreach ($accessible_entities as $entity) {
-      if ($flag_field = $entity->get($this->flagFieldName)) {
+      $flag_field = $entity->get($this->flagFieldName);
 
-        // Save existing flags if appending.
-        $existing_flags = [];
-        if ($form_state->getValue('operation') === 'append') {
-          $existing_flags = array_column($flag_field->getValue(), 'value');
-        }
-
-        // Empty the flag field.
-        $flag_field->setValue([]);
-
-        $new_flags = array_unique(array_merge($existing_flags, $form_state->getValue('flags')));
-        foreach ($new_flags as $flag) {
-          $flag_field->appendItem($flag);
-        }
-
-        // Validate the entity before saving.
-        $violations = $entity->validate();
-        if ($violations->count() > 0) {
-          $this->messenger()->addWarning(
-            $this->t('Could not flag <a href=":entity_link">%entity_label</a>: validation failed.',
-              [
-                ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
-                '%entity_label' => $entity->label(),
-              ],
-            ),
-          );
-          continue;
-        }
-
-        $entity->save();
-        $total_count++;
+      // Save existing flags if appending.
+      $existing_flags = [];
+      if ($form_state->getValue('operation') === 'append') {
+        $existing_flags = array_column($flag_field->getValue(), 'value');
       }
+
+      // Empty the flag field.
+      $flag_field->setValue([]);
+
+      $new_flags = array_unique(array_merge($existing_flags, $form_state->getValue('flags')));
+      foreach ($new_flags as $flag) {
+        $flag_field->appendItem($flag);
+      }
+
+      // Validate the entity before saving.
+      $violations = $entity->validate();
+      if ($violations->count() > 0) {
+        $this->messenger()->addWarning(
+          $this->t('Could not flag <a href=":entity_link">%entity_label</a>: validation failed.',
+            [
+              ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
+              '%entity_label' => $entity->label(),
+            ],
+          ),
+        );
+        continue;
+      }
+
+      $entity->save();
+      $total_count++;
     }
 
     // Add warning message for inaccessible entities.

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -23,9 +23,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class EntityFlagActionForm extends ConfirmFormBase {
 
   /**
-   * The tempstore factory.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -137,13 +137,6 @@ class EntityFlagActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfirmText() {
     return $this->t('Flag');
   }
@@ -187,7 +180,14 @@ class EntityFlagActionForm extends ConfirmFormBase {
       '#default_value' => 'append',
       '#required' => TRUE,
     ];
-    return parent::buildForm($form, $form_state);
+
+    // Delegate to the parent method.
+    $form = parent::buildForm($form, $form_state);
+
+    // Remove form description text.
+    unset($form['description']);
+
+    return $form;
   }
 
   /**

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -148,6 +148,9 @@ class EntityFlagActionForm extends ConfirmFormBase {
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type_id);
     $this->entities = $this->tempStore->get($this->user->id() . ':' . $entity_type_id);
     if (empty($entity_type_id) || empty($this->entities)) {
+      // Ignore PHPstan error for incorrect return type.
+      // Forms can return a RedirectResponse.
+      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -144,13 +144,10 @@ class EntityFlagActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL): array|RedirectResponse {
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type_id);
     $this->entities = $this->tempStore->get($this->user->id() . ':' . $entity_type_id);
     if (empty($entity_type_id) || empty($this->entities)) {
-      // Ignore PHPstan error for incorrect return type.
-      // Forms can return a RedirectResponse.
-      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/flag/src/Plugin/Action/EntityFlag.php
+++ b/modules/core/flag/src/Plugin/Action/EntityFlag.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityFlag extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/id_tag/src/Plugin/Field/FieldType/IdTagItem.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldType/IdTagItem.php
@@ -82,7 +82,7 @@ class IdTagItem extends FieldItemBase {
     $id = $this->get('id');
     $type = $this->get('type');
     $location = $this->get('location');
-    return ($id === NULL || $id->getValue() === '') && ($type === NULL || $type->getValue() === '') && ($location === NULL || $location->getValue() === '');
+    return $id->getValue() === ''&& $type->getValue() === '' && $location->getValue() === '';
   }
 
 }

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -109,7 +109,7 @@ class CsvImportController extends ControllerBase {
     // Load all menu links below it.
     $parameters = new MenuTreeParameters();
     $parameters->setRoot('farm.import.csv')->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
-    $tree = $this->menuLinkTree->load(NULL, $parameters);
+    $tree = $this->menuLinkTree->load('', $parameters);
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
@@ -36,9 +36,9 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
   protected $currentUser;
 
   /**
-   * The tempstore service.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
@@ -146,7 +146,7 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
         foreach ($record_numbers as $record_number) {
           $messages = $event->getMigration()->getIdMap()->getMessages(['file_id' => $file_id, 'record_number' => $record_number]);
           foreach ($messages as $message) {
-            $this->messenger->addWarning($this->t('Row @rownum: @message', ['@rownum' => $record_number, '@message' => $message->message]));
+            $this->messenger->addWarning($this->t('Row @rownum: @message', ['@rownum' => $record_number, '@message' => $message->message])->render());
           }
         }
       }

--- a/modules/core/import/src/Controller/ImportController.php
+++ b/modules/core/import/src/Controller/ImportController.php
@@ -55,7 +55,7 @@ class ImportController extends ControllerBase {
     // Load all menu links below it.
     $parameters = new MenuTreeParameters();
     $parameters->setRoot('farm.import')->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
-    $tree = $this->menuLinkTree->load(NULL, $parameters);
+    $tree = $this->menuLinkTree->load('', $parameters);
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],

--- a/modules/core/inventory/src/Field/AssetInventoryItemList.php
+++ b/modules/core/inventory/src/Field/AssetInventoryItemList.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_inventory\Field;
 
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\asset\Entity\AssetInterface;
 
 /**
  * Computes the current inventory value for assets.
@@ -23,6 +24,7 @@ class AssetInventoryItemList extends FieldItemList {
     $entity = $this->getEntity();
 
     // Get the asset's current inventories.
+    assert($entity instanceof AssetInterface);
     $inventories = \Drupal::service('asset.inventory')->getInventory($entity);
 
     // Update the assets current inventory values to match.

--- a/modules/core/inventory/src/Plugin/Field/FieldType/InventoryItem.php
+++ b/modules/core/inventory/src/Plugin/Field/FieldType/InventoryItem.php
@@ -67,7 +67,7 @@ class InventoryItem extends FieldItemBase {
     $measure = $this->get('measure');
     $value = $this->get('value');
     $units = $this->get('units');
-    return ($measure === NULL || $measure->getValue() === '') && ($value === NULL || $value->getValue() === '') && ($units === NULL || $units->getValue() === '');
+    return $measure->getValue() === '' && $value->getValue() === '' && $units->getValue() === '';
   }
 
 }

--- a/modules/core/kml/src/FarmKmlServiceProvider.php
+++ b/modules/core/kml/src/FarmKmlServiceProvider.php
@@ -16,6 +16,9 @@ class FarmKmlServiceProvider implements ServiceModifierInterface {
    * {@inheritdoc}
    */
   public function alter(ContainerBuilder $container) {
+    // Ignore PHPStan error for conditional logic.
+    // We check that the container service exists for extra safety.
+    // @phpstan-ignore booleanAnd.leftAlwaysTrue
     if ($container->has('http_middleware.negotiation') && is_a($container->getDefinition('http_middleware.negotiation')->getClass(), '\Drupal\Core\StackMiddleware\NegotiationMiddleware', TRUE)) {
       $container->getDefinition('http_middleware.negotiation')->addMethodCall('registerFormat', ['kml', ['application/vnd.google-earth.kml+xml']]);
     }

--- a/modules/core/kml/src/FarmKmlServiceProvider.php
+++ b/modules/core/kml/src/FarmKmlServiceProvider.php
@@ -16,8 +16,10 @@ class FarmKmlServiceProvider implements ServiceModifierInterface {
    * {@inheritdoc}
    */
   public function alter(ContainerBuilder $container) {
-    // Ignore PHPStan error for conditional logic.
-    // We check that the container service exists for extra safety.
+    // PHPStan level 3+ throws the following error on the next line:
+    // Left side of && is always true.
+    // We ignore this because we check that the container service exists for
+    // extra safety.
     // @phpstan-ignore booleanAnd.leftAlwaysTrue
     if ($container->has('http_middleware.negotiation') && is_a($container->getDefinition('http_middleware.negotiation')->getClass(), '\Drupal\Core\StackMiddleware\NegotiationMiddleware', TRUE)) {
       $container->getDefinition('http_middleware.negotiation')->addMethodCall('registerFormat', ['kml', ['application/vnd.google-earth.kml+xml']]);

--- a/modules/core/location/src/AssetLocation.php
+++ b/modules/core/location/src/AssetLocation.php
@@ -221,17 +221,8 @@ class AssetLocation implements AssetLocationInterface {
       return NULL;
     }
 
-    // Load the first log.
-    /** @var \Drupal\log\Entity\LogInterface $log */
-    $log = $this->entityTypeManager->getStorage('log')->load(reset($log_ids));
-
-    // Return the log, if available.
-    if (!is_null($log)) {
-      return $log;
-    }
-
-    // Otherwise, return NULL.
-    return NULL;
+    // Load the first log or return NULL.
+    return $this->entityTypeManager->getStorage('log')->load(reset($log_ids));
   }
 
   /**

--- a/modules/core/location/src/Field/AssetGeometryItemList.php
+++ b/modules/core/location/src/Field/AssetGeometryItemList.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_location\Field;
 
 use Drupal\Core\Field\FieldItemList;
 use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\asset\Entity\AssetInterface;
 
 /**
  * Computes the current geometry value for assets.
@@ -23,6 +24,7 @@ class AssetGeometryItemList extends FieldItemList {
     $entity = $this->getEntity();
 
     // Get the asset geometry.
+    assert($entity instanceof AssetInterface);
     $geometry = \Drupal::service('asset.location')->getGeometry($entity);
 
     // Update the assets current geometry value to match.

--- a/modules/core/location/src/Field/AssetLocationItemList.php
+++ b/modules/core/location/src/Field/AssetLocationItemList.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_location\Field;
 
 use Drupal\Core\Field\EntityReferenceFieldItemList;
 use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\asset\Entity\AssetInterface;
 
 /**
  * Computes the current location value for assets.
@@ -23,6 +24,7 @@ class AssetLocationItemList extends EntityReferenceFieldItemList {
     $entity = $this->getEntity();
 
     // Get the asset's current locations.
+    assert($entity instanceof AssetInterface);
     $locations = \Drupal::service('asset.location')->getLocation($entity);
 
     // Update the assets current location values to match.

--- a/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
+++ b/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
@@ -73,6 +73,7 @@ class CircularAssetLocationConstraintValidator extends ConstraintValidator imple
 
       // Load assets that are located in the asset being referenced.
       // Use our own method to recurse into sub-location assets as well.
+      assert($asset instanceof AssetInterface);
       $assets_in_location = $this->getAssetsByLocationRecursively($asset, $timestamp);
 
       // Make sure that none of the assets are located in this asset.

--- a/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
+++ b/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
@@ -130,7 +130,7 @@ class LogQuantityEventSubscriber implements EventSubscriberInterface {
         return TRUE;
       }));
       $log->setNewRevision(TRUE);
-      $log->setRevisionLogMessage($this->t('Removed reference to deleted quantity %uuid.', ['%uuid' => $quantity->uuid()]));
+      $log->setRevisionLogMessage($this->t('Removed reference to deleted quantity %uuid.', ['%uuid' => $quantity->uuid()])->render());
       $log->save();
     }
   }

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -121,7 +121,7 @@ class AssetAddLogActionForm extends ConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
-    $this->entities = $this->tempStore->get($this->user->id());
+    $this->entities = $this->tempStore->get((string) $this->user->id());
     if (!$this->entityType || empty($this->entities)) {
       // Ignore PHPstan error for incorrect return type.
       // Forms can return a RedirectResponse.
@@ -203,7 +203,7 @@ class AssetAddLogActionForm extends ConfirmFormBase {
       }
     }
 
-    $this->tempStore->delete($this->currentUser()->id());
+    $this->tempStore->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($redirect_url);
   }
 

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class AssetAddLogActionForm extends ConfirmFormBase {
 
   /**
-   * The tempstore factory.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -122,7 +122,7 @@ class AssetAddLogActionForm extends ConfirmFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
     $this->entities = $this->tempStore->get($this->user->id());
-    if (empty($this->entityType) || empty($this->entities)) {
+    if (!$this->entityType || empty($this->entities)) {
       // Ignore PHPstan error for incorrect return type.
       // Forms can return a RedirectResponse.
       // @phpstan-ignore return.type

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -123,6 +123,9 @@ class AssetAddLogActionForm extends ConfirmFormBase {
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
     $this->entities = $this->tempStore->get($this->user->id());
     if (empty($this->entityType) || empty($this->entities)) {
+      // Ignore PHPstan error for incorrect return type.
+      // Forms can return a RedirectResponse.
+      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -112,13 +112,6 @@ class AssetAddLogActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfirmText() {
     return $this->t('Continue');
   }
@@ -153,7 +146,13 @@ class AssetAddLogActionForm extends ConfirmFormBase {
       '#required' => TRUE,
     ];
 
-    return parent::buildForm($form, $form_state);
+    // Delegate to the parent method.
+    $form = parent::buildForm($form, $form_state);
+
+    // Remove form description text.
+    unset($form['description']);
+
+    return $form;
   }
 
   /**

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -119,13 +119,10 @@ class AssetAddLogActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
     $this->entities = $this->tempStore->get((string) $this->user->id());
     if (!$this->entityType || empty($this->entities)) {
-      // Ignore PHPstan error for incorrect return type.
-      // Forms can return a RedirectResponse.
-      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -79,7 +79,7 @@ class AssetAddLog extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id(), $entities);
+    $this->tempStore->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AssetAddLog extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/log/tests/src/Kernel/LogTest.php
+++ b/modules/core/log/tests/src/Kernel/LogTest.php
@@ -84,7 +84,7 @@ class LogTest extends KernelTestBase {
 
     // Set the timestamp of one log to the future.
     $now = \Drupal::time()->getRequestTime();
-    $foo_log->timestamp = $now + 86400;
+    $foo_log->set('timestamp', $now + 86400);
     $foo_log->save();
 
     // Test that results can be filtered by timestamp.
@@ -92,7 +92,7 @@ class LogTest extends KernelTestBase {
     $this->assertNotContains($foo_log->id(), $log_ids, 'Log query results can be filtered by timestamp.');
 
     // Set the status of one log to complete.
-    $bar_log->status = 'complete';
+    $bar_log->set('status', 'complete');
     $bar_log->save();
 
     // Test that results can be filtered by status.
@@ -100,7 +100,7 @@ class LogTest extends KernelTestBase {
     $this->assertNotContains($bar_log->id(), $log_ids, 'Log query results can be filtered by status.');
 
     // Reference the asset in one of the logs.
-    $foo_log->asset[] = $asset;
+    $foo_log->get('asset')->appendItem($asset);
     $foo_log->save();
 
     // Test that results can be filtered by asset reference.
@@ -110,9 +110,9 @@ class LogTest extends KernelTestBase {
 
     // Set the timestamps of both logs to now.
     $now = \Drupal::time()->getRequestTime();
-    $foo_log->timestamp = $now;
+    $foo_log->set('timestamp', $now);
     $foo_log->save();
-    $bar_log->timestamp = $now;
+    $bar_log->set('timestamp', $now);
     $bar_log->save();
 
     // Test that logs with the same timestamp are sorted by ID descending.
@@ -121,7 +121,7 @@ class LogTest extends KernelTestBase {
 
     // Set the timestamp of one log to the future.
     $now = \Drupal::time()->getRequestTime();
-    $foo_log->timestamp = $now + 86400;
+    $foo_log->set('timestamp', $now + 86400);
     $foo_log->save();
 
     // Test that logs are sorted by timestamp descending.

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\farm_login\Functional;
 
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Test using an email in the UserLoginForm.
@@ -182,26 +182,26 @@ class UserLoginTest extends FarmBrowserTestBase {
   /**
    * A helper function to login using an email.
    *
-   * @param \Drupal\Core\Session\AccountInterface $account
+   * @param \Drupal\user\UserInterface $user
    *   User object representing the user to log in.
    *
    * @see drupalLogin()
    * @see drupalCreateUser()
    */
-  protected function drupalLoginUsingEmail(AccountInterface $account) {
+  protected function drupalLoginUsingEmail(UserInterface $user) {
     if ($this->loggedInUser) {
       $this->drupalLogout();
     }
 
     $this->drupalGet(Url::fromRoute('user.login'));
     $this->submitForm([
-      'name' => $account->getEmail(),
+      'name' => $user->getEmail(),
       // PHPStan level 2+ throws the following error on the next line:
       // Access to an undefined property
       // Drupal\Core\Session\AccountInterface::$passRaw.
       // We ignore this because we are following Drupal core's pattern.
       // @phpstan-ignore property.notFound
-      'pass' => $account->passRaw,
+      'pass' => $user->passRaw,
     ], 'Log in');
 
     // PHPStan level 2+ throws the following error on the next line:
@@ -210,11 +210,11 @@ class UserLoginTest extends FarmBrowserTestBase {
     // We ignore this because we are following Drupal core's pattern.
     // @see ::drupalUserIsLoggedIn()
     // @phpstan-ignore property.notFound
-    $account->sessionId = $this->getSession()->getCookie(\Drupal::service('session_configuration')->getOptions(\Drupal::request())['name']);
-    $this->assertTrue($this->drupalUserIsLoggedIn($account), 'User ' . $account->getAccountName() . ' successfully logged in.');
+    $user->sessionId = $this->getSession()->getCookie(\Drupal::service('session_configuration')->getOptions(\Drupal::request())['name']);
+    $this->assertTrue($this->drupalUserIsLoggedIn($user), 'User ' . $user->getAccountName() . ' successfully logged in.');
 
-    $this->loggedInUser = $account;
-    $this->container->get('current_user')->setAccount($account);
+    $this->loggedInUser = $user;
+    $this->container->get('current_user')->setAccount($user);
   }
 
 }

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -189,8 +189,10 @@ class UserLoginTest extends FarmBrowserTestBase {
    * @see drupalCreateUser()
    */
   protected function drupalLoginUsingEmail(UserInterface $user) {
-    // Ignore PHPStan error for unnecessary if statement.
-    // The loggedInUser property has an incorrect type hint.
+    // PHPStan level 3+ throws the following error on the next line:
+    // If condition is always true.
+    // We ignore this because the \Drupal\Tests\UiHelperTrait::loggedInUser
+    // property has an incorrect type hint.
     // @phpstan-ignore if.alwaysTrue
     if ($this->loggedInUser) {
       $this->drupalLogout();

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -189,6 +189,9 @@ class UserLoginTest extends FarmBrowserTestBase {
    * @see drupalCreateUser()
    */
   protected function drupalLoginUsingEmail(UserInterface $user) {
+    // Ignore PHPStan error for unnecessary if statement.
+    // The loggedInUser property has an incorrect type hint.
+    // @phpstan-ignore if.alwaysTrue
     if ($this->loggedInUser) {
       $this->drupalLogout();
     }

--- a/modules/core/map/src/Element/FarmMap.php
+++ b/modules/core/map/src/Element/FarmMap.php
@@ -96,7 +96,7 @@ class FarmMap extends RenderElementBase {
     // If #behaviors are included, attach each one.
     $behavior_storage = $entity_type_manager->getStorage('map_behavior');
     foreach ($element['#behaviors'] as $behavior_name) {
-      /** @var \Drupal\farm_map\Entity\MapBehaviorInterface|NULL $behavior */
+      /** @var \Drupal\farm_map\Entity\MapBehaviorInterface|null $behavior */
       if ($behavior = $behavior_storage->load($behavior_name)) {
         $element['#attached']['library'][] = $behavior->getLibrary();
       }

--- a/modules/core/map/src/Element/FarmMap.php
+++ b/modules/core/map/src/Element/FarmMap.php
@@ -40,8 +40,8 @@ class FarmMap extends RenderElementBase {
    *   appended to 'farm-map-' as the map element ID if one has not already
    *   been provided.
    *
-   * @return array
-   *   A renderable array representing the map.
+   * @return \Drupal\farm_map\Element\FarmMap
+   *   The farm map render element.
    *
    * @see \Drupal\farm_map\Event\MapRenderEvent
    */

--- a/modules/core/map/src/Element/FarmMap.php
+++ b/modules/core/map/src/Element/FarmMap.php
@@ -94,10 +94,10 @@ class FarmMap extends RenderElementBase {
     $element['#attached']['drupalSettings']['farm_map_public_path'] = $public_path;
 
     // If #behaviors are included, attach each one.
+    $behavior_storage = $entity_type_manager->getStorage('map_behavior');
     foreach ($element['#behaviors'] as $behavior_name) {
-      /** @var \Drupal\farm_map\Entity\MapBehaviorInterface $behavior */
-      $behavior = $entity_type_manager->getStorage('map_behavior')->load($behavior_name);
-      if (!is_null($behavior)) {
+      /** @var \Drupal\farm_map\Entity\MapBehaviorInterface|NULL $behavior */
+      if ($behavior = $behavior_storage->load($behavior_name)) {
         $element['#attached']['library'][] = $behavior->getLibrary();
       }
     }

--- a/modules/core/map/src/Entity/MapType.php
+++ b/modules/core/map/src/Entity/MapType.php
@@ -92,7 +92,7 @@ class MapType extends ConfigEntityBase implements MapTypeInterface {
    * {@inheritdoc}
    */
   public function getMapBehaviors() {
-    return $this->behaviors ?? [];
+    return empty($this->behaviors) ? [] : $this->behaviors;
   }
 
   /**

--- a/modules/core/map/src/Event/MapRenderEvent.php
+++ b/modules/core/map/src/Event/MapRenderEvent.php
@@ -18,9 +18,9 @@ class MapRenderEvent extends Event {
   const EVENT_NAME = 'map_render_event';
 
   /**
-   * The farm_map render element.
+   * The farm_map render element or render array.
    *
-   * @var \Drupal\farm_map\Element\FarmMap
+   * @var \Drupal\farm_map\Element\FarmMap|array
    */
   public $element;
 

--- a/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
+++ b/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
@@ -346,7 +346,7 @@ class GeofieldWidget extends GeofieldBaseWidget {
 
     // Get the file extension.
     $matches = [];
-    if (preg_match('/(?<=\.)[^.]+$/', $file->getFilename(), $matches) && isset($matches[0])) {
+    if (preg_match('/(?<=\.)[^.]+$/', $file->getFilename(), $matches) && !empty($matches[0])) {
       // Return the associated GeoPHP type.
       if (isset(self::$geoPhpTypes[$matches[0]])) {
         return self::$geoPhpTypes[$matches[0]];

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -143,7 +143,7 @@ class AssignActionForm extends ConfirmFormBase {
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type);
 
     // Load saved entities.
-    $this->entities = $this->tempStore->get($this->user->id());
+    $this->entities = $this->tempStore->get((string) $this->user->id());
 
     // If there are no entities, or if the entity type definition didn't load,
     // redirect the user to the cancel URL.
@@ -267,7 +267,7 @@ class AssignActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete($this->currentUser()->id());
+    $this->tempStore->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -21,9 +21,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class AssignActionForm extends ConfirmFormBase {
 
   /**
-   * The tempstore factory.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -215,40 +215,39 @@ class AssignActionForm extends ConfirmFormBase {
     $total_count = 0;
     foreach ($accessible_entities as $entity) {
       /** @var \Drupal\Core\Field\FieldItemListInterface $owner_field */
-      if ($owner_field = $entity->get('owner')) {
+      $owner_field = $entity->get('owner');
 
-        // Save existing users if appending.
-        $existing_owners = [];
-        if ($form_state->getValue('operation') === 'append') {
-          $existing_owners = array_column($owner_field->getValue(), 'target_id');
-        }
-
-        // Empty the owner field.
-        $owner_field->setValue([]);
-
-        // Build list of owners.
-        $new_owners = array_unique(array_merge($existing_owners, $form_state->getValue('users')));
-        foreach ($new_owners as $owner) {
-          $owner_field->appendItem($owner);
-        }
-
-        // Validate the entity before saving.
-        $violations = $entity->validate();
-        if ($violations->count() > 0) {
-          $this->messenger()->addWarning(
-            $this->t('Could not assign <a href=":entity_link">%entity_label</a>: validation failed.',
-              [
-                ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
-                '%entity_label' => $entity->label(),
-              ],
-            ),
-          );
-          continue;
-        }
-
-        $entity->save();
-        $total_count++;
+      // Save existing users if appending.
+      $existing_owners = [];
+      if ($form_state->getValue('operation') === 'append') {
+        $existing_owners = array_column($owner_field->getValue(), 'target_id');
       }
+
+      // Empty the owner field.
+      $owner_field->setValue([]);
+
+      // Build list of owners.
+      $new_owners = array_unique(array_merge($existing_owners, $form_state->getValue('users')));
+      foreach ($new_owners as $owner) {
+        $owner_field->appendItem($owner);
+      }
+
+      // Validate the entity before saving.
+      $violations = $entity->validate();
+      if ($violations->count() > 0) {
+        $this->messenger()->addWarning(
+          $this->t('Could not assign <a href=":entity_link">%entity_label</a>: validation failed.',
+            [
+              ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
+              '%entity_label' => $entity->label(),
+            ],
+          ),
+        );
+        continue;
+      }
+
+      $entity->save();
+      $total_count++;
     }
 
     // Add warning message for inaccessible entities.

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -148,6 +148,9 @@ class AssignActionForm extends ConfirmFormBase {
     // If there are no entities, or if the entity type definition didn't load,
     // redirect the user to the cancel URL.
     if (empty($this->entityType) || empty($this->entities)) {
+      // Ignore PHPstan error for incorrect return type.
+      // Forms can return a RedirectResponse.
+      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -132,7 +132,7 @@ class AssignActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, ?string $entity_type = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, ?string $entity_type = NULL): array|RedirectResponse {
 
     // Only allow asset and log entities.
     if (!in_array($entity_type, ['asset', 'log'])) {
@@ -148,9 +148,6 @@ class AssignActionForm extends ConfirmFormBase {
     // If there are no entities, or if the entity type definition didn't load,
     // redirect the user to the cancel URL.
     if (!$this->entityType || empty($this->entities)) {
-      // Ignore PHPstan error for incorrect return type.
-      // Forms can return a RedirectResponse.
-      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -125,13 +125,6 @@ class AssignActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfirmText() {
     return $this->t('Assign');
   }
@@ -190,7 +183,13 @@ class AssignActionForm extends ConfirmFormBase {
       '#required' => TRUE,
     ];
 
-    return parent::buildForm($form, $form_state);
+    // Delegate to the parent method.
+    $form = parent::buildForm($form, $form_state);
+
+    // Remove form description text.
+    unset($form['description']);
+
+    return $form;
   }
 
   /**

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -147,7 +147,7 @@ class AssignActionForm extends ConfirmFormBase {
 
     // If there are no entities, or if the entity type definition didn't load,
     // redirect the user to the cancel URL.
-    if (empty($this->entityType) || empty($this->entities)) {
+    if (!$this->entityType || empty($this->entities)) {
       // Ignore PHPstan error for incorrect return type.
       // Forms can return a RedirectResponse.
       // @phpstan-ignore return.type

--- a/modules/core/owner/src/Plugin/Action/AssignBase.php
+++ b/modules/core/owner/src/Plugin/Action/AssignBase.php
@@ -16,9 +16,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class AssignBase extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/owner/src/Plugin/Action/AssignBase.php
+++ b/modules/core/owner/src/Plugin/Action/AssignBase.php
@@ -71,7 +71,7 @@ abstract class AssignBase extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id(), $entities);
+    $this->tempStore->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -149,7 +149,7 @@ class AssetParentActionForm extends ConfirmFormBase {
     }
     // Else load entities from the tempStore state.
     else {
-      $this->entities = $this->tempStore->get($this->user->id());
+      $this->entities = $this->tempStore->get((string) $this->user->id());
     }
 
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
@@ -277,7 +277,7 @@ class AssetParentActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete($this->currentUser()->id());
+    $this->tempStore->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -21,9 +21,9 @@ use Symfony\Component\HttpFoundation\Request;
 class AssetParentActionForm extends ConfirmFormBase {
 
   /**
-   * The tempstore factory.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -226,39 +226,38 @@ class AssetParentActionForm extends ConfirmFormBase {
     $total_count = 0;
     foreach ($accessible_entities as $entity) {
       /** @var \Drupal\Core\Field\EntityReferenceFieldItemListInterface $parent_field */
-      if ($parent_field = $entity->get('parent')) {
+      $parent_field = $entity->get('parent');
 
-        // Save existing values if appending.
-        $existing_values = [];
-        if ($form_state->getValue('operation') === 'append') {
-          $existing_values = array_column($parent_field->getValue(), 'target_id');
-        }
-
-        // Empty the field.
-        $parent_field->setValue([]);
-
-        $new_values = array_unique(array_merge($existing_values, $submitted_parent_ids));
-        foreach ($new_values as $parent_id) {
-          $parent_field->appendItem($parent_id);
-        }
-
-        // Validate the entity before saving.
-        $violations = $entity->validate();
-        if ($violations->count() > 0) {
-          $this->messenger()->addWarning(
-            $this->t('Could not assign parent for <a href=":entity_link">%entity_label</a>: validation failed.',
-              [
-                ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
-                '%entity_label' => $entity->label(),
-              ],
-            ),
-          );
-          continue;
-        }
-
-        $entity->save();
-        $total_count++;
+      // Save existing values if appending.
+      $existing_values = [];
+      if ($form_state->getValue('operation') === 'append') {
+        $existing_values = array_column($parent_field->getValue(), 'target_id');
       }
+
+      // Empty the field.
+      $parent_field->setValue([]);
+
+      $new_values = array_unique(array_merge($existing_values, $submitted_parent_ids));
+      foreach ($new_values as $parent_id) {
+        $parent_field->appendItem($parent_id);
+      }
+
+      // Validate the entity before saving.
+      $violations = $entity->validate();
+      if ($violations->count() > 0) {
+        $this->messenger()->addWarning(
+          $this->t('Could not assign parent for <a href=":entity_link">%entity_label</a>: validation failed.',
+            [
+              ':entity_link' => $entity->toUrl()->setAbsolute()->toString(),
+              '%entity_label' => $entity->label(),
+            ],
+          ),
+        );
+        continue;
+      }
+
+      $entity->save();
+      $total_count++;
     }
 
     // Add warning message for inaccessible entities.

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -154,6 +154,9 @@ class AssetParentActionForm extends ConfirmFormBase {
 
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
     if (empty($this->entityType) || empty($this->entities)) {
+      // Ignore PHPstan error for incorrect return type.
+      // Forms can return a RedirectResponse.
+      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -125,13 +125,6 @@ class AssetParentActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfirmText() {
     return $this->t('Save');
   }
@@ -198,7 +191,13 @@ class AssetParentActionForm extends ConfirmFormBase {
       '#required' => TRUE,
     ];
 
-    return parent::buildForm($form, $form_state);
+    // Delegate to the parent method.
+    $form = parent::buildForm($form, $form_state);
+
+    // Remove form description text.
+    unset($form['description']);
+
+    return $form;
   }
 
   /**

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -132,7 +132,7 @@ class AssetParentActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
 
     // Check if asset IDs were provided in the asset query param.
     if ($asset_ids = $this->request->get('asset')) {
@@ -154,9 +154,6 @@ class AssetParentActionForm extends ConfirmFormBase {
 
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
     if (!$this->entityType || empty($this->entities)) {
-      // Ignore PHPstan error for incorrect return type.
-      // Forms can return a RedirectResponse.
-      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -153,7 +153,7 @@ class AssetParentActionForm extends ConfirmFormBase {
     }
 
     $this->entityType = $this->entityTypeManager->getDefinition('asset');
-    if (empty($this->entityType) || empty($this->entities)) {
+    if (!$this->entityType || empty($this->entities)) {
       // Ignore PHPstan error for incorrect return type.
       // Forms can return a RedirectResponse.
       // @phpstan-ignore return.type

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AssetParent extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -79,7 +79,7 @@ class AssetParent extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id(), $entities);
+    $this->tempStore->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/core/plan/src/Entity/PlanInterface.php
+++ b/modules/core/plan/src/Entity/PlanInterface.php
@@ -65,7 +65,7 @@ interface PlanInterface extends ContentEntityInterface, EntityChangedInterface, 
   /**
    * Sets the plan archived timestamp.
    *
-   * @param int $timestamp
+   * @param int|string|null $timestamp
    *   Archived timestamp of the plan.
    *
    * @return \Drupal\plan\Entity\PlanInterface

--- a/modules/core/plan/src/Plugin/Action/PlanStateChangeBase.php
+++ b/modules/core/plan/src/Plugin/Action/PlanStateChangeBase.php
@@ -83,7 +83,7 @@ abstract class PlanStateChangeBase extends EntityActionBase {
     // Deny access if the workflow does not support the target state.
     if (empty($target_state)) {
       $result = $result->orIf(AccessResult::forbidden(
-        $this->t('The %workflow workflow does not support the %target_state state.', ['%workflow' => $workflow->getLabel(), '%target_state' => $this->targetState]),
+        $this->t('The %workflow workflow does not support the %target_state state.', ['%workflow' => $workflow->getLabel(), '%target_state' => $this->targetState])->render(),
       ));
     }
     // Else check that a transition exists to the desired target state.

--- a/modules/core/plan/tests/src/Functional/PlanTestBase.php
+++ b/modules/core/plan/tests/src/Functional/PlanTestBase.php
@@ -12,9 +12,7 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 abstract class PlanTestBase extends FarmBrowserTestBase {
 
   /**
-   * Modules to install.
-   *
-   * @var array
+   * {@inheritdoc}
    */
   protected static $modules = [
     'plan',

--- a/modules/core/quick/src/Controller/QuickFormAddPage.php
+++ b/modules/core/quick/src/Controller/QuickFormAddPage.php
@@ -57,7 +57,7 @@ class QuickFormAddPage extends ControllerBase {
 
     // Filter to configurable quick form plugins.
     $plugins = array_filter($this->quickFormPluginManager->getDefinitions(), function (array $plugin) {
-      if (($instance = $this->quickFormPluginManager->createInstance($plugin['id'])) && $instance instanceof ConfigurableQuickFormInterface) {
+      if ($this->quickFormPluginManager->createInstance($plugin['id']) instanceof ConfigurableQuickFormInterface) {
         return TRUE;
       }
       return FALSE;

--- a/modules/core/quick/src/Controller/QuickFormAddPage.php
+++ b/modules/core/quick/src/Controller/QuickFormAddPage.php
@@ -70,8 +70,8 @@ class QuickFormAddPage extends ControllerBase {
     // Add link for each configurable plugin.
     foreach ($plugins as $plugin_id => $plugin) {
       $render['#bundles'][$plugin_id] = [
-        'label' => Html::escape($plugin['label']),
-        'description' => Html::escape($plugin['description']) ?? '',
+        'label' => Html::escape($plugin['label'] ?? ''),
+        'description' => Html::escape($plugin['description'] ?? ''),
         'add_link' => Link::createFromRoute($plugin['label'], 'farm_quick.add_form', ['plugin' => $plugin_id]),
       ];
     }

--- a/modules/core/quick/src/Entity/QuickFormInstance.php
+++ b/modules/core/quick/src/Entity/QuickFormInstance.php
@@ -122,6 +122,9 @@ class QuickFormInstance extends ConfigEntityBase implements QuickFormInstanceInt
    *   The block's plugin collection.
    */
   protected function getPluginCollection() {
+    // Ignore PHPStan error for conditional logic.
+    // We follow Drupal core convention.
+    // @phpstan-ignore booleanNot.alwaysFalse
     if (!$this->pluginCollection) {
       $this->pluginCollection = new QuickFormPluginCollection(\Drupal::service('plugin.manager.quick_form'), $this->plugin, $this->get('settings'), $this->id());
     }

--- a/modules/core/quick/src/Entity/QuickFormInstance.php
+++ b/modules/core/quick/src/Entity/QuickFormInstance.php
@@ -122,8 +122,9 @@ class QuickFormInstance extends ConfigEntityBase implements QuickFormInstanceInt
    *   The block's plugin collection.
    */
   protected function getPluginCollection() {
-    // Ignore PHPStan error for conditional logic.
-    // We follow Drupal core convention.
+    // PHPStan level 3+ throws the following error on the next line:
+    // Negated boolean expression is always false.
+    // We ignore this because we are following Drupal core's pattern.
     // @phpstan-ignore booleanNot.alwaysFalse
     if (!$this->pluginCollection) {
       $this->pluginCollection = new QuickFormPluginCollection(\Drupal::service('plugin.manager.quick_form'), $this->plugin, $this->get('settings'), $this->id());

--- a/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
+++ b/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
@@ -16,9 +16,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class QuickFormActionBase extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/core/report/src/Controller/ReportController.php
+++ b/modules/core/report/src/Controller/ReportController.php
@@ -55,7 +55,7 @@ class ReportController extends ControllerBase {
     // Load all menu links below it.
     $parameters = new MenuTreeParameters();
     $parameters->setRoot('farm.report')->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
-    $tree = $this->menuLinkTree->load(NULL, $parameters);
+    $tree = $this->menuLinkTree->load('', $parameters);
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -98,6 +98,9 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
    * {@inheritdoc}
    */
   protected function getDiscovery() {
+    // Ignore PHPStan error for conditional logic.
+    // We follow Drupal core convention.
+    // @phpstan-ignore booleanNot.alwaysFalse
     if (!$this->discovery) {
       $discovery = new YamlDiscovery('managed_role_permissions', $this->moduleHandler->getModuleDirectories());
       $this->discovery = new ContainerDerivativeDiscoveryDecorator($discovery);

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -98,7 +98,7 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
    * {@inheritdoc}
    */
   protected function getDiscovery() {
-    if (!isset($this->discovery)) {
+    if (!$this->discovery) {
       $discovery = new YamlDiscovery('managed_role_permissions', $this->moduleHandler->getModuleDirectories());
       $this->discovery = new ContainerDerivativeDiscoveryDecorator($discovery);
     }

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -98,8 +98,9 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
    * {@inheritdoc}
    */
   protected function getDiscovery() {
-    // Ignore PHPStan error for conditional logic.
-    // We follow Drupal core convention.
+    // PHPStan level 3+ throws the following error on the next line:
+    // Negated boolean expression is always false.
+    // We ignore this because we are following Drupal core's pattern.
     // @phpstan-ignore booleanNot.alwaysFalse
     if (!$this->discovery) {
       $discovery = new YamlDiscovery('managed_role_permissions', $this->moduleHandler->getModuleDirectories());

--- a/modules/core/settings/tests/src/Functional/ModulesFormTest.php
+++ b/modules/core/settings/tests/src/Functional/ModulesFormTest.php
@@ -95,8 +95,7 @@ class ModulesFormTest extends WebDriverTestBase {
     $field_name = $type . "[modules][$module]";
     $checkbox = $page->findField($field_name);
     $this->assertNotEmpty($checkbox, "The checkbox for $module exists.");
-
-    $this->assertEquals($checked, $checkbox->isChecked(), "The $module checkbox is " . $checked ? '' : 'not ' . 'checked.');
+    $this->assertEquals($checked, $checkbox->isChecked(), "The $module checkbox has expected state.");
     $this->assertEquals($disabled, $checkbox->hasAttribute('disabled'), "The $module checkbox is disabled: $disabled");
   }
 

--- a/modules/core/setup/src/Controller/SetupController.php
+++ b/modules/core/setup/src/Controller/SetupController.php
@@ -55,7 +55,7 @@ class SetupController extends ControllerBase {
     // Load all menu links below it.
     $parameters = new MenuTreeParameters();
     $parameters->setRoot('farm.setup')->excludeRoot()->setTopLevelOnly()->onlyEnabledLinks();
-    $tree = $this->menuLinkTree->load(NULL, $parameters);
+    $tree = $this->menuLinkTree->load('', $parameters);
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],

--- a/modules/core/timeline/src/Plugin/DataType/TimelineRow.php
+++ b/modules/core/timeline/src/Plugin/DataType/TimelineRow.php
@@ -24,8 +24,9 @@ class TimelineRow extends Map implements ComplexDataInterface {
    * {@inheritdoc}
    */
   public function setValue($values, $notify = TRUE) {
-    // Ignore PHPStan error for conditional logic.
-    // We follow Drupal core convention from the parent method.
+    // PHPStan level 3+ throws the following error on the next line:
+    // Result of && is always false.
+    // We ignore this because we are following Drupal core's pattern.
     // @phpstan-ignore booleanAnd.alwaysFalse
     if (isset($values) && !is_array($values)) {
       throw new \InvalidArgumentException("Invalid values given. Values must be represented as an associative array.");

--- a/modules/core/timeline/src/Plugin/DataType/TimelineRow.php
+++ b/modules/core/timeline/src/Plugin/DataType/TimelineRow.php
@@ -24,6 +24,9 @@ class TimelineRow extends Map implements ComplexDataInterface {
    * {@inheritdoc}
    */
   public function setValue($values, $notify = TRUE) {
+    // Ignore PHPStan error for conditional logic.
+    // We follow Drupal core convention from the parent method.
+    // @phpstan-ignore booleanAnd.alwaysFalse
     if (isset($values) && !is_array($values)) {
       throw new \InvalidArgumentException("Invalid values given. Values must be represented as an associative array.");
     }

--- a/modules/core/timeline/src/Plugin/DataType/TimelineTask.php
+++ b/modules/core/timeline/src/Plugin/DataType/TimelineTask.php
@@ -24,6 +24,9 @@ class TimelineTask extends Map implements ComplexDataInterface {
    * {@inheritdoc}
    */
   public function setValue($values, $notify = TRUE) {
+    // Ignore PHPStan error for conditional logic.
+    // We follow Drupal core convention from the parent method.
+    // @phpstan-ignore booleanAnd.alwaysFalse
     if (isset($values) && !is_array($values)) {
       throw new \InvalidArgumentException("Invalid values given. Values must be represented as an associative array.");
     }

--- a/modules/core/timeline/src/Plugin/DataType/TimelineTask.php
+++ b/modules/core/timeline/src/Plugin/DataType/TimelineTask.php
@@ -24,8 +24,9 @@ class TimelineTask extends Map implements ComplexDataInterface {
    * {@inheritdoc}
    */
   public function setValue($values, $notify = TRUE) {
-    // Ignore PHPStan error for conditional logic.
-    // We follow Drupal core convention from the parent method.
+    // PHPStan level 3+ throws the following error on the next line:
+    // Result of && is always false.
+    // We ignore this because we are following Drupal core's pattern.
     // @phpstan-ignore booleanAnd.alwaysFalse
     if (isset($values) && !is_array($values)) {
       throw new \InvalidArgumentException("Invalid values given. Values must be represented as an associative array.");

--- a/modules/core/timeline/src/TypedData/TimelineRowDefinition.php
+++ b/modules/core/timeline/src/TypedData/TimelineRowDefinition.php
@@ -20,7 +20,7 @@ class TimelineRowDefinition extends ComplexDataDefinitionBase {
    * {@inheritdoc}
    */
   public function getPropertyDefinitions() {
-    if (!isset($this->propertyDefinitions)) {
+    if (empty($this->propertyDefinitions)) {
 
       $this->propertyDefinitions['id'] = DataDefinition::create('string')
         ->setLabel($this->t('ID'))

--- a/modules/core/timeline/src/TypedData/TimelineTaskDefinition.php
+++ b/modules/core/timeline/src/TypedData/TimelineTaskDefinition.php
@@ -20,7 +20,7 @@ class TimelineTaskDefinition extends ComplexDataDefinitionBase {
    * {@inheritdoc}
    */
   public function getPropertyDefinitions() {
-    if (!isset($this->propertyDefinitions)) {
+    if (empty($this->propertyDefinitions)) {
 
       $this->propertyDefinitions['id'] = DataDefinition::create('string')
         ->setLabel($this->t('ID'))

--- a/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -82,7 +82,7 @@ class AddEntity extends LocalActionDefault {
     $bundle_label = $this->entityTypeManager->getStorage($entity_type->getBundleEntityType())->load($bundle)->label();
 
     // Build the link title.
-    return $this->t('Add @bundle @entity_type', ['@bundle' => $bundle_label, '@entity_type' => $entity_type_label]);
+    return $this->t('Add @bundle @entity_type', ['@bundle' => $bundle_label, '@entity_type' => $entity_type_label])->render();
   }
 
   /**

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -121,15 +121,13 @@ class DashboardController extends ControllerBase {
 
         // Render plugin block if is set.
         $block = $this->blockManager->createInstance($pane['block'], $args);
-        if ($block) {
 
-          // Check block access.
-          $access_result = $block->access($this->currentUser);
-          if ($access_result == TRUE) {
+        // Check block access.
+        $access_result = $block->access($this->currentUser);
 
-            // Builds renderable array of the block.
-            $output = $block->build();
-          }
+        // Build renderable array of the block.
+        if ($access_result == TRUE) {
+          $output = $block->build();
         }
       }
 

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -306,7 +306,7 @@ class LocationHierarchyForm extends FormBase {
       }
 
       // Remove the original parent.
-      if (!empty($asset->get('parent'))) {
+      if (!$asset->get('parent')->isEmpty()) {
         /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $parent */
         foreach ($asset->get('parent') as $delta => $parent) {
           $parent_id = $parent->getValue()['target_id'];

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -99,7 +99,7 @@ class LocationHierarchyForm extends FormBase {
    * @param \Drupal\asset\Entity\AssetInterface|null $asset
    *   Optionally specify the parent asset that this page is being built for.
    *
-   * @return string
+   * @return \Drupal\Core\StringTranslation\TranslatableMarkup
    *   Returns the translated page title.
    */
   public function getTitle(?AssetInterface $asset = NULL) {

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -321,7 +321,7 @@ class LocationHierarchyForm extends FormBase {
 
       // Add the new parent, if applicable.
       if (!empty($change['new_parent'])) {
-        $asset->get('parent')[] = ['target_id' => $change['new_parent']];
+        $asset->get('parent')->appendItem($change['new_parent']);
         if (!array_key_exists($asset->id(), $save_assets)) {
           $save_assets[$asset->id()] = $asset;
         }

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -340,7 +340,7 @@ class LocationHierarchyForm extends FormBase {
         $message = $this->t('Parents changed to %parents via the Locations drag and drop editor.', ['%parents' => implode(', ', $parent_names)]);
       }
       $asset->setNewRevision(TRUE);
-      $asset->setRevisionLogMessage($message);
+      $asset->setRevisionLogMessage($message->render());
       $asset->save();
     }
 

--- a/modules/core/ui/map/farm_ui_map.views_execution.inc
+++ b/modules/core/ui/map/farm_ui_map.views_execution.inc
@@ -70,6 +70,7 @@ function farm_ui_map_views_pre_render(ViewExecutable $view) {
     $layer_group = $view->getBaseEntityType()->getCollectionLabel();
 
     // Get exposed filters.
+    /** @var array<string,string[]> $exposed_filters */
     $exposed_filters = $view->getExposedInput();
 
     // Add multiple asset layers to the page of all assets.

--- a/modules/core/ui/map/farm_ui_map.views_execution.inc
+++ b/modules/core/ui/map/farm_ui_map.views_execution.inc
@@ -120,7 +120,7 @@ function farm_ui_map_views_pre_render(ViewExecutable $view) {
       $type = AssetType::load($bundle);
 
       // Load the map layer style.
-      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|null $layer_style */
       if ($layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => $bundle])) {
         $color = $layer_style->get('color');
       }

--- a/modules/core/ui/map/farm_ui_map.views_execution.inc
+++ b/modules/core/ui/map/farm_ui_map.views_execution.inc
@@ -120,9 +120,8 @@ function farm_ui_map_views_pre_render(ViewExecutable $view) {
       $type = AssetType::load($bundle);
 
       // Load the map layer style.
-      /** @var \Drupal\farm_map\Entity\LayerStyleInterface $layer_style */
-      $layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => $bundle]);
-      if (!is_null($layer_style)) {
+      /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+      if ($layer_style = \Drupal::service('farm_map.layer_style_loader')->load(['asset_type' => $bundle])) {
         $color = $layer_style->get('color');
       }
 

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -104,7 +104,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
         if ($type->getThirdPartySetting('farm_location', 'is_location', FALSE)) {
 
           // Load the map layer style.
-          /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+          /** @var \Drupal\farm_map\Entity\LayerStyleInterface|null $layer_style */
           if ($layer_style = $this->layerStyleLoader->load(['asset_type' => $type->id()])) {
             $color = $layer_style->get('color');
           }

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -104,9 +104,8 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
         if ($type->getThirdPartySetting('farm_location', 'is_location', FALSE)) {
 
           // Load the map layer style.
-          /** @var \Drupal\farm_map\Entity\LayerStyleInterface $layer_style */
-          $layer_style = $this->layerStyleLoader->load(['asset_type' => $type->id()]);
-          if (!is_null($layer_style)) {
+          /** @var \Drupal\farm_map\Entity\LayerStyleInterface|NULL $layer_style */
+          if ($layer_style = $this->layerStyleLoader->load(['asset_type' => $type->id()])) {
             $color = $layer_style->get('color');
           }
 

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -29,7 +29,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   /**
    * The layer style loader service.
    *
-   * @var \Drupal\farm_map\LayerStyleLoader
+   * @var \Drupal\farm_map\LayerStyleLoaderInterface
    */
   protected $layerStyleLoader;
 

--- a/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
+++ b/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
@@ -64,7 +64,7 @@ class EntityTypeLabelLocalTask extends LocalTaskDefault implements ContainerFact
     // Bail if no entity type option is provided.
     $entity_type = $this->pluginDefinition['options']['entity_type'] ?? NULL;
     if (!$entity_type) {
-      return $this->t('View');
+      return $this->t('View')->render();
     }
 
     // Get the entity from the route match.
@@ -78,7 +78,7 @@ class EntityTypeLabelLocalTask extends LocalTaskDefault implements ContainerFact
 
     // Default to "View" if no entity is loaded.
     if (!$entity instanceof EntityInterface) {
-      return $this->t('View');
+      return $this->t('View')->render();
     }
 
     // For entity types with bundles, return the bundle label.

--- a/modules/core/ui/menu/src/Render/Element/FarmAdminToolbar.php
+++ b/modules/core/ui/menu/src/Render/Element/FarmAdminToolbar.php
@@ -39,7 +39,7 @@ class FarmAdminToolbar implements TrustedCallbackInterface {
     $menu_tree = \Drupal::service('toolbar.menu_tree');
     $parameters = new MenuTreeParameters();
     $parameters->setRoot('farm.base')->excludeRoot()->setMaxDepth(4)->onlyEnabledLinks();
-    $tree = $menu_tree->load(NULL, $parameters);
+    $tree = $menu_tree->load('', $parameters);
     $manipulators = [
       ['callable' => 'menu.default_tree_manipulators:checkAccess'],
       ['callable' => 'menu.default_tree_manipulators:generateIndexAndSort'],

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -127,7 +127,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
 
     // Only alter the form display if farm_ui_theme.use_field_group is TRUE
     // or if the form display is new and not saved.
-    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $form_display */
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|NULL $form_display */
     $form_display = $form_state->get('form_display');
     if (!$form_display || !$form_display->getThirdPartySetting('farm_ui_theme', 'use_field_group', $form_display->isNew())) {
       return $form;
@@ -250,7 +250,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
     }
 
     // Remove the sidebar if the display is not using field groups.
-    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface $form_display */
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|NULL $form_display */
     $form_display = $form_state->get('form_display');
     if (!$form_display || !$form_display->getThirdPartySetting('farm_ui_theme', 'use_field_group', $form_display->isNew())) {
 

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -127,7 +127,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
 
     // Only alter the form display if farm_ui_theme.use_field_group is TRUE
     // or if the form display is new and not saved.
-    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|NULL $form_display */
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|null $form_display */
     $form_display = $form_state->get('form_display');
     if (!$form_display || !$form_display->getThirdPartySetting('farm_ui_theme', 'use_field_group', $form_display->isNew())) {
       return $form;
@@ -250,7 +250,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
     }
 
     // Remove the sidebar if the display is not using field groups.
-    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|NULL $form_display */
+    /** @var \Drupal\Core\Entity\Display\EntityFormDisplayInterface|null $form_display */
     $form_display = $form_state->get('form_display');
     if (!$form_display || !$form_display->getThirdPartySetting('farm_ui_theme', 'use_field_group', $form_display->isNew())) {
 

--- a/modules/core/ui/views/farm_ui_views.module
+++ b/modules/core/ui/views/farm_ui_views.module
@@ -116,6 +116,11 @@ function farm_ui_views_form_views_exposed_form_alter(&$form, FormStateInterface 
     // This is needed to prevent the filter from opening when click sort is
     // applied and all default filter values are passed as query parameters.
     $open_input = FALSE;
+    /**
+     * Add correct type hint for returned array structure.
+     * @var string $filter_name
+     * @var string|array $filter_value
+     */
     foreach ($view->getExposedInput() as $filter_name => $filter_value) {
 
       // Check if the exposed input is for a filter.

--- a/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_views\Plugin\views\argument;
 
 use Drupal\Core\Entity\EntityFieldManagerInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\taxonomy\TermStorageInterface;
 use Drupal\views\Plugin\views\argument\NumericArgument;
 use Drupal\views\Plugin\views\query\Sql;
 use Drupal\views\Views;
@@ -60,7 +60,7 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
    *   The plugin ID for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityStorageInterface $term_storage
+   * @param \Drupal\taxonomy\TermStorageInterface $term_storage
    *   The taxonomy term storage service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
@@ -73,7 +73,7 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    EntityStorageInterface $term_storage,
+    TermStorageInterface $term_storage,
     EntityTypeManagerInterface $entity_type_manager,
     EntityTypeBundleInfoInterface $entity_bundle_info,
     EntityFieldManagerInterface $entity_field_manager,

--- a/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
@@ -94,8 +94,8 @@ class DashboardTasksTest extends FarmBrowserTestBase {
     $this->assertSession()->pageTextContains('No logs found.');
 
     // Mark the log as pending in the future.
-    $this->log->status = 'pending';
-    $this->log->timestamp = \Drupal::time()->getCurrentTime() + 86400;
+    $this->log->set('status', 'pending');
+    $this->log->set('timestamp', \Drupal::time()->getCurrentTime() + 86400);
     $this->log->save();
 
     // Assert that the log is displayed.
@@ -104,8 +104,8 @@ class DashboardTasksTest extends FarmBrowserTestBase {
     $this->assertSession()->pageTextContains($this->log->label());
 
     // Mark the log as pending in the past.
-    $this->log->status = 'pending';
-    $this->log->timestamp = \Drupal::time()->getCurrentTime() - 86400;
+    $this->log->set('status', 'pending');
+    $this->log->set('timestamp', \Drupal::time()->getCurrentTime() - 86400);
     $this->log->save();
 
     // Assert that the log is displayed.

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -22,9 +22,9 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
   protected $user;
 
   /**
-   * Test animal asset.
+   * Test plant type.
    *
-   * @var \Drupal\asset\Entity\Asset
+   * @var \Drupal\taxonomy\Entity\Term
    */
   protected $favaPlantType;
 

--- a/modules/core/update/src/FarmUpdate.php
+++ b/modules/core/update/src/FarmUpdate.php
@@ -115,7 +115,7 @@ class FarmUpdate implements FarmUpdateInterface {
 
       // Get the config type and bail if simple configuration.
       // The lister gives NULL if simple configuration.
-      /** @var string|NULL $type */
+      /** @var string|null $type */
       $type = $this->configList->getTypeNameByConfigName($name);
       if ($type === NULL) {
         continue;

--- a/modules/core/update/src/FarmUpdate.php
+++ b/modules/core/update/src/FarmUpdate.php
@@ -115,6 +115,7 @@ class FarmUpdate implements FarmUpdateInterface {
 
       // Get the config type and bail if simple configuration.
       // The lister gives NULL if simple configuration.
+      /** @var string|NULL $type */
       $type = $this->configList->getTypeNameByConfigName($name);
       if ($type === NULL) {
         continue;

--- a/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
+++ b/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
@@ -49,7 +49,7 @@ class UniqueBirthLogConstraintValidator extends ConstraintValidator implements C
     /** @var \Drupal\farm_birth\Plugin\Validation\Constraint\UniqueBirthLogConstraint $constraint */
 
     // Only continue if this is a birth log.
-    /** @var \Drupal\log\Entity\LogInterface|NULL $log */
+    /** @var \Drupal\log\Entity\LogInterface|null $log */
     $log = $value->getParent()->getValue();
     if (!is_null($log) && $log->bundle() != 'birth') {
       return;

--- a/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
+++ b/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
@@ -49,7 +49,7 @@ class UniqueBirthLogConstraintValidator extends ConstraintValidator implements C
     /** @var \Drupal\farm_birth\Plugin\Validation\Constraint\UniqueBirthLogConstraint $constraint */
 
     // Only continue if this is a birth log.
-    /** @var \Drupal\log\Entity\LogInterface $log */
+    /** @var \Drupal\log\Entity\LogInterface|NULL $log */
     $log = $value->getParent()->getValue();
     if (!is_null($log) && $log->bundle() != 'birth') {
       return;

--- a/modules/log/lab_test/farm_lab_test.post_update.php
+++ b/modules/log/lab_test/farm_lab_test.post_update.php
@@ -140,7 +140,7 @@ function farm_lab_test_post_update_migrate_lab_terms(&$sandbox) {
 
     // Save a new revision of the log.
     $log->setNewRevision(TRUE);
-    $log->setRevisionLogMessage(t('Automatically migrated laboratory name to taxonomy term in the new Lab vocabulary.'));
+    $log->setRevisionLogMessage(t('Automatically migrated laboratory name to taxonomy term in the new Lab vocabulary.')->render());
     $log->save();
 
     // Declare that the log has been fixed.

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -131,6 +131,9 @@ class Birth extends QuickFormBase {
       $container->get('config.factory'),
       $container->get('asset.location'),
       $container->get('current_user'),
+      // Ignore PHPStan error for ternary logic. It is possible that the
+      // group.membership does not exist if the group module is not installed.
+      // @phpstan-ignore ternary.alwaysTrue
       $container->has('group.membership') ? $container->get('group.membership') : NULL,
     );
   }

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -131,8 +131,10 @@ class Birth extends QuickFormBase {
       $container->get('config.factory'),
       $container->get('asset.location'),
       $container->get('current_user'),
-      // Ignore PHPStan error for ternary logic. It is possible that the
-      // group.membership does not exist if the group module is not installed.
+      // PHPStan level 3+ throws the following error on the next line:
+      // Ternary operator condition is always true.
+      // We ignore this because we know that the group.membership service will
+      // not exist if the group module is not installed.
       // @phpstan-ignore ternary.alwaysTrue
       $container->has('group.membership') ? $container->get('group.membership') : NULL,
     );

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Drupal\farm_quick_group\Plugin\QuickForm;
 
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_group\GroupMembershipInterface;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
@@ -224,11 +224,11 @@ class Group extends QuickFormBase implements QuickFormInterface {
       return $entities;
     }
     foreach ($values as $value) {
-      if ($value instanceof EntityInterface) {
-        $entities[] = $value;
+      if (is_array($value) && !empty($value['target_id'])) {
+        $value = $this->entityTypeManager->getStorage('asset')->load($value['target_id']);
       }
-      elseif (!empty($value['target_id'])) {
-        $entities[] = $this->entityTypeManager->getStorage('asset')->load($value['target_id']);
+      if ($value instanceof AssetInterface) {
+        $entities[] = $value;
       }
     }
     return $entities;

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Drupal\farm_quick_movement\Plugin\QuickForm;
 
 use Drupal\Core\Datetime\DrupalDateTime;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\farm_location\AssetLocationInterface;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
@@ -261,11 +261,11 @@ class Movement extends QuickFormBase implements QuickFormInterface {
       return $entities;
     }
     foreach ($values as $value) {
-      if ($value instanceof EntityInterface) {
-        $entities[] = $value;
+      if (is_array($value) && !empty($value['target_id'])) {
+        $value = $this->entityTypeManager->getStorage('asset')->load($value['target_id']);
       }
-      elseif (!empty($value['target_id'])) {
-        $entities[] = $this->entityTypeManager->getStorage('asset')->load($value['target_id']);
+      if ($value instanceof AssetInterface) {
+        $entities[] = $value;
       }
     }
     return $entities;

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -427,7 +427,6 @@ class Planting extends QuickFormBase {
     }
 
     // Get the crop/variety names.
-    /** @var \Drupal\taxonomy\TermInterface[] $crops */
     $crops = $form_state->getValue('crops') ?? [];
     $crop_names = [];
     foreach ($crops as $crop) {

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class LogCategorizeActionForm extends ConfirmFormBase {
 
   /**
-   * The tempstore factory.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -139,7 +139,7 @@ class LogCategorizeActionForm extends ConfirmFormBase {
 
     // Filter to active terms.
     $active_terms = array_filter($terms, function ($term) {
-      return (int) $term->get('status')->value;
+      return (bool) $term->get('status')->value;
     });
 
     // Build options with -- to represent hierarchies.

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -202,25 +202,24 @@ class LogCategorizeActionForm extends ConfirmFormBase {
     $total_count = 0;
     foreach ($accessible_entities as $entity) {
       /** @var \Drupal\Core\Field\EntityReferenceFieldItemList $category_field */
-      if ($category_field = $entity->get('category')) {
+      $category_field = $entity->get('category');
 
-        // Save existing values if appending.
-        $existing_values = [];
-        if ($form_state->getValue('operation') === 'append') {
-          $existing_values = array_column($category_field->getValue(), 'target_id');
-        }
-
-        // Empty the field.
-        $category_field->setValue([]);
-
-        $new_values = array_unique(array_merge($existing_values, $submitted_category_ids));
-        foreach ($new_values as $parent_id) {
-          $category_field->appendItem($parent_id);
-        }
-
-        $entity->save();
-        $total_count++;
+      // Save existing values if appending.
+      $existing_values = [];
+      if ($form_state->getValue('operation') === 'append') {
+        $existing_values = array_column($category_field->getValue(), 'target_id');
       }
+
+      // Empty the field.
+      $category_field->setValue([]);
+
+      $new_values = array_unique(array_merge($existing_values, $submitted_category_ids));
+      foreach ($new_values as $parent_id) {
+        $category_field->appendItem($parent_id);
+      }
+
+      $entity->save();
+      $total_count++;
     }
 
     // Add warning message for inaccessible entities.

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -122,7 +122,7 @@ class LogCategorizeActionForm extends ConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $this->entityType = $this->entityTypeManager->getDefinition('log');
-    $this->entities = $this->tempStore->get($this->user->id());
+    $this->entities = $this->tempStore->get((string) $this->user->id());
     if (!$this->entityType || empty($this->entities)) {
       // Ignore PHPstan error for incorrect return type.
       // Forms can return a RedirectResponse.

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -113,13 +113,6 @@ class LogCategorizeActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function getDescription() {
-    return '';
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getConfirmText() {
     return $this->t('Categorize');
   }
@@ -174,7 +167,13 @@ class LogCategorizeActionForm extends ConfirmFormBase {
       '#required' => TRUE,
     ];
 
-    return parent::buildForm($form, $form_state);
+    // Delegate to the parent method.
+    $form = parent::buildForm($form, $form_state);
+
+    // Remove form description text.
+    unset($form['description']);
+
+    return $form;
   }
 
   /**

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -123,7 +123,7 @@ class LogCategorizeActionForm extends ConfirmFormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $this->entityType = $this->entityTypeManager->getDefinition('log');
     $this->entities = $this->tempStore->get($this->user->id());
-    if (empty($this->entityType) || empty($this->entities)) {
+    if (!$this->entityType || empty($this->entities)) {
       // Ignore PHPstan error for incorrect return type.
       // Forms can return a RedirectResponse.
       // @phpstan-ignore return.type

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -120,13 +120,10 @@ class LogCategorizeActionForm extends ConfirmFormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state) {
+  public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
     $this->entityType = $this->entityTypeManager->getDefinition('log');
     $this->entities = $this->tempStore->get((string) $this->user->id());
     if (!$this->entityType || empty($this->entities)) {
-      // Ignore PHPstan error for incorrect return type.
-      // Forms can return a RedirectResponse.
-      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -124,6 +124,9 @@ class LogCategorizeActionForm extends ConfirmFormBase {
     $this->entityType = $this->entityTypeManager->getDefinition('log');
     $this->entities = $this->tempStore->get($this->user->id());
     if (empty($this->entityType) || empty($this->entities)) {
+      // Ignore PHPstan error for incorrect return type.
+      // Forms can return a RedirectResponse.
+      // @phpstan-ignore return.type
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
         ->toString());

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LogCategorize extends EntityActionBase {
 
   /**
-   * The tempstore object.
+   * The private temp store.
    *
-   * @var \Drupal\Core\TempStore\SharedTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $tempStore;
 

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -79,7 +79,7 @@ class LogCategorize extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id(), $entities);
+    $this->tempStore->set((string) $this->currentUser->id(), $entities);
   }
 
   /**


### PR DESCRIPTION
This PR builds off #906  adds fixes for PHPStan levels 3 and 4. Brief summary of what these level check for:

> 3. return types, types assigned to properties
> 4. basic dead code checking - always false instanceof and other type checks, dead else branches, unreachable code after return; etc.

Level 3 required minimal changes, the first ~15 commits.

Level 4 seemed a bit more daunting at first. But once I turned off [`treatPhpDocTypesAsCertain`](https://phpstan.org/config-reference#treatphpdoctypesascertain) there were way fewer errors. I'm not sure yet if we will want this on or off.