### PR TITLE
Update oauth2 static scopes for pluggable granularity

### DIFF
--- a/modules/core/api/tests/modules/farm_api_test/farm_api_test.oauth2_scopes.yml
+++ b/modules/core/api/tests/modules/farm_api_test/farm_api_test.oauth2_scopes.yml
@@ -8,5 +8,6 @@ test:password:
     password:
       status: true
       description: 'Password grant'
-  granularity: 'permission'
-  permission: 'access content'
+  granularity_id: 'permission'
+  granularity_configuration:
+    permission: 'access content'

--- a/modules/core/role/modules/roles/farm_role_roles.oauth2_scopes.yml
+++ b/modules/core/role/modules/roles/farm_role_roles.oauth2_scopes.yml
@@ -8,8 +8,9 @@ farm_manager:
       status: true
     refresh_token:
       status: true
-  granularity: 'role'
-  role: 'farm_manager'
+  granularity_id: 'role'
+  granularity_configuration:
+    role: 'farm_manager'
 farm_worker:
   description: 'Grants access to the Farm Worker role.'
   umbrella: false
@@ -20,8 +21,9 @@ farm_worker:
       status: true
     refresh_token:
       status: true
-  granularity: 'role'
-  role: 'farm_worker'
+  granularity_id: 'role'
+  granularity_configuration:
+    role: 'farm_worker'
 farm_viewer:
   description: 'Grants access to the Farm Viewer role.'
   umbrella: false
@@ -32,5 +34,6 @@ farm_viewer:
       status: true
     refresh_token:
       status: true
-  granularity: 'role'
-  role: 'farm_viewer'
+  granularity_id: 'role'
+  granularity_configuration:
+    role: 'farm_viewer'


### PR DESCRIPTION
The next release of simple_oauth will have support for pluggable granularity on oauth2 scopes: https://www.drupal.org/node/3492888

We provide some static oauth2 scopes and need to update them to use `granularity_id` and `granularity_configuration`. This old `granularity` property is deprecated until v7 but we might as well fix it now: https://git.drupalcode.org/project/simple_oauth/-/blob/3ab9ede24b45016d9059877c3a901150309588a6/modules/simple_oauth_static_scope/src/Plugin/Oauth2ScopeManager.php#L126

These changes have already been committed to simple_oauth 6.0.x so I added a temp commit to unpin the dependency for our testing in the meantime.