### PR TITLE
Fix hidden entity fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix hidden entity fields #950](https://github.com/farmOS/farmOS/pull/950)
+
 ## [3.4.4] 2025-04-03
 
 ### Changed

--- a/modules/core/entity/modules/fields/farm_entity_fields.module
+++ b/modules/core/entity/modules/fields/farm_entity_fields.module
@@ -90,23 +90,13 @@ function farm_entity_fields_entity_base_field_info_alter(&$fields, EntityTypeInt
 
     // Hide the field, if desired.
     if (!empty($options['hidden'])) {
-      switch ($options['hidden']) {
-
-        // Only hide in the entity form.
-        case 'form':
-          $form_display_options['region'] = 'hidden';
-          break;
-
-        // Only hide in the entity view.
-        case 'view':
-          $view_display_options['region'] = 'hidden';
-          break;
-
-        // Hide in both the entity form and view.
-        case TRUE:
-          $form_display_options['region'] = 'hidden';
-          $view_display_options['region'] = 'hidden';
-          break;
+      /** @var bool|string $hidden */
+      $hidden = $options['hidden'];
+      if ($hidden === TRUE || $hidden === 'form') {
+        $form_display_options['region'] = 'hidden';
+      }
+      if ($hidden === TRUE || $hidden === 'view') {
+        $view_display_options['region'] = 'hidden';
       }
     }
 


### PR DESCRIPTION
I noticed recently that the "Authored by" and "Authored on" fields were being displayed on records:

![Screenshot from 2025-04-14 09-23-18](https://github.com/user-attachments/assets/86357306-59d6-4cba-b676-85af7c5fa6bc)
![Screenshot from 2025-04-14 09-25-14](https://github.com/user-attachments/assets/3958b8e2-51ae-4b84-8d3a-0709c7832998)

We intentionally hide those via code in our `farm_entity_fields.module`:

https://github.com/farmOS/farmOS/blob/8bcc1c09a266d668d59d3e4ca9d83ba752ae37b0/modules/core/entity/modules/fields/farm_entity_fields.module#L68-L73

I traced this to a recent change I made in #911:

https://github.com/farmOS/farmOS/commit/9950c97c12a00736f6ad38b8ec3a33ffeb3ae23f

While debugging with XDebug, I found that `switch ($options['hidden'])` is ending up in `case 'form':` when `$options['hidden']` is `TRUE`.

![Screenshot from 2025-04-14 09-35-58](https://github.com/user-attachments/assets/39f66a8f-5ace-4dae-9976-e0e3c5aa5219)

This SO question (and the first answer) explains what's happening: https://stackoverflow.com/questions/8829229/why-switchtrue-in-php-with-a-strange-logic

To fix this, I changed the code from a `switch` statement to `if` + `elseif` + `else`.