### PR TITLE
Replace instances of "complete" log status with "done"

### DIFF
--- a/docs/development/api/changes.md
+++ b/docs/development/api/changes.md
@@ -226,7 +226,7 @@ for more information.
 To illustrate, this is how to filter activity logs by their completed status:
 
 - farmOS 1.x: `/log.json?type=activity&done=1`
-- farmOS 2.x: `/api/log/activity?filter[status]=complete`
+- farmOS 2.x: `/api/log/activity?filter[status]=done`
 
 ### Text format
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -37,7 +37,7 @@ Asset details popup.
 
 Below the map you will see "Upcoming tasks" and "Late tasks" on the left, which
 summarize Logs that are still in "pending" status. From here you can quickly
-select Logs and mark them as "complete", reschedule them, clone them, or delete
+select Logs and mark them as "done", reschedule them, clone them, or delete
 them.
 
 To the right you will see a summary of various farm metrics, including total

--- a/docs/guide/inventory.md
+++ b/docs/guide/inventory.md
@@ -9,7 +9,7 @@ To adjust the inventory of an Asset, enable the Inventory module, and create a
 Log with a Quantity. Within the Quantity, select "Increment", "Decrement", or
 "Reset" in the "Inventory adjustment" options, and then select the Asset whose
 inventory you would like to adjust. Fill in the Quantity's value (and
-optionally its measure, units, and label), set the Log's status to "complete",
+optionally its measure, units, and label), set the Log's status to "done",
 and then save the Log. Browse to the Asset you selected, and you will see the
 new inventory level.
 

--- a/docs/guide/location.md
+++ b/docs/guide/location.md
@@ -10,7 +10,7 @@ though they are actually a more specific Log type like "Activity",
 
 farmOS determines the "current location" of an Asset by looking at the Asset's
 most recent movement Log (with a date less than or equal to the present moment).
-Only Logs that have been marked as "complete" are taken into consideration.
+Only Logs that have been marked as "done" are taken into consideration.
 
 Every Log has a "Location" reference field (for referencing the location Asset
 that things are moving to), a "Geometry" field (for recording the precise

--- a/docs/guide/logs.md
+++ b/docs/guide/logs.md
@@ -6,7 +6,7 @@ in the future.
 
 Planning ahead in farmOS is exactly the same as recording things that already
 happened. The only difference is that the date is in the future, and the Log
-status is "pending" instead of "complete".
+status is "pending" instead of "done".
 
 Logs that are in the future and "pending" will appear in your "Upcoming Tasks"
 list on the dashboard. Underneath that is a "Late tasks" list, which shows all

--- a/modules/core/location/farm_location.base_fields.inc
+++ b/modules/core/location/farm_location.base_fields.inc
@@ -163,7 +163,7 @@ function farm_location_log_base_fields() {
   $options = [
     'type' => 'boolean',
     'label' => t('Is movement'),
-    'description' => t('If this log is a movement, then all assets referenced by it will be located in the referenced locations and/or geometry at the time the log takes place. The log must be complete in order for the movement to take effect.'),
+    'description' => t('If this log is a movement, then all assets referenced by it will be located in the referenced locations and/or geometry at the time the log takes place. The log must have a status of "done" in order for the movement to take effect.'),
     'default_value_callback' => 'farm_location_is_movement_default_value',
     'weight' => [
       'form' => 20,

--- a/modules/core/location/src/AssetLocation.php
+++ b/modules/core/location/src/AssetLocation.php
@@ -285,7 +285,7 @@ class AssetLocation implements AssetLocationInterface {
           -- These conditions should match the values in the WHERE clause.
           AND (lfd2.status = 'done') AND (lfd2.timestamp <= :timestamp)
 
-      -- Limit results to completed movement logs to the desired location that
+      -- Limit results to done movement logs to the desired location that
       -- took place before the given timestamp.
       WHERE (lfd.is_movement = 1) AND (lfd.status = 'done') AND (lfd.timestamp <= :timestamp) AND (ll.location_target_id IN (:location_ids[]))
 

--- a/modules/core/log/tests/src/Kernel/LogTest.php
+++ b/modules/core/log/tests/src/Kernel/LogTest.php
@@ -91,8 +91,8 @@ class LogTest extends KernelTestBase {
     $log_ids = $this->logQueryFactory->getQuery(['timestamp' => $now])->accessCheck(FALSE)->execute();
     $this->assertNotContains($foo_log->id(), $log_ids, 'Log query results can be filtered by timestamp.');
 
-    // Set the status of one log to complete.
-    $bar_log->set('status', 'complete');
+    // Set the status of one log to "done".
+    $bar_log->set('status', 'done');
     $bar_log->save();
 
     // Test that results can be filtered by status.


### PR DESCRIPTION
We reference a log status called "complete" in a few places in our docs. It should be "done".