### PR TITLE
Add a hook for excluding fields from CSV importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ will ensure that all necessary changes have been applied before updating to 4.x.
 ### Added
 
 - [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)
+- [Add a hook for excluding fields from CSV importers #958](https://github.com/farmOS/farmOS/pull/958)
 
 ### Changed
 

--- a/modules/core/import/modules/csv/farm_import_csv.api.php
+++ b/modules/core/import/modules/csv/farm_import_csv.api.php
@@ -37,5 +37,25 @@ function hook_farm_import_csv_base_fields(string $entity_type) {
 }
 
 /**
+ * Excludes fields from default CSV importers.
+ *
+ * @param string $entity_type
+ *   The entity type machine name.
+ *
+ * @return array
+ *   Returns an array of field machine names to exclude from the entity type.
+ */
+function hook_farm_import_csv_exclude_fields(string $entity_type) {
+  $exclude_fields = [];
+
+  // Exclude my custom field from asset CSV importers.
+  if ($entity_type == 'asset') {
+    $exclude_fields[] = 'mycustomfield';
+  }
+
+  return $exclude_fields;
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -148,12 +148,18 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
       // Alter column descriptions for this bundle.
       $this->alterColumnDescriptions($definition['third_party_settings']['farm_import_csv']['columns'], $bundle->id());
 
+      // Ask modules for a list of fields to exclude.
+      $exclude_fields = $this->moduleHandler->invokeAll('farm_import_csv_exclude_fields', [$this->entityType]);
+
       // Add column mapping and descriptions for base fields provided by other
       // modules.
       $base_fields = $this->moduleHandler->invokeAll('farm_import_csv_base_fields', [$this->entityType]);
       foreach ($this->entityFieldManager->getBaseFieldDefinitions($this->entityType) as $field_definition) {
         /** @var \Drupal\Core\Field\BaseFieldDefinition $field_definition */
         if (!in_array($field_definition->getName(), $base_fields)) {
+          continue;
+        }
+        if (in_array($field_definition->getName(), $exclude_fields)) {
           continue;
         }
         $this->addFieldMapping($field_definition, $definition['process'], $definition['third_party_settings']['farm_import_csv']['columns']);
@@ -164,6 +170,9 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
       if ($this->entityTypeManager->hasHandler($this->entityType, 'bundle_plugin')) {
         $bundle_fields = $this->entityTypeManager->getHandler($this->entityType, 'bundle_plugin')->getFieldDefinitions($bundle->id());
         foreach ($bundle_fields as $field_definition) {
+          if (in_array($field_definition->getName(), $exclude_fields)) {
+            continue;
+          }
           $this->addFieldMapping($field_definition, $definition['process'], $definition['third_party_settings']['farm_import_csv']['columns']);
         }
       }
@@ -199,12 +208,6 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
       'boolean',
     ];
     if (!in_array($field_definition->getType(), $supported_field_types)) {
-      return;
-    }
-
-    // Do not include hidden fields.
-    $form_display_options = $field_definition->getDisplayOptions('form');
-    if (isset($form_display_options['region']) && $form_display_options['region'] == 'hidden') {
       return;
     }
 

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/farm_import_csv_test.module
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/farm_import_csv_test.module
@@ -15,15 +15,23 @@ use Drupal\Core\Entity\EntityTypeInterface;
 function farm_import_csv_test_entity_base_field_info(EntityTypeInterface $entity_type) {
   $fields = [];
 
-  // Add a test string base field to logs.
+  // Add base fields to logs.
   if ($entity_type->id() == 'log') {
+
+    // Add a test string base field.
     $options = [
       'type' => 'string',
       'label' => t('Test string'),
     ];
     $fields['test_string'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
-  }
 
+    // Add an excluded test string base field.
+    $options = [
+      'type' => 'string',
+      'label' => t('Excluded test string'),
+    ];
+    $fields['excluded_test_string'] = \Drupal::service('farm_field.factory')->baseFieldDefinition($options);
+  }
   return $fields;
 }
 
@@ -33,10 +41,29 @@ function farm_import_csv_test_entity_base_field_info(EntityTypeInterface $entity
 function farm_import_csv_test_farm_import_csv_base_fields(string $entity_type) {
   $base_fields = [];
 
-  // Add test string base field to log CSV importers.
+  // Add log base fields to log CSV importers.
   if ($entity_type == 'log') {
+
+    // Add test string base field.
     $base_fields[] = 'test_string';
+
+    // Add excluded test string base field (so that it can be excluded).
+    $base_fields[] = 'excluded_test_string';
   }
 
   return $base_fields;
+}
+
+/**
+ * Implements hook_farm_import_csv_exclude_fields().
+ */
+function farm_import_csv_test_farm_import_csv_exclude_fields(string $entity_type) {
+  $exclude_fields = [];
+
+  // Exclude the excluded_test_string field from log CSV importers.
+  if ($entity_type == 'log') {
+    $exclude_fields[] = 'excluded_test_string';
+  }
+
+  return $exclude_fields;
 }

--- a/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
@@ -131,6 +131,7 @@ class CsvImportTest extends FarmBrowserTestBase {
     foreach ($log_columns as $description) {
       $this->assertSession()->pageTextContains($description);
     }
+    $this->assertSession()->pageTextNotContains('excluded test string');
     $this->drupalGet('import/csv/csv_taxonomy_term:animal_type');
     $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('Download template');


### PR DESCRIPTION
This adds a `hook_farm_import_csv_exclude_fields()` hook so that modules can exclude fields from the default CSV importers.

This replaces the simple logic we have now that simply excludes "hidden" fields:

https://github.com/farmOS/farmOS/commit/c125581241c850ce51987718233911e71235e547#diff-0e77ffc0e1e4eca5cac2f4f650d5696f0bfd1a8d5fbe22d209958a02d2d6c844L205-L210

This logic is too simple. There are cases where it's desirable to import data into a "hidden" field. I am about to open a pull request that adds CSV import support for config fields, which will require this.

This is a breaking change, because it means that any fields that are "hidden" (and therefore excluded from the default CSV importers currently) will need to decide if they want to explicitly implement the new hook in order to continue excluding them. Otherwise, they will become an available column in CSV importers automatically.