### PR TITLE
Cast processed text exported to CSV as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Issue #3511488: Refreshed access_token is missing scope with league/oauth2-server ^9](https://www.drupal.org/project/simple_oauth_password_grant/issues/3511488)
+- [Cast processed text exported to CSV as a string #931](https://github.com/farmOS/farmOS/pull/931)
 
 ## [3.4.1] 2025-02-19
 

--- a/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
@@ -27,7 +27,9 @@ class TextLongFieldItemNormalizer extends FieldItemNormalizer {
     // accordingly.
     if (isset($context['processed_text'])) {
       if ($context['processed_text']) {
-        return $field_item->get('processed')->getValue();
+        /** @var \Drupal\filter\Render\FilteredMarkup $processed_text */
+        $processed_text = $field_item->get('processed')->getValue();
+        return (string) $processed_text;
       }
       else {
         return $field_item->get('value')->getValue();


### PR DESCRIPTION
This fixes the following error that occurs when "Export processed text" is selected from the CSV export action:

`Uncaught PHP Exception TypeError: "Drupal\farm_csv\Normalizer\TextLongFieldItemNormalizer::normalize(): Return value must be of type ArrayObject|array|string|int|float|bool|null, Drupal\filter\Render\FilteredMarkup returned" at /opt/repos/farmOS/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php line 32`

This started happening when strict typing was enabled in #902.

I noticed it in Farmier logs.