### PR TITLE
Restore missing transplant_days field on plant_type terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Issue #3511488: Refreshed access_token is missing scope with league/oauth2-server ^9](https://www.drupal.org/project/simple_oauth_password_grant/issues/3511488)
 - [Cast processed text exported to CSV as a string #931](https://github.com/farmOS/farmOS/pull/931)
 - [Fix TypeError on invalid /asset/%asset_id/assets path #932](https://github.com/farmOS/farmOS/pull/932)
+- [Restore missing transplant_days field on plant_type terms #935](https://github.com/farmOS/farmOS/pull/935)
 
 ## [3.4.1] 2025-02-19
 

--- a/modules/log/transplanting/farm_transplanting.post_update.php
+++ b/modules/log/transplanting/farm_transplanting.post_update.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the farm_transplanting module.
+ */
+
+declare(strict_types=1);
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
+/**
+ * Restore missing transplant_days field.
+ */
+function farm_transplanting_post_update_restore_transplant_days() {
+
+  // A previous update hook in the farm_plant_type module moved the field to
+  // this module, but the update logic was flawed and caused the field to be
+  // deleted in some cases. We only proceed if that update hook ran.
+  $update_list = \Drupal::keyValue('post_update')->get('existing_updates');
+  if (!in_array('farm_plant_type_post_update_move_transplant_days', $update_list)) {
+    return;
+  }
+
+  // Install the transplant_days field storage config and field config if they
+  // do not exist.
+  if (is_null(FieldStorageConfig::load('taxonomy_term.transplant_days'))) {
+    $field_storage = FieldStorageConfig::create([
+      'id' => 'taxonomy_term.transplant_days',
+      'field_name' => 'transplant_days',
+      'entity_type' => 'taxonomy_term',
+      'type' => 'integer',
+      'settings' => [
+        'unsigned' => TRUE,
+        'size' => 'normal',
+      ],
+      'module' => 'core',
+      'locked' => FALSE,
+      'cardinality' => 1,
+      'indexes' => [],
+      'persist_with_no_fields' => FALSE,
+      'custom_storage' => FALSE,
+      'dependencies' => [
+        'enforced' => [
+          'module' => [
+            'farm_transplanting',
+          ],
+        ],
+        'module' => [
+          'taxonomy',
+        ],
+      ],
+    ]);
+    $field_storage->save();
+  }
+  if (is_null(FieldConfig::load('taxonomy_term.plant_type.transplant_days'))) {
+    $field = FieldConfig::create([
+      'id' => 'taxonomy_term.plant_type.transplant_days',
+      'field_name' => 'transplant_days',
+      'entity_type' => 'taxonomy_term',
+      'bundle' => 'plant_type',
+      'label' => 'Days to transplant',
+      'description' => '',
+      'required' => FALSE,
+      'default_value' => [],
+      'default_value_callback' => '',
+      'settings' => [
+        'min' => 1,
+        'max' => NULL,
+        'prefix' => '',
+        'suffix' => ' day| days',
+      ],
+      'field_type' => 'integer',
+      'dependencies' => [
+        'enforced' => [
+          'module' => [
+            'farm_transplanting',
+          ],
+        ],
+        'module' => [
+          'taxonomy',
+        ],
+      ],
+    ]);
+    $field->save();
+  }
+}

--- a/modules/taxonomy/plant_type/farm_plant_type.post_update.php
+++ b/modules/taxonomy/plant_type/farm_plant_type.post_update.php
@@ -125,19 +125,24 @@ function farm_plant_type_post_update_move_transplant_days() {
 
   // The transplant_days field was previously part of this module. It has moved
   // to the farm_transplanting module, so that it is only made available in
-  // instances that deal with transplants. If there is transplant_days data in
-  // the database, but the farm_transplant module is not installed, we should
-  // install it so that module can be responsible for the data moving forward.
-  $data_count = \Drupal::database()->query('SELECT COUNT(*) FROM {taxonomy_term__transplant_days}')->fetchField();
-  if (!empty($data_count)) {
-    if (!\Drupal::service('module_handler')->moduleExists('farm_transplanting')) {
-      \Drupal::configFactory()->getEditable('field.field.taxonomy_term.plant_type.transplant_days')->delete();
-      \Drupal::configFactory()->getEditable('field.storage.taxonomy_term.transplant_days')->delete();
-      \Drupal::service('module_installer')->install(['farm_transplanting']);
-    }
+  // instances that deal with transplants. This update hook helps hand off the
+  // responsibility of the field to farm_transplanting. If the module is already
+  // installed, we don't do need to do anything.
+  if (\Drupal::service('module_handler')->moduleExists('farm_transplanting')) {
+    return;
   }
 
-  // Otherwise, we can delete the transplant_days field.
+  // If there is transplant_days data in the database, install the
+  // farm_transplanting module so that it can be responsible for the data moving
+  // forward.
+  $data_count = \Drupal::database()->query('SELECT COUNT(*) FROM {taxonomy_term__transplant_days}')->fetchField();
+  if (!empty($data_count)) {
+    \Drupal::configFactory()->getEditable('field.field.taxonomy_term.plant_type.transplant_days')->delete();
+    \Drupal::configFactory()->getEditable('field.storage.taxonomy_term.transplant_days')->delete();
+    \Drupal::service('module_installer')->install(['farm_transplanting']);
+  }
+
+  // Otherwise, if there is no data, we can delete the transplant_days field.
   // Using FieldConfig::load() and FieldStorageConfig::load() and their
   // associated delete() methods will delete the config and database tables.
   else {


### PR DESCRIPTION
I discovered a nasty bug with the update hook that was added in #795, which resulted in the `transplant_days` field being deleted from `plant_type` terms in some cases. As far as I can tell no data was lost. More details below. This PR fixes the original update hook, and adds a new one to restore the deleted field, if necessary.

Original issue:

The update hook that was added in #795 had a flaw in its logic. Here is the current code, for reference:

https://github.com/farmOS/farmOS/blob/a192967c8d847a9b171892bd2d93c3c13565e029/modules/taxonomy/plant_type/farm_plant_type.post_update.php#L121-L153

The intention of that update hook was to check if any `transplant_days` data was present in the database, and whether or not the `farm_transplant` module was installed, and either delete the field or install the module and hand off responsibility of the field data to it accordingly.

The issue occurred when there was no `transplant_days` data, but the `farm_transplant` module was installed. In that case, the `else` condition ended up running, which deleted the `transplant_days` field when it shouldn't have.

To fix the original update hook (in case anyone hasn't updated their farmOS yet and hasn't run it yet), I moved the "is `farm_transplant` module installed" check to the top of the function, so the logic only runs if the module is NOT installed. Then, if data exists, it gets installed. If data doesn't exist, the field is deleted.

This PR adds a new update hook to the `farm_transplant` module which aims to restore the deleted field. It only does this if a) the `farm_plant_type_post_update_move_transplant_days()` update hook has already run, and b) if the `transplant_days` field is missing. This ensures that it only runs if necessary.