### PR TITLE
Convert equipment to a base field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ will ensure that all necessary changes have been applied before updating to 4.x.
 ### Changed
 
 - farmOS 4.x requires PHP 8.3+.
+- [Convert equipment to a base field #956](https://github.com/farmOS/farmOS/pull/956)
 
 ### Deprecated
 

--- a/modules/asset/equipment/farm_equipment.module
+++ b/modules/asset/equipment/farm_equipment.module
@@ -10,9 +10,9 @@ declare(strict_types=1);
 use Drupal\Core\Entity\EntityTypeInterface;
 
 /**
- * Implements hook_farm_entity_bundle_field_info().
+ * Implements hook_entity_base_field_info().
  */
-function farm_equipment_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, string $bundle) {
+function farm_equipment_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
 
   // Add an Equipment reference field to logs.
@@ -29,10 +29,38 @@ function farm_equipment_farm_entity_bundle_field_info(EntityTypeInterface $entit
         'view' => 40,
       ],
     ];
-    $fields['equipment'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+    $fields['equipment'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
   }
 
   return $fields;
+}
+
+/**
+ * Implements hook_farm_import_csv_base_fields().
+ */
+function farm_equipment_farm_import_csv_base_fields(string $entity_type) {
+  $base_fields = [];
+
+  // Add equipment base field to log CSV importers.
+  if ($entity_type == 'log') {
+    $base_fields[] = 'equipment';
+  }
+
+  return $base_fields;
+}
+
+/**
+ * Implements hook_farm_ui_views_base_fields().
+ */
+function farm_equipment_farm_ui_views_base_fields(string $entity_type) {
+  $base_fields = [];
+
+  // Add equipment base field to farmOS log Views.
+  if ($entity_type == 'log') {
+    $base_fields[] = 'equipment';
+  }
+
+  return $base_fields;
 }
 
 /**


### PR DESCRIPTION
The `equipment` field on logs (provided by the `farm_equipment` module, which also provides the `equipment` asset type) is currently a bundle field, instead of a base field. It's added to all log types, so normally it would be a base field, but we made it a bundle field because that made it show up automatically as a column and filter in our default log Views. #915 made it possible to add base fields to those Views, so this PR takes the next step of converting `equipment` to a base field.

This is technically a breaking change, so it couldn't be done in 3.x.