### PR TITLE
Add support for boolean fields in CsvImportMigrationBase::addFieldMapping()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Add support for geometry fields in CSV exports #884](https://github.com/farmOS/farmOS/pull/884)
 - [Allow modules to add base fields to farmOS Views #915](https://github.com/farmOS/farmOS/pull/915)
 - [Allow modules to add base fields to default CSV importers #916](https://github.com/farmOS/farmOS/pull/916)
+- [Add support for boolean fields in CsvImportMigrationBase::addFieldMapping() #917](https://github.com/farmOS/farmOS/pull/917)
 
 ### Changed
 

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -196,6 +196,7 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
       'list_string',
       'string',
       'timestamp',
+      'boolean',
     ];
     if (!in_array($field_definition->getType(), $supported_field_types)) {
       return;
@@ -288,6 +289,18 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
         // Describe allowed values.
         $description[] = $this->t('Accepts most date/time formats.');
+        break;
+
+      // Boolean.
+      case 'boolean':
+
+        // Parse with the boolean plugin.
+        $process[] = [
+          'plugin' => 'boolean',
+        ];
+
+        // Describe allowed values.
+        $description[] = $this->t('Accepts most boolean values.');
         break;
     }
 


### PR DESCRIPTION
This adds support for boolean field types in `CsvImportMigrationBase::addFieldMapping()`, which is the method used to dynmically add base and bundle fields to the default farmOS CSV importers. This means that bundle fields of type `boolean` will be automatically added, and base fields can be added by implementing `hook_farm_import_csv_base_fields()` (added in #916).

This PR builds on top of #916, so it includes all of that PR's commits as well. This PR is technically only one commit.