### PR TITLE
Build docker images with ubuntu-22.04

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -19,7 +19,9 @@ jobs:
 
   build:
     name: Build Docker images
-    runs-on: ubuntu-latest
+    # Pin to Ubuntu 22.04 to work around upstream issue with QEMU and binfmt.
+    # @see https://github.com/tonistiigi/binfmt/issues/215
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform:


### PR DESCRIPTION
This is a workaround for an upstream issue with QEMU and binfmt on 24.04 https://github.com/tonistiigi/binfmt/issues/215

This is probably the easiest way to get our tests passing again. We can revert once this fixed upstream