### PR TITLE
Fix TypeError on invalid /asset/%asset_id/assets path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Issue #3511488: Refreshed access_token is missing scope with league/oauth2-server ^9](https://www.drupal.org/project/simple_oauth_password_grant/issues/3511488)
 - [Cast processed text exported to CSV as a string #931](https://github.com/farmOS/farmOS/pull/931)
+- [Fix TypeError on invalid /asset/%asset_id/assets path #932](https://github.com/farmOS/farmOS/pull/932)
 
 ## [3.4.1] 2025-02-19
 

--- a/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
@@ -50,10 +50,10 @@ class FarmLocationAssetViewsAccessCheck implements AccessInterface {
    */
   public function access(RouteMatchInterface $route_match) {
 
-    // If there is no "asset" parameter, bail.
+    // If there is no integer "asset" parameter, deny access.
     $asset_id = $route_match->getParameter('asset');
-    if (empty($asset_id)) {
-      return AccessResult::allowed();
+    if (empty($asset_id) || !is_int($asset_id)) {
+      return AccessResult::forbidden();
     }
 
     // Allow access if the asset is a location.


### PR DESCRIPTION
Fix `TypeError: "Drupal\farm_location\AssetLocation::isLocation(): Argument #1 ($asset) must be of type Drupal\asset\Entity\AssetInterface, null given`

This happens if you try to visit /asset/%asset_id/assets with a non-numeric %asset_id.

This appeared in Farmier logs. It's a pretty obscure bug because it requires a user to manually type in an invalid URL, but no harm in making our logic a bit more defensive to prevent fatal errors.

Notably, this also changes the return from `AccessResult::allowed()` to `AccessResult::forbidden()`. I'm not sure why it was originally defaulting to an "allowed" return. That doesn't make much sense. I wrote the logic in 2021, so I take the blame. :-)