### PR TITLE
Pin PHP version to 8.3 in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Pin PHP version to 8.3 in Dockerfile #923](https://github.com/farmOS/farmOS/pull/923)
+
 ### Deprecated
 
 - [Issue #3498064: Deprecate d7_plan plugin](https://www.drupal.org/project/farm/issues/3498064)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Alias the Drupal base image for use in other build stages.
 # We do this so that the Drupal image version only needs to be updated here.
-FROM drupal:10.4 as baseimage
+FROM drupal:10.4-php8.3 as baseimage
 
 # Define common paths.
 # BUILD_PATH is where the farmOS codebase will be built.


### PR DESCRIPTION
This PR pins the PHP version in the official farmOS Docker images to 8.3. This will allow us to be more intentional about updating the PHP version moving forward.