### PR TITLE
Fix PHPStan errors: Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value

### DIFF
--- a/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
+++ b/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
@@ -63,6 +63,7 @@ class HideableBoolean extends BooleanFormatter {
 
     $formats = $this->getOutputFormats();
 
+    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\BooleanItem $item */
     foreach ($items as $delta => $item) {
       $format = $this->getSetting('format');
 

--- a/modules/core/field/src/Plugin/Field/FieldFormatter/UrlLinkFormatter.php
+++ b/modules/core/field/src/Plugin/Field/FieldFormatter/UrlLinkFormatter.php
@@ -28,6 +28,7 @@ class UrlLinkFormatter extends FormatterBase {
 
     // This is a clone of Drupal core's UriLinkFormatter, but it only renders
     // a link if the URI is a valid URL.
+    /** @var \Drupal\Core\Field\Plugin\Field\FieldType\UriItem $item */
     foreach ($items as $delta => $item) {
       if (!$item->isEmpty()) {
         if (filter_var($item->value, FILTER_VALIDATE_URL)) {

--- a/modules/core/inventory/src/Plugin/Field/FieldFormatter/InventoryFormatter.php
+++ b/modules/core/inventory/src/Plugin/Field/FieldFormatter/InventoryFormatter.php
@@ -25,6 +25,7 @@ class InventoryFormatter extends FormatterBase {
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = [];
 
+    /** @var \Drupal\farm_inventory\Plugin\Field\FieldType\InventoryItem $item */
     foreach ($items as $delta => $item) {
       $summary = $item->value;
       if (!empty($item->units)) {

--- a/modules/core/inventory/src/Plugin/Field/FieldType/InventoryItem.php
+++ b/modules/core/inventory/src/Plugin/Field/FieldType/InventoryItem.php
@@ -12,6 +12,10 @@ use Drupal\Core\TypedData\DataDefinition;
 
 /**
  * Plugin implementation of the 'Inventory' field type.
+ *
+ * @property string $measure
+ * @property string $value
+ * @property string $units
  */
 #[FieldType(
   id: 'inventory',


### PR DESCRIPTION
The following PHPStan errors started happening in automated tests today:

```
 ------ ------------------------------------------------------------------------------------------
  Line   web/profiles/farm/modules/core/field/src/Plugin/Field/FieldFormatter/HideableBoolean.php
 ------ ------------------------------------------------------------------------------------------
  73     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  73     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  78     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  81     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ ------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------
  Line   web/profiles/farm/modules/core/field/src/Plugin/Field/FieldFormatter/UrlLinkFormatter.php
 ------ -------------------------------------------------------------------------------------------
  33     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  36     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  37     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
  43     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ -------------------------------------------------------------------------------------------

 ------ -------------------------------------------------------------------------------------------------
  Line   web/profiles/farm/modules/core/inventory/src/Plugin/Field/FieldFormatter/InventoryFormatter.php
 ------ -------------------------------------------------------------------------------------------------
  29     Access to an undefined property Drupal\Core\Field\FieldItemInterface::$value.
         💡 Learn more: https://phpstan.org/blog/solving-phpstan-access-to-undefined-property
 ------ -------------------------------------------------------------------------------------------------
```

This PR fixes them by replacing `$item->value` with `$item->getValue()`.