### PR TITLE
Fix TypeError: CircularAssetLocationConstraintValidator::getAssetsByLocationRecursively(): Argument #2 ($timestamp) must be of type int, string given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix Warning: Undefined array keys in hook_views_pre_render() #937](https://github.com/farmOS/farmOS/pull/937)
+- [Fix TypeError: CircularAssetLocationConstraintValidator::getAssetsByLocationRecursively(): Argument #2 ($timestamp) must be of type int, string given #938](https://github.com/farmOS/farmOS/pull/938)
 
 ## [3.4.3] 2025-03-20
 

--- a/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
+++ b/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
@@ -66,7 +66,7 @@ class CircularAssetLocationConstraintValidator extends ConstraintValidator imple
     }
 
     // Get the log's timestamp.
-    $timestamp = $log->get('timestamp')->value;
+    $timestamp = (int) $log->get('timestamp')->value;
 
     // Iterate through referenced entities.
     foreach ($value->referencedEntities() as $delta => $asset) {


### PR DESCRIPTION
Saw this error in Farmier logs:

`TypeError: Drupal\farm_location\Plugin\Validation\Constraint\CircularAssetLocationConstraintValidator::getAssetsByLocationRecursively(): Argument #2 ($timestamp) must be of type int, string given, called in /opt/drupal/web/profiles/farm/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php on line 77 in Drupal\farm_location\Plugin\Validation\Constraint\CircularAssetLocationConstraintValidator->getAssetsByLocationRecursively() (line 120 of /opt/drupal/web/profiles/farm/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php).`

We should be casting the log timestamp to an integer before passing it to `CircularAssetLocationConstraintValidator::getAssetsByLocationRecursively()`.