### PR TITLE
Add group and is_group_assignment base fields to log CSV importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Allow modules to add base fields to farmOS Views #915](https://github.com/farmOS/farmOS/pull/915)
 - [Allow modules to add base fields to default CSV importers #916](https://github.com/farmOS/farmOS/pull/916)
 - [Add support for boolean fields in CsvImportMigrationBase::addFieldMapping() #917](https://github.com/farmOS/farmOS/pull/917)
+- [Add group and is_group_assignment base fields to log CSV importers #919](https://github.com/farmOS/farmOS/pull/919)
 
 ### Changed
 

--- a/modules/asset/group/farm_group.module
+++ b/modules/asset/group/farm_group.module
@@ -43,6 +43,21 @@ function farm_group_entity_base_field_info_alter(&$fields, EntityTypeInterface $
 }
 
 /**
+ * Implements hook_farm_import_csv_base_fields().
+ */
+function farm_group_farm_import_csv_base_fields(string $entity_type) {
+  $base_fields = [];
+
+  // Add group and is_group_assignment base fields to log CSV importers.
+  if ($entity_type == 'log') {
+    $base_fields[] = 'group';
+    $base_fields[] = 'is_group_assignment';
+  }
+
+  return $base_fields;
+}
+
+/**
  * Implements hook_farm_ui_views_base_fields().
  */
 function farm_group_farm_ui_views_base_fields(string $entity_type) {


### PR DESCRIPTION
This leverages the new hook provided by #916 to add the `group` and `is_group_assignment` base fields to default log CSV importers in farmOS.

Note that this is only a single commit, but is part of a larger branch that has been split into multiple PRs, so it includes all the commits from #915, #916, #917, and #918.