### PR TITLE
Fix missing Assets tab on locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix hidden entity fields #950](https://github.com/farmOS/farmOS/pull/950)
+- [Fix missing Assets tab on locations #951](https://github.com/farmOS/farmOS/pull/951)
 
 ## [3.4.4] 2025-04-03
 

--- a/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
@@ -50,10 +50,10 @@ class FarmLocationAssetViewsAccessCheck implements AccessInterface {
    */
   public function access(RouteMatchInterface $route_match) {
 
-    // If there is no integer "asset" parameter, deny access.
+    // If there is no "asset" parameter, bail.
     $asset_id = $route_match->getParameter('asset');
-    if (empty($asset_id) || !is_int($asset_id)) {
-      return AccessResult::forbidden();
+    if (empty($asset_id)) {
+      return AccessResult::allowed();
     }
 
     // Allow access if the asset is a location.

--- a/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
+++ b/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
@@ -101,6 +101,21 @@ class FarmUiViewsTest extends FarmBrowserTestBase {
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('Foo activity');
     $this->assertSession()->pageTextNotContains('Baz activity');
+
+    // Move the equipment asset into the water asset via an activity log.
+    $movement = Log::create([
+      'type' => 'activity',
+      'asset' => [$equipment],
+      'location' => [$water],
+      'status' => 'done',
+      'is_movement' => TRUE,
+    ]);
+    $movement->save();
+
+    // Check that the equipment appears in /asset/%/assets.
+    $this->drupalGet('/asset/' . $water->id() . '/assets');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains($equipment->label());
   }
 
 }


### PR DESCRIPTION
In farmOS, assets that are designated as "locations" have an "Assets" tab on them that shows a list of assets currently in that location. A bug was introduced recently that prevents this tab from showing.

Originally reported in: https://farmos.discourse.group/t/how-to-list-all-the-current-plant-quantities-in-my-vegetable-garden-field/2273/16