### PR TITLE
Delete associated plan_record entities when a plan is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Pin PHP version to 8.3 in Dockerfile #923](https://github.com/farmOS/farmOS/pull/923)
 - [Update farmOS-map to 2.4.0 #926](https://github.com/farmOS/farmOS/pull/926)
+- [Delete associated plan_record entities when a plan is deleted #928](https://github.com/farmOS/farmOS/pull/928)
 
 ### Deprecated
 

--- a/modules/core/plan/plan.module
+++ b/modules/core/plan/plan.module
@@ -33,9 +33,14 @@ function plan_help($route_name, RouteMatchInterface $route_match) {
 function plan_plan_delete(EntityInterface $entity) {
 
   // Delete all plan_record entities associated with the plan.
-  $plan_records = \Drupal::entityTypeManager()->getStorage('plan_record')->loadByProperties(['plan' => $entity->id()]);
-  foreach ($plan_records as $plan_record) {
-    $plan_record->delete();
+  $plan_record_storage = \Drupal::entityTypeManager()->getStorage('plan_record');
+  $plan_ids = $plan_record_storage->getQuery()
+    ->condition('plan', $entity->id())
+    ->accessCheck(FALSE)
+    ->execute();
+  foreach ($plan_ids as $id) {
+    $plan_record = $plan_record_storage->load($id);
+    $plan_record?->delete();
   }
 }
 

--- a/modules/core/plan/plan.module
+++ b/modules/core/plan/plan.module
@@ -38,9 +38,12 @@ function plan_plan_delete(EntityInterface $entity) {
     ->condition('plan', $entity->id())
     ->accessCheck(FALSE)
     ->execute();
-  foreach ($plan_ids as $id) {
-    $plan_record = $plan_record_storage->load($id);
-    $plan_record?->delete();
+  if (!is_array($plan_ids) || count($plan_ids) < 1) {
+    return;
+  }
+  foreach (array_chunk($plan_ids, 100) as $chunk) {
+    $plan_records = $plan_record_storage->loadMultiple($chunk);
+    $plan_record_storage->delete($plan_records);
   }
 }
 

--- a/modules/core/plan/plan.module
+++ b/modules/core/plan/plan.module
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Routing\RouteMatchInterface;
 
@@ -24,6 +25,18 @@ function plan_help($route_name, RouteMatchInterface $route_match) {
   }
 
   return $output;
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ */
+function plan_plan_delete(EntityInterface $entity) {
+
+  // Delete all plan_record entities associated with the plan.
+  $plan_records = \Drupal::entityTypeManager()->getStorage('plan_record')->loadByProperties(['plan' => $entity->id()]);
+  foreach ($plan_records as $plan_record) {
+    $plan_record->delete();
+  }
 }
 
 /**

--- a/modules/core/plan/tests/modules/plan_test/config/install/plan.record.type.default.yml
+++ b/modules/core/plan/tests/modules/plan_test/config/install/plan.record.type.default.yml
@@ -1,0 +1,4 @@
+id: default
+label: default
+description: 'Test plan_record type'
+langcode: en

--- a/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
+++ b/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\plan\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\plan\Entity\Plan;
+use Drupal\plan\Entity\PlanRecord;
+
+/**
+ * Tests for plan_record entities.
+ *
+ * @group farm
+ */
+class PlanRecordTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'plan',
+    'plan_test',
+    'user',
+    'state_machine',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('plan');
+    $this->installEntitySchema('plan_record');
+    $this->installConfig(['plan_test']);
+  }
+
+  /**
+   * Test plan_record entities.
+   */
+  public function testPlanRecord() {
+
+    // Get storage for plan and plan_record entities.
+    $plan_storage = \Drupal::entityTypeManager()->getStorage('plan');
+    $plan_record_storage = \Drupal::entityTypeManager()->getStorage('plan_record');
+
+    // Create a plan entity.
+    $plan = Plan::create([
+      'name' => 'Test plan',
+      'type' => 'default',
+    ]);
+    $plan->save();
+
+    // Confirm that the plan entity was created.
+    $plans = $plan_storage->loadMultiple();
+    $this->assertCount(1, $plans);
+
+    // Create two plan_record entities that reference the plan.
+    $plan_record1 = PlanRecord::create([
+      'plan' => $plan,
+      'type' => 'default',
+    ]);
+    $plan_record1->save();
+    $plan_record2 = PlanRecord::create([
+      'plan' => $plan,
+      'type' => 'default',
+    ]);
+    $plan_record2->save();
+
+    // Confirm that the plan_record entities were created.
+    $plan_records = $plan_record_storage->loadMultiple();
+    $this->assertCount(2, $plan_records);
+
+    // Delete the plan.
+    $plan->delete();
+
+    // Confirm that the plan and plan_record entities were all deleted.
+    $plans = $plan_storage->loadMultiple();
+    $this->assertCount(0, $plans);
+    $plan_records = $plan_record_storage->loadMultiple();
+    $this->assertCount(0, $plan_records);
+  }
+
+}


### PR DESCRIPTION
This adds some logic to the `plan` module to automatically delete `plan_record` entities that are associated with a `plan` entity when the plan is deleted.

As of right now it's possible to delete a plan without cleaning up the `plan_record` entities (and there is no UI for deleting `plan_record` entities), resulting in orphaned records in the database.

More context/discussion: https://farmos.discourse.group/t/module-beta-release-guidance-and-best-practices/2219/12