### PR TITLE
Install and configure ImageMagick

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "drupal/fraction": "^3.0",
         "drupal/geofield": "^1.40",
         "drupal/gin": "4.0.6",
+        "drupal/imagick": "^1.12",
         "drupal/inline_entity_form": "^1.0@RC",
         "drupal/inspire_tree": "^1.0",
         "drupal/jsonapi_extras": "^3.22",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update && apt-get install -y \
     postgresql-client \
     # Install libgeos-c1v5 so geos php extension can use libgeos_c.so.1.
     libgeos-c1v5 \
+    # Install libmagickwand-dev for ImageMagick. \
+    libmagickwand-dev \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 
@@ -36,6 +38,17 @@ RUN apt-get update && apt-get install -y libgeos-dev \
   && ( tar xzf /opt/php-geos.tar.gz -C /opt/ \
     && cd /opt/php-geos-${PHP_GEOS_VERSION} \
     && ./autogen.sh \
+    && ./configure \
+    && make \
+    && make install \
+    )
+
+# Build and install the ImageMagick PHP extension.
+ARG IMAGICK_VERSION=52ec37ff633de0e5cca159a6437b8c340afe7831
+ADD https://github.com/Imagick/imagick/archive/${IMAGICK_VERSION}.tar.gz /opt/php-imagick.tar.gz
+RUN ( tar xzf /opt/php-imagick.tar.gz -C /opt/ \
+    && cd /opt/imagick-${IMAGICK_VERSION} \
+    && phpize \
     && ./configure \
     && make \
     && make install \
@@ -59,7 +72,7 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf
 
 # Enable PHP dependencies.
 COPY --from=php-dependencies /usr/local/lib/php/extensions/ /usr/local/lib/php/extensions/
-RUN docker-php-ext-enable bcmath exif geos
+RUN docker-php-ext-enable bcmath exif geos imagick
 
 # Add custom PHP configurations.
 COPY conf.d/ /usr/local/etc/php/conf.d

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,6 +13,17 @@ FROM drupal:10.4-php8.3 AS baseimage
 ENV BUILD_PATH=/var/farmOS
 ENV DRUPAL_PATH=/opt/drupal
 
+# Install apt dependencies.
+RUN apt-get update && apt-get install -y \
+    # Install git and unzip (needed by Composer).
+    git unzip \
+    # Install postgresql-client so Drush can connect to the database.
+    postgresql-client \
+    # Install libgeos-c1v5 so geos php extension can use libgeos_c.so.1.
+    libgeos-c1v5 \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
+
 ##
 # Build/install PHP extensions.
 FROM baseimage AS php-dependencies
@@ -52,17 +63,6 @@ RUN docker-php-ext-enable bcmath exif geos
 
 # Add custom PHP configurations.
 COPY conf.d/ /usr/local/etc/php/conf.d
-
-# Install apt dependencies.
-RUN apt-get update && apt-get install -y \
-    # Install git and unzip (needed by Composer).
-    git unzip \
-    # Install postgresql-client so Drush can connect to the database.
-    postgresql-client \
-    # Install libgeos-c1v5 so geos php extension can use libgeos_c.so.1.
-    libgeos-c1v5 \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean
 
 # Set the COMPOSER_MEMORY_LIMIT environment variable to unlimited.
 ENV COMPOSER_MEMORY_LIMIT=-1

--- a/modules/core/image/farm_image.install
+++ b/modules/core/image/farm_image.install
@@ -14,6 +14,13 @@ use Drupal\image\Entity\ImageStyle;
  */
 function farm_image_install() {
 
+  // Install the imagick module if the PHP extension is available.
+  if (extension_loaded('imagick')) {
+    if (!\Drupal::service('module_handler')->moduleExists('imagick')) {
+      \Drupal::service('module_installer')->install(['imagick']);
+    }
+  }
+
   // Add auto-orient effect to Drupal core image styles.
   $styles = [
     'large',

--- a/modules/core/image/farm_image.install
+++ b/modules/core/image/farm_image.install
@@ -22,6 +22,11 @@ function farm_image_install() {
       \Drupal::service('module_installer')->install(['imagick']);
     }
 
+    // Make imagick the default image toolkit.
+    $config = \Drupal::configFactory()->getEditable('system.image');
+    $config->set('toolkit', 'imagick');
+    $config->save();
+
     // Configure imagick to disable strip_metadata.
     // This ensures that EXIF data is preserved in derivative images, which
     // allows browsers to auto-orient them if they have Orientation data.

--- a/modules/core/image/farm_image.install
+++ b/modules/core/image/farm_image.install
@@ -14,11 +14,20 @@ use Drupal\image\Entity\ImageStyle;
  */
 function farm_image_install() {
 
-  // Install the imagick module if the PHP extension is available.
+  // If the imagick PHP extension is available...
   if (extension_loaded('imagick')) {
+
+    // Install the imagick module.
     if (!\Drupal::service('module_handler')->moduleExists('imagick')) {
       \Drupal::service('module_installer')->install(['imagick']);
     }
+
+    // Configure imagick to disable strip_metadata.
+    // This ensures that EXIF data is preserved in derivative images, which
+    // allows browsers to auto-orient them if they have Orientation data.
+    $config = \Drupal::configFactory()->getEditable('imagick.config');
+    $config->set('strip_metadata', FALSE);
+    $config->save();
   }
 
   // Add auto-orient effect to Drupal core image styles.

--- a/modules/core/image/farm_image.post_update.php
+++ b/modules/core/image/farm_image.post_update.php
@@ -18,6 +18,11 @@ function farm_image_post_update_install_imagick() {
       \Drupal::service('module_installer')->install(['imagick']);
     }
 
+    // Make imagick the default image toolkit.
+    $config = \Drupal::configFactory()->getEditable('system.image');
+    $config->set('toolkit', 'imagick');
+    $config->save();
+
     // Configure imagick to disable strip_metadata.
     // This ensures that EXIF data is preserved in derivative images, which
     // allows browsers to auto-orient them if they have Orientation data.

--- a/modules/core/image/farm_image.post_update.php
+++ b/modules/core/image/farm_image.post_update.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Updates farm_image module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Install the imagick module, if the PHP extension is available.
+ */
+function farm_image_post_update_install_imagick() {
+  if (extension_loaded('imagick')) {
+
+    // Install the imagick module.
+    if (!\Drupal::service('module_handler')->moduleExists('imagick')) {
+      \Drupal::service('module_installer')->install(['imagick']);
+    }
+  }
+}

--- a/modules/core/image/farm_image.post_update.php
+++ b/modules/core/image/farm_image.post_update.php
@@ -8,7 +8,7 @@
 declare(strict_types=1);
 
 /**
- * Install the imagick module, if the PHP extension is available.
+ * Install and configure the imagick module, if the PHP extension is available.
  */
 function farm_image_post_update_install_imagick() {
   if (extension_loaded('imagick')) {
@@ -17,5 +17,12 @@ function farm_image_post_update_install_imagick() {
     if (!\Drupal::service('module_handler')->moduleExists('imagick')) {
       \Drupal::service('module_installer')->install(['imagick']);
     }
+
+    // Configure imagick to disable strip_metadata.
+    // This ensures that EXIF data is preserved in derivative images, which
+    // allows browsers to auto-orient them if they have Orientation data.
+    $config = \Drupal::configFactory()->getEditable('imagick.config');
+    $config->set('strip_metadata', FALSE);
+    $config->save();
   }
 }


### PR DESCRIPTION
See: #939

This installs+configures the `imagick` PHP extension and Drupal module.

The end result is that EXIF information is preserved in derivative images generated by Drupal.