### PR TITLE
Allow modules to add base fields to default CSV importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add Equipment type field to Equipment assets #894](https://github.com/farmOS/farmOS/pull/894)
 - [Add support for geometry fields in CSV exports #884](https://github.com/farmOS/farmOS/pull/884)
 - [Allow modules to add base fields to farmOS Views #915](https://github.com/farmOS/farmOS/pull/915)
+- [Allow modules to add base fields to default CSV importers #916](https://github.com/farmOS/farmOS/pull/916)
 
 ### Changed
 

--- a/modules/core/import/modules/csv/farm_import_csv.api.php
+++ b/modules/core/import/modules/csv/farm_import_csv.api.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Hooks provided by farm_import_csv.
+ *
+ * This file contains no working PHP code; it exists to provide additional
+ * documentation for doxygen as well as to document hooks in the standard
+ * Drupal manner.
+ */
+
+declare(strict_types=1);
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Defines base fields that should be added to default CSV importers.
+ *
+ * @param string $entity_type
+ *   The entity type machine name.
+ *
+ * @return array
+ *   Returns an array of base field machine names for a given entity type.
+ */
+function hook_farm_import_csv_base_fields(string $entity_type) {
+  $base_fields = [];
+
+  // Add my base field to asset CSV importers.
+  if ($entity_type == 'asset') {
+    $base_fields[] = 'mybasefield';
+  }
+
+  return $base_fields;
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Drupal\farm_import_csv\Plugin\Derivative;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -35,13 +37,33 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
   protected $entityTypeManager;
 
   /**
+   * The entity field manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
+   * The module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
    * CsvImportMigration constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
+   *   The entity field manager service.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, ModuleHandlerInterface $module_handler) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -50,6 +72,8 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
   public static function create(ContainerInterface $container, $base_plugin_id) {
     return new static(
       $container->get('entity_type.manager'),
+      $container->get('entity_field.manager'),
+      $container->get('module_handler'),
     );
   }
 
@@ -123,6 +147,17 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
       // Alter column descriptions for this bundle.
       $this->alterColumnDescriptions($definition['third_party_settings']['farm_import_csv']['columns'], $bundle->id());
+
+      // Add column mapping and descriptions for base fields provided by other
+      // modules.
+      $base_fields = $this->moduleHandler->invokeAll('farm_import_csv_base_fields', [$this->entityType]);
+      foreach ($this->entityFieldManager->getBaseFieldDefinitions($this->entityType) as $field_definition) {
+        /** @var \Drupal\Core\Field\BaseFieldDefinition $field_definition */
+        if (!in_array($field_definition->getName(), $base_fields)) {
+          continue;
+        }
+        $this->addFieldMapping($field_definition, $definition['process'], $definition['third_party_settings']['farm_import_csv']['columns']);
+      }
 
       // If the entity type has a bundle_plugin manager, add column mappings
       // and descriptions for bundle fields.

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -6,8 +6,10 @@ namespace Drupal\farm_import_csv\Plugin\Derivative;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\entity\BundleFieldDefinition;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -127,7 +129,7 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
       if ($this->entityTypeManager->hasHandler($this->entityType, 'bundle_plugin')) {
         $bundle_fields = $this->entityTypeManager->getHandler($this->entityType, 'bundle_plugin')->getFieldDefinitions($bundle->id());
         foreach ($bundle_fields as $field_definition) {
-          $this->addBundleField($field_definition, $definition['process'], $definition['third_party_settings']['farm_import_csv']['columns']);
+          $this->addFieldMapping($field_definition, $definition['process'], $definition['third_party_settings']['farm_import_csv']['columns']);
         }
       }
 
@@ -142,16 +144,16 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
   }
 
   /**
-   * Adds bundle field mapping configuration for supported field types.
+   * Adds field mapping configuration for supported field types.
    *
-   * @param \Drupal\entity\BundleFieldDefinition $field_definition
+   * @param \Drupal\Core\Field\BaseFieldDefinition|\Drupal\entity\BundleFieldDefinition $field_definition
    *   The field definition.
    * @param array &$mapping
    *   The migration process mapping.
    * @param array &$columns
    *   The column descriptions from third-party settings.
    */
-  protected function addBundleField($field_definition, &$mapping, &$columns): void {
+  protected function addFieldMapping(BaseFieldDefinition|BundleFieldDefinition $field_definition, array &$mapping, array &$columns): void {
 
     // This only supports certain field types.
     $supported_field_types = [

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/harvests.csv
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/harvests.csv
@@ -1,4 +1,4 @@
-timestamp,name,assets,locations,quantity,quantity units,quantity measure,quantity label,notes,categories,status
-2023-07-15,Harvest garlic,Garlic,Field A,200,bulbs,count,total,Great big bulbs,Category 1,done
-2023-08-15,Harvest potatoes,"Potatoes 1,1234","Field B,Field C",80,lbs,weight,,Heavy harvest,"Category 1, Category 2",
-2023-09-15,Harvest onions,,,,lbs,weight,,Small bulbs from weed pressure,,pending
+timestamp,name,assets,locations,quantity,quantity units,quantity measure,quantity label,notes,categories,status,test string
+2023-07-15,Harvest garlic,Garlic,Field A,200,bulbs,count,total,Great big bulbs,Category 1,done,foo
+2023-08-15,Harvest potatoes,"Potatoes 1,1234","Field B,Field C",80,lbs,weight,,Heavy harvest,"Category 1, Category 2",,bar
+2023-09-15,Harvest onions,,,,lbs,weight,,Small bulbs from weed pressure,,pending,baz

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/farm_import_csv_test.module
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/farm_import_csv_test.module
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @file
+ * Contains farm_import_csv_test.module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Entity\EntityTypeInterface;
+
+/**
+ * Implements hook_entity_base_field_info().
+ */
+function farm_import_csv_test_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+
+  // Add a test string base field to logs.
+  if ($entity_type->id() == 'log') {
+    $options = [
+      'type' => 'string',
+      'label' => t('Test string'),
+    ];
+    $fields['test_string'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
+  }
+
+  return $fields;
+}
+
+/**
+ * Implements hook_farm_import_csv_base_fields().
+ */
+function farm_import_csv_test_farm_import_csv_base_fields(string $entity_type) {
+  $base_fields = [];
+
+  // Add test string base field to log CSV importers.
+  if ($entity_type == 'log') {
+    $base_fields[] = 'test_string';
+  }
+
+  return $base_fields;
+}

--- a/modules/core/import/modules/csv/tests/src/Kernel/LogCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/LogCsvImportTest.php
@@ -114,6 +114,7 @@ class LogCsvImportTest extends CsvImportTestBase {
           'Category 1',
         ],
         'status' => 'done',
+        'test_string' => 'foo',
       ],
       2 => [
         'name' => 'Harvest potatoes',
@@ -138,6 +139,7 @@ class LogCsvImportTest extends CsvImportTestBase {
           'Category 2',
         ],
         'status' => 'done',
+        'test_string' => 'bar',
       ],
       3 => [
         'name' => 'Harvest onions',
@@ -153,6 +155,7 @@ class LogCsvImportTest extends CsvImportTestBase {
         'notes' => 'Small bulbs from weed pressure',
         'categories' => [],
         'status' => 'pending',
+        'test_string' => 'baz',
       ],
     ];
     foreach ($logs as $id => $log) {
@@ -182,6 +185,7 @@ class LogCsvImportTest extends CsvImportTestBase {
         }
       }
       $this->assertEquals($expected_values[$id]['status'], $log->get('status')->value);
+      $this->assertEquals($expected_values[$id]['test_string'], $log->get('test_string')->value);
       $this->assertEquals('Imported via CSV.', $log->getRevisionLogMessage());
     }
 


### PR DESCRIPTION
This adds a new `hook_farm_import_csv_base_fields()` hook to the `farm_import_csv` module, which allows modules to return a list of base field machine IDs that should be included in default CSV importers.

This will also enable the https://github.com/farmOS/farmOS/pull/849 PR to add the  `farm` base field to asset CSV importers.

This takes the same approach as #915. It is not technically dependent on it, but I have based the branch off of it (so it includes all of that PR's commits as well), because I will be opening two more PRs that build on both.