### PR TITLE
Allow WebP files in image fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Automatically rotate derivative images based on EXIF Orientation #941](https://github.com/farmOS/farmOS/pull/941)
+- [Allow WebP files in image fields #942](https://github.com/farmOS/farmOS/pull/942)
 
 ### Fixed
 

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -629,7 +629,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         break;
 
       case 'image':
-        $settings['file_extensions'] = 'png gif jpg jpeg';
+        $settings['file_extensions'] = 'png gif jpg jpeg webp';
         $settings['max_resolution'] = '';
         $settings['min_resolution'] = '';
         $settings['alt_field'] = FALSE;


### PR DESCRIPTION
This adds the ability to upload `*.webp` files to image fields in farmOS.

Spawned from this comment: https://github.com/farmOS/farmOS/pull/941#discussion_r2012940992