### PR TITLE
Add abandoned log status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ requirements:
 
 ### Added
 
+- [Issue #3304608: Add an "abandoned" log status](https://www.drupal.org/project/farm/issues/3304608)
 - [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)
 - [Add a hook for excluding fields from CSV importers #958](https://github.com/farmOS/farmOS/pull/958)
 - [Include config fields in CSV importers #959](https://github.com/farmOS/farmOS/pull/959)

--- a/docs/development/api/changes.md
+++ b/docs/development/api/changes.md
@@ -1,5 +1,10 @@
 # API Changes
 
+## 4.x vs 3.x
+
+- Logs can now have a status of `abandoned`, in addition to the existing `done`
+  and `pending`.
+
 ## 3.x vs 2.x
 
 The [Simple OAuth](https://www.drupal.org/project/simple_oauth) module has been

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -36,9 +36,8 @@ clicking on a location and then clicking on the available links within the
 Asset details popup.
 
 Below the map you will see "Upcoming tasks" and "Late tasks" on the left, which
-summarize Logs that are still in "pending" status. From here you can quickly
-select Logs and mark them as "done", reschedule them, clone them, or delete
-them.
+summarize Logs that have a "pending" status. From here you can quickly select
+Logs and mark them as "done", reschedule them, clone them, or delete them.
 
 To the right you will see a summary of various farm metrics, including total
 Asset and Log counts. Additional metrics can be added via modules.

--- a/docs/model/type/log.md
+++ b/docs/model/type/log.md
@@ -62,10 +62,15 @@ Logs always have a timestamp which indicates when they took place.
 
 #### Status
 
-Logs can be marked as "pending" or "done", to indicate whether they are
-"planned" or "actual" events. Every change that is made to a Log is stored as
-a revision, so that it's possible to see how a plan evolves over time until it
-eventually becomes a canonical record of the event that took place.
+Logs can be marked as "pending", "done", or "abandoned". Pending Logs represent
+planned events, while done Logs represent events that actually happened. If an
+event is never completed and there is no intention of completing it, the Log
+can be marked as "abandoned" to make that clear while preserving it for future
+reference.
+
+Every change that is made to a Log is stored as a revision, so that it's
+possible to see how a plan evolves over time until it eventually becomes a
+canonical record of the event that took place.
 
 #### Flags
 

--- a/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
@@ -108,7 +108,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
     }
 
     // If updating an existing group assignment log, invalidate the cache.
-    // This catches group assignment logs changing from done to pending.
+    // This catches group assignment logs changing from done to another status.
     if (!empty($log->original) && $this->isActiveGroupAssignment($log->original)) {
       $update_asset_cache = TRUE;
     }
@@ -155,7 +155,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
     }
 
     // If updating an existing 'done' movement log, invalidate the cache.
-    // This catches any movement logs changing from done to pending.
+    // This catches any movement logs changing from done to another status.
     if (!empty($log->original) && LocationLogEventSubscriber::isActiveMovementLog($log->original)) {
       $update_asset_cache = TRUE;
     }

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -174,7 +174,60 @@ class GroupTest extends KernelTestBase {
     // Assert that the animal's cache tags were not invalidated.
     $this->assertEntityTestCache($animal, TRUE);
 
+    // Create an "abandoned" log that assigns the animal to the second group
+    // and confirm that it still has the same group membership as before.
+    /** @var \Drupal\log\Entity\LogInterface $abandoned_log */
+    $abandoned_log = Log::create([
+      'type' => 'test',
+      'status' => 'abandoned',
+      'is_group_assignment' => TRUE,
+      'group' => ['target_id' => $second_group->id()],
+      'asset' => ['target_id' => $animal->id()],
+    ]);
+    $abandoned_log->save();
+    $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'Abandoned group assignment logs do not affect membership.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Groups with only abandoned membership have zero members.');
+
+    // Assert that the animal's cache tags were not invalidated.
+    $this->assertEntityTestCache($animal, TRUE);
+
+    // Change the pending log's status to "abandoned" and confirm that the group
+    // membership is still unchanged.
+    $second_log->set('status', 'abandoned');
+    $second_log->save();
+    $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'Abandoned group assignment logs do not affect membership.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Groups with only abandoned membership logs have zero members.');
+
+    // Assert that the animal's cache tags were not invalidated.
+    $this->assertEntityTestCache($animal, TRUE);
+
     // When the log is marked as "done", the asset's membership is updated.
+    $second_log->set('status', 'done');
+    $second_log->save();
+    $this->assertEquals($second_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'A second group assignment log updates group membership.');
+    $this->assertCorrectAssets([$animal], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Completed group assignment logs add group members.');
+
+    // Assert that the animal's cache tags were invalidated.
+    $this->assertEntityTestCache($animal, FALSE);
+
+    // Re-populate a cache value dependent on the animal's cache tags.
+    $this->populateEntityTestCache($animal);
+
+    // When a log is changed from "done" to "abandoned", the asset's membership
+    // is reverted to what it was previously.
+    $second_log->set('status', 'abandoned');
+    $second_log->save();
+    $this->assertEquals($first_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'Abandoned group assignment logs do not affect membership.');
+    $this->assertCorrectAssets([], $this->groupMembership->getGroupMembers([$second_group]), TRUE, 'Groups with only abandoned membership logs have zero members.');
+
+    // Assert that the animal's cache tags were invalidated.
+    $this->assertEntityTestCache($animal, FALSE);
+
+    // Re-populate a cache value dependent on the animal's cache tags.
+    $this->populateEntityTestCache($animal);
+
+    // When a log is changed from "abandoned" to "done", the asset's membership
+    // is updated.
     $second_log->set('status', 'done');
     $second_log->save();
     $this->assertEquals($second_group->id(), $this->groupMembership->getGroup($animal)[0]->id(), 'A second group assignment log updates group membership.');

--- a/modules/core/import/modules/csv/migrations/csv_log.yml
+++ b/modules/core/import/modules/csv/migrations/csv_log.yml
@@ -128,6 +128,6 @@ third_party_settings:
       - name: is movement
         description: Whether this log represents an asset movement. Accepts most boolean values. Leave this blank to use the default for this log type.
       - name: status
-        description: 'Status of the log. Allowed values: pending, done. Defaults to done.'
+        description: 'Status of the log. Allowed values: pending, done, abandoned. Defaults to done.'
 
 deriver: \Drupal\farm_import_csv\Plugin\Derivative\CsvImportMigrationLog

--- a/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
@@ -95,7 +95,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
     }
 
     // If updating an existing inventory log, invalidate the cache.
-    // This catches inventory logs changing from done to pending.
+    // This catches inventory logs changing from done to another status.
     if (!empty($log->original) && $this->isActiveQuantityLog($log->original)) {
       $update_asset_cache = TRUE;
     }

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -343,7 +343,7 @@ class InventoryTest extends KernelTestBase {
    * @param string|int|null $units
    *   The quantity units of the inventory (term ID).
    * @param int|null $timestamp
-   *   Optionally specify the timestamp when the adjustment occured.
+   *   Optionally specify the timestamp when the adjustment occurred.
    *   If this is NULL (default), the current time will be used.
    *
    * @return \Drupal\log\Entity\LogInterface

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -117,9 +117,22 @@ class InventoryTest extends KernelTestBase {
     $this->populateEntityTestCache($asset);
 
     // Decrement the inventory by 1.
-    $this->adjustInventory($asset, 'decrement', '1');
+    $log = $this->adjustInventory($asset, 'decrement', '1');
     $inventory = $this->assetInventory->getInventory($asset);
     $this->assertEquals('5', $inventory[0]['value'], 'Asset inventory is 5.');
+
+    // Assert that the asset's cache tags were invalidated.
+    $this->assertEntityTestCache($asset, FALSE);
+
+    // Re-populate a cache value dependent on the asset's cache tags.
+    $this->populateEntityTestCache($asset);
+
+    // Change the previous log's status to "abandoned", and confirm that it
+    // resets the inventory back to 6.
+    $log->set('status', 'abandoned');
+    $log->save();
+    $inventory = $this->assetInventory->getInventory($asset);
+    $this->assertEquals('6', $inventory[0]['value'], 'Asset inventory is 6.');
 
     // Assert that the asset's cache tags were invalidated.
     $this->assertEntityTestCache($asset, FALSE);
@@ -140,9 +153,28 @@ class InventoryTest extends KernelTestBase {
 
     // Add a pending adjustment, and confirm that it does not affect the current
     // inventory.
-    $this->adjustInventory($asset, 'increment', '1', '', NULL, NULL, 'pending');
+    $log = $this->adjustInventory($asset, 'increment', '1', '', NULL, NULL, 'pending');
     $inventory = $this->assetInventory->getInventory($asset);
     $this->assertEquals('0', $inventory[0]['value'], 'Pending adjustments do not affect inventory.');
+
+    // Assert that the asset's cache tags were not invalidated.
+    $this->assertEntityTestCache($asset, TRUE);
+
+    // Change the pending log's status to "abandoned", and confirm that it does
+    // not affect the current inventory.
+    $log->set('status', 'abandoned');
+    $log->save();
+    $inventory = $this->assetInventory->getInventory($asset);
+    $this->assertEquals('0', $inventory[0]['value'], 'Pending adjustments do not affect inventory.');
+
+    // Assert that the asset's cache tags were not invalidated.
+    $this->assertEntityTestCache($asset, TRUE);
+
+    // Add an abandoned adjustment, and confirm that it does not affect the
+    // current inventory.
+    $this->adjustInventory($asset, 'increment', '1', '', NULL, NULL, 'abandoned');
+    $inventory = $this->assetInventory->getInventory($asset);
+    $this->assertEquals('0', $inventory[0]['value'], 'Abandoned adjustments do not affect inventory.');
 
     // Assert that the asset's cache tags were not invalidated.
     $this->assertEntityTestCache($asset, TRUE);

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -137,13 +137,10 @@ class InventoryTest extends KernelTestBase {
 
     // Add a pending adjustment, and confirm that it does not affect the current
     // inventory.
-    $log = $this->adjustInventory($asset, 'increment', '1');
-    $log->set('status', 'pending');
-    $log->save();
+    $this->adjustInventory($asset, 'increment', '1', '', NULL, NULL, 'pending');
 
     // Re-populate a cache value dependent on the asset's cache tags.
     $this->populateEntityTestCache($asset);
-    $log->save();
 
     $inventory = $this->assetInventory->getInventory($asset);
     $this->assertEquals('0', $inventory[0]['value'], 'Pending adjustments do not affect inventory.');
@@ -345,11 +342,13 @@ class InventoryTest extends KernelTestBase {
    * @param int|null $timestamp
    *   Optionally specify the timestamp when the adjustment occurred.
    *   If this is NULL (default), the current time will be used.
+   * @param string $status
+   *   Optionally specify the status of the adjustment log. Defaults to "done".
    *
    * @return \Drupal\log\Entity\LogInterface
    *   The log entity.
    */
-  protected function adjustInventory(AssetInterface $asset, string $adjustment, string $value, string $measure = '', string|int|null $units = NULL, $timestamp = NULL) {
+  protected function adjustInventory(AssetInterface $asset, string $adjustment, string $value, string $measure = '', string|int|null $units = NULL, $timestamp = NULL, $status = 'done') {
     $fraction = Fraction::createFromDecimal($value);
     /** @var \Drupal\quantity\Entity\Quantity $quantity */
     $quantity = Quantity::create([
@@ -375,7 +374,7 @@ class InventoryTest extends KernelTestBase {
     $log = Log::create([
       'type' => 'adjustment',
       'timestamp' => $timestamp,
-      'status' => 'done',
+      'status' => $status,
       'quantity' => [
         'target_id' => $quantity->id(),
         'target_revision_id' => $quantity->getRevisionId(),

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -150,13 +150,11 @@ class InventoryTest extends KernelTestBase {
 
     // Add an adjustment in the future, and confirm that it does not affect
     // the current inventory.
-    $log = $this->adjustInventory($asset, 'increment', '1');
-    $log->set('timestamp', \Drupal::time()->getRequestTime() + 86400);
-    $log->save();
+    $timestamp = \Drupal::time()->getRequestTime() + 86400;
+    $this->adjustInventory($asset, 'increment', '1', '', NULL, $timestamp);
 
     // Re-populate a cache value dependent on the asset's cache tags.
     $this->populateEntityTestCache($asset);
-    $log->save();
 
     $inventory = $this->assetInventory->getInventory($asset);
     $this->assertEquals('0', $inventory[0]['value'], 'Future adjustments do not affect inventory.');

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -135,13 +135,12 @@ class InventoryTest extends KernelTestBase {
     // Assert that the asset's cache tags were invalidated.
     $this->assertEntityTestCache($asset, FALSE);
 
-    // Add a pending adjustment, and confirm that it does not affect the current
-    // inventory.
-    $this->adjustInventory($asset, 'increment', '1', '', NULL, NULL, 'pending');
-
     // Re-populate a cache value dependent on the asset's cache tags.
     $this->populateEntityTestCache($asset);
 
+    // Add a pending adjustment, and confirm that it does not affect the current
+    // inventory.
+    $this->adjustInventory($asset, 'increment', '1', '', NULL, NULL, 'pending');
     $inventory = $this->assetInventory->getInventory($asset);
     $this->assertEquals('0', $inventory[0]['value'], 'Pending adjustments do not affect inventory.');
 
@@ -152,10 +151,6 @@ class InventoryTest extends KernelTestBase {
     // the current inventory.
     $timestamp = \Drupal::time()->getRequestTime() + 86400;
     $this->adjustInventory($asset, 'increment', '1', '', NULL, $timestamp);
-
-    // Re-populate a cache value dependent on the asset's cache tags.
-    $this->populateEntityTestCache($asset);
-
     $inventory = $this->assetInventory->getInventory($asset);
     $this->assertEquals('0', $inventory[0]['value'], 'Future adjustments do not affect inventory.');
 

--- a/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
@@ -264,7 +264,7 @@ class LogEventSubscriber implements EventSubscriberInterface {
     }
 
     // If updating an existing 'done' movement log, invalidate the cache.
-    // This catches any movement logs changing from done to pending.
+    // This catches any movement logs changing from done to another status.
     if (!empty($log->original) && $this->isActiveMovementLog($log->original)) {
       $update_asset_cache = TRUE;
     }

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -318,7 +318,59 @@ class LocationTest extends KernelTestBase {
     // Assert that the asset's cache tags were not invalidated.
     $this->assertEntityTestCache($asset, TRUE);
 
+    // Create an "abandoned" log that references the asset.
+    /** @var \Drupal\log\Entity\LogInterface $abandoned_log */
+    $abandoned_log = Log::create([
+      'type' => 'movement',
+      'status' => 'abandoned',
+      'asset' => ['target_id' => $asset->id()],
+      'location' => ['target_id' => $this->locations[2]->id()],
+      'is_movement' => TRUE,
+    ]);
+    $abandoned_log->save();
+    $this->assertEquals($this->logLocation->getLocation($first_log), $this->assetLocation->getLocation($asset), 'Asset with abandoned movement log has original location');
+    $this->assertEquals($this->logLocation->getGeometry($first_log), $this->assetLocation->getGeometry($asset), 'Asset with abandoned movement log has original geometry.');
+
+    // Assert that the asset's cache tags were not invalidated.
+    $this->assertEntityTestCache($asset, TRUE);
+
+    // Change the pending log's status to "abandoned" and confirm that the asset
+    // location is still unchanged.
+    $second_log->set('status', 'abandoned');
+    $second_log->save();
+    $this->assertEquals($this->logLocation->getLocation($first_log), $this->assetLocation->getLocation($asset), 'Asset with abandoned movement log has original location');
+    $this->assertEquals($this->logLocation->getGeometry($first_log), $this->assetLocation->getGeometry($asset), 'Asset with abandoned movement log has original geometry.');
+
+    // Assert that the asset's cache tags were not invalidated.
+    $this->assertEntityTestCache($asset, TRUE);
+
     // When the log is marked as "done", the asset location is updated.
+    $second_log->set('status', 'done');
+    $second_log->save();
+    $this->assertEquals($this->logLocation->getLocation($second_log), $this->assetLocation->getLocation($asset), 'Asset with second movement log has new location');
+    $this->assertEquals($this->logLocation->getGeometry($second_log), $this->assetLocation->getGeometry($asset), 'Asset with second movement log has new geometry.');
+
+    // Assert that the asset's cache tags were invalidated.
+    $this->assertEntityTestCache($asset, FALSE);
+
+    // Re-populate a cache value dependent on the asset's cache tags.
+    $this->populateEntityTestCache($asset);
+
+    // When a log is changed from "done" to "abandoned", the asset's location
+    // is reverted to what it was previously.
+    $second_log->set('status', 'abandoned');
+    $second_log->save();
+    $this->assertEquals($this->logLocation->getLocation($first_log), $this->assetLocation->getLocation($asset), 'Asset with abandoned movement log has original location');
+    $this->assertEquals($this->logLocation->getGeometry($first_log), $this->assetLocation->getGeometry($asset), 'Asset with abandoned movement log has original geometry.');
+
+    // Assert that the asset's cache tags were invalidated.
+    $this->assertEntityTestCache($asset, FALSE);
+
+    // Re-populate a cache value dependent on the asset's cache tags.
+    $this->populateEntityTestCache($asset);
+
+    // When a log is changed from "abandoned" to "done", the asset's location
+    // is updated.
     $second_log->set('status', 'done');
     $second_log->save();
     $this->assertEquals($this->logLocation->getLocation($second_log), $this->assetLocation->getLocation($asset), 'Asset with second movement log has new location');

--- a/modules/core/log/farm_log.workflows.yml
+++ b/modules/core/log/farm_log.workflows.yml
@@ -7,12 +7,18 @@ farm_log_workflow:
       label: Done
     pending:
       label: Pending
+    abandoned:
+      label: Abandoned
   transitions:
     done:
       label: 'Done'
-      from: [pending]
+      from: [pending, abandoned]
       to: done
     to_pending:
       label: 'Move to Pending'
-      from: [done]
+      from: [done, abandoned]
       to: pending
+    to_abandoned:
+      label: 'Abandon'
+      from: [done, pending]
+      to: abandoned

--- a/modules/core/ui/views/farm_ui_views.module
+++ b/modules/core/ui/views/farm_ui_views.module
@@ -41,7 +41,7 @@ function farm_ui_views_help($route_name, RouteMatchInterface $route_match) {
 
   // Logs View.
   if ($route_name == $entity_routes['log']) {
-    $output .= '<p>' . t('Logs represent events that take place in relation to <a href=":assets">assets</a> and other records. They have a timestamp to represent when they take place, and can be marked as "Pending" or "Done" for planning purposes.', [':assets' => $entity_urls['asset']]) . '</p>';
+    $output .= '<p>' . t('Logs represent events that take place in relation to <a href=":assets">assets</a> and other records. They have a timestamp to represent when they take place, and a status to designate that they are "Done", "Pending", or "Abandoned".', [':assets' => $entity_urls['asset']]) . '</p>';
     $output .= '<p>' . t('Logs can be assigned to <a href=":people">people</a> for task management purposes.', [':people' => $entity_urls['people']]) . '</p>';
   }
 


### PR DESCRIPTION
See: https://www.drupal.org/project/farm/issues/330460

And forum discussion: https://farmos.discourse.group/t/ability-to-create-abandoned-logs/1636

Opening this as a draft PR to kick off discussion. Right now all it does is add the status as an option and updates the documentation to include it.

TBD:

- Do we need to change any other code to accommodate this?
- Do we need any automated tests?
- ... ?