### PR TITLE
Convert quick to a base field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ will ensure that all necessary changes have been applied before updating to 4.x.
 
 - farmOS 4.x requires PHP 8.3+.
 - [Convert equipment to a base field #956](https://github.com/farmOS/farmOS/pull/956)
+- [Convert quick to a base field #957](https://github.com/farmOS/farmOS/pull/957)
 
 ### Deprecated
 

--- a/modules/core/quick/farm_quick.module
+++ b/modules/core/quick/farm_quick.module
@@ -44,9 +44,9 @@ function farm_quick_help($route_name, RouteMatchInterface $route_match) {
 }
 
 /**
- * Implements hook_farm_entity_bundle_field_info().
+ * Implements hook_entity_base_field_info().
  */
-function farm_quick_farm_entity_bundle_field_info(EntityTypeInterface $entity_type, string $bundle) {
+function farm_quick_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
 
   // We only act on asset and log entities.
@@ -62,7 +62,7 @@ function farm_quick_farm_entity_bundle_field_info(EntityTypeInterface $entity_ty
     'multiple' => TRUE,
     'hidden' => TRUE,
   ];
-  $fields['quick'] = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
+  $fields['quick'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
 
   return $fields;
 }

--- a/modules/core/quick/tests/src/Kernel/QuickStringTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickStringTest.php
@@ -23,6 +23,7 @@ class QuickStringTest extends KernelTestBase {
    */
   protected static $modules = [
     'asset',
+    'farm_field',
     'farm_quick',
     'state_machine',
     'user',


### PR DESCRIPTION
The `quick` field on assets and logs (provided by the `farm_quick` module) is currently a bundle field, instead of a base field. It's added to all asset and log types, so it should be a base field. TBH I can't recall why it was originally made as a bundle field.

This is technically a breaking change, so it couldn't be done in 3.x.