### PR TITLE
Disable fail-fast strategy for automated tests

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -120,6 +120,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     strategy:
+      fail-fast: false
       matrix:
         dbms:
          - pgsql


### PR DESCRIPTION
Currently if any job in the `test` job matrix fails, other in-progress and queued jobs in the matrix are cancelled. This PR changes that behavior to disable the [`fail-fast`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) strategy and let all `test` matrix jobs run, even if one failed. This does not cause the `test` job itself to pass in the event any one job fails.

The current behavior is frustrating when actively "debugging" some changes and the tests against one DB randomly fail, causing you to manually restart jobs to see test results again. We should still re-run the tests to make sure they pass on all DBs, but this will save time when debugging and chasing errors.

I've also been experiencing an issue lately where PHPUnit errors thrown in Browser test cases (specifically those searching for html/text on the page, I think?) crash with a generic error when run with `paratest`. But these same errors return the standard test report w/ useful info when run with `phpunit`, which we currently only run in our `sqlite` matrix dbms case. As a result I have been turning off all `test` jobs except for `sqlite` in my draft PRs. Turning off `fail-fast` will help when debugging these situation as well.