### PR TITLE
Add farmOS-map snapshot behavior

### DIFF
--- a/modules/core/map/js/farm_map.js
+++ b/modules/core/map/js/farm_map.js
@@ -38,6 +38,9 @@
       };
       const instance = farmOS.map.create(element, mapOptions);
 
+      // Enable the snapshot behavior.
+      instance.addBehavior("snapshot");
+
       // Expose settings on the instance so other behaviors don't need to know how to look them up in drupalSettings
       instance.farmMapSettings = drupalSettings.farm_map[drupalSettingsKey] || {};
 


### PR DESCRIPTION
This is dependent on this PR being included in a new release of farmOS-map: https://github.com/farmOS/farmOS-map/pull/202 but opening a PR to start reviewing the integration of that change here...

I think we have two options:

1. Enable the new Snapshot behavior on all farmOS-map instances (very simple)
2. Make it a configurable option site-wide in farmOS, doing so would make it possible to turn it on/off, but would affect all users. A little more work, but something we already do, so it's not introducing much more complexity for us to maintain.

Thoughts? @mstenta @symbioquine @Farmer-Eds-Shed @Fosten 

In this PR I have implemented option 1. I think there is minimal impact/clutter and little issue to add this to all maps.