### PR TITLE
Fix Warning: Undefined array keys in hook_views_pre_render()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix Warning: Undefined array keys in hook_views_pre_render() #937](https://github.com/farmOS/farmOS/pull/937)
+
 ## [3.4.3] 2025-03-20
 
 ### Security

--- a/modules/asset/land/farm_land.views_execution.inc
+++ b/modules/asset/land/farm_land.views_execution.inc
@@ -32,8 +32,10 @@ function farm_land_views_pre_render(ViewExecutable $view) {
 
     // If the land type exposed filter is already in use remove land types
     // that are not specified by the filter value.
-    $land_type_filters = (array) $exposed_filters['land_type_value'];
-    $land_types = array_intersect_key($land_types, $land_type_filters);
+    if (isset($exposed_filters['land_type_value'])) {
+      $land_type_filters = (array) $exposed_filters['land_type_value'];
+      $land_types = array_intersect_key($land_types, $land_type_filters);
+    }
 
     // Create a layer for each land type.
     $asset_layers = [];

--- a/modules/asset/structure/farm_structure.views_execution.inc
+++ b/modules/asset/structure/farm_structure.views_execution.inc
@@ -32,8 +32,10 @@ function farm_structure_views_pre_render(ViewExecutable $view) {
 
     // If the structure type exposed filter is already in use remove structure
     // types that are not specified in the filter value.
-    $structure_type_filters = (array) $exposed_filters['structure_type_value'];
-    $structure_types = array_intersect_key($structure_types, $structure_type_filters);
+    if (isset($exposed_filters['structure_type_value'])) {
+      $structure_type_filters = (array) $exposed_filters['structure_type_value'];
+      $structure_types = array_intersect_key($structure_types, $structure_type_filters);
+    }
 
     // Create a layer for each structure type.
     $asset_layers = [];


### PR DESCRIPTION
This fixes a PHP warning that occurs when you visit `/assets/land` or `/assets/structure`:

`Warning: Undefined array key "land_type_value" in farm_land_views_pre_render() (line 35 of /opt/repos/farmOS/modules/asset/land/farm_land.views_execution.inc) `

or

`Warning: Undefined array key "structure_type_value" in farm_structure_views_pre_render() (line 35 of /opt/repos/farmOS/modules/asset/structure/farm_structure.views_execution.inc) `

This is happening because `$exposed_filters` is an empty array by default, so the `land_type_value` / `structure_type_value` key doesn't exist. Here are the lines that throw the warning:

https://github.com/farmOS/farmOS/blob/ac24d086fd424e557e18c63483379a7b8db71792/modules/asset/land/farm_land.views_execution.inc#L35

https://github.com/farmOS/farmOS/blob/ac24d086fd424e557e18c63483379a7b8db71792/modules/asset/structure/farm_structure.views_execution.inc#L35