### PR TITLE
Include config fields in CSV importers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ will ensure that all necessary changes have been applied before updating to 4.x.
 
 - [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)
 - [Add a hook for excluding fields from CSV importers #958](https://github.com/farmOS/farmOS/pull/958)
+- [Include config fields in CSV importers #959](https://github.com/farmOS/farmOS/pull/959)
 
 ### Changed
 

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -8,10 +8,10 @@ use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\entity\BundleFieldDefinition;
+use Drupal\field\FieldConfigInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -177,6 +177,18 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
         }
       }
 
+      // If the bundle has fields defined by configuration, add column mappings
+      // and descriptions for them.
+      $config_field_definitions = array_filter($this->entityFieldManager->getFieldDefinitions($this->entityType, $bundle->id()), function ($definition) {
+        return $definition instanceof FieldConfigInterface;
+      });
+      foreach ($config_field_definitions as $field_definition) {
+        if (in_array($field_definition->getName(), $exclude_fields)) {
+          continue;
+        }
+        $this->addFieldMapping($field_definition, $definition['process'], $definition['third_party_settings']['farm_import_csv']['columns']);
+      }
+
       // Add access control permissions to third party settings.
       $definition['third_party_settings']['farm_import_csv']['access']['permissions'][] = $this->getCreatePermission($bundle->id());
 
@@ -190,14 +202,14 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
   /**
    * Adds field mapping configuration for supported field types.
    *
-   * @param \Drupal\Core\Field\BaseFieldDefinition|\Drupal\entity\BundleFieldDefinition $field_definition
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
    *   The field definition.
    * @param array &$mapping
    *   The migration process mapping.
    * @param array &$columns
    *   The column descriptions from third-party settings.
    */
-  protected function addFieldMapping(BaseFieldDefinition|BundleFieldDefinition $field_definition, array &$mapping, array &$columns): void {
+  protected function addFieldMapping(FieldDefinitionInterface $field_definition, array &$mapping, array &$columns): void {
 
     // This only supports certain field types.
     $supported_field_types = [
@@ -309,7 +321,7 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
     // If the field supports multiple values, explode on comma delimiter
     // as a first step and describe how to format values.
-    if ($field_definition->getCardinality() === -1 || $field_definition->getCardinality() > 1) {
+    if ($field_definition->getFieldStorageDefinition()->getCardinality() === -1 || $field_definition->getFieldStorageDefinition()->getCardinality() > 1) {
       array_unshift($process, ['plugin' => 'explode', 'delimiter' => ',']);
       array_unshift($process, ['plugin' => 'skip_on_empty', 'method' => 'process']);
       $description[] = $this->t('Multiple values can be separated by commas with the whole cell wrapped in quotes.');

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -214,7 +214,9 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
     // This only supports certain field types.
     $supported_field_types = [
       'boolean',
+      'decimal',
       'entity_reference',
+      'integer',
       'list_string',
       'string',
       'timestamp',
@@ -246,6 +248,16 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
         // Describe allowed values.
         $description[] = $this->t('Accepts most boolean values.');
+        break;
+
+      // Number fields.
+      case 'integer':
+      case 'decimal':
+
+        // Map directly from source.
+        $process[] = [
+          'plugin' => 'get',
+        ];
         break;
 
       // Entity reference field.

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -213,11 +213,11 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
     // This only supports certain field types.
     $supported_field_types = [
+      'boolean',
       'entity_reference',
       'list_string',
       'string',
       'timestamp',
-      'boolean',
     ];
     if (!in_array($field_definition->getType(), $supported_field_types)) {
       return;
@@ -235,6 +235,18 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
     // Add configuration based on field type.
     switch ($field_definition->getType()) {
+
+      // Boolean.
+      case 'boolean':
+
+        // Parse with the boolean plugin.
+        $process[] = [
+          'plugin' => 'boolean',
+        ];
+
+        // Describe allowed values.
+        $description[] = $this->t('Accepts most boolean values.');
+        break;
 
       // Entity reference field.
       case 'entity_reference':
@@ -304,18 +316,6 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
 
         // Describe allowed values.
         $description[] = $this->t('Accepts most date/time formats.');
-        break;
-
-      // Boolean.
-      case 'boolean':
-
-        // Parse with the boolean plugin.
-        $process[] = [
-          'plugin' => 'boolean',
-        ];
-
-        // Describe allowed values.
-        $description[] = $this->t('Accepts most boolean values.');
         break;
     }
 

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/animal-types.csv
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/animal-types.csv
@@ -1,4 +1,4 @@
-name,description,parent
-Cow,Cow description,
-Pig,Pig description,
-Galway,Large polled white-faced sheep,Sheep
+name,description,parent,test config field
+Cow,Cow description,,foo
+Pig,Pig description,,bar
+Galway,Large polled white-faced sheep,Sheep,

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/config/install/field.field.taxonomy_term.animal_type.test_config_field.yml
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/config/install/field.field.taxonomy_term.animal_type.test_config_field.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.test_config_field
+    - taxonomy.vocabulary.animal_type
+id: taxonomy_term.animal_type.test_config_field
+field_name: test_config_field
+entity_type: taxonomy_term
+bundle: animal_type
+label: Test config field
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/config/install/field.storage.taxonomy_term.test_config_field.yml
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/config/install/field.storage.taxonomy_term.test_config_field.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.test_config_field
+field_name: test_config_field
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
@@ -139,6 +139,7 @@ class CsvImportTest extends FarmBrowserTestBase {
       'name: Name of the term. Required.',
       'description: Description of the term.',
       'parent: Parent term in the taxonomy hierarchy.',
+      'test config field',
     ];
     foreach ($log_columns as $description) {
       $this->assertSession()->pageTextContains($description);

--- a/modules/core/import/modules/csv/tests/src/Kernel/ConfigCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/ConfigCsvImportTest.php
@@ -27,7 +27,6 @@ class ConfigCsvImportTest extends CsvImportTestBase {
   public function setUp(): void {
     parent::setUp();
     $this->installConfig(['farm_harvest']);
-    $this->installConfig(['farm_import_csv_test']);
   }
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
@@ -32,6 +32,7 @@ class CsvImportTestBase extends MigrateTestBase {
     'asset',
     'entity_reference_revisions',
     'entity_reference_validators',
+    'farm_animal_type',
     'farm_entity_fields',
     'farm_field',
     'farm_format',
@@ -43,6 +44,7 @@ class CsvImportTestBase extends MigrateTestBase {
     'farm_log_quantity',
     'farm_migrate',
     'farm_quantity_standard',
+    'field',
     'file',
     'filter',
     'fraction',
@@ -75,7 +77,7 @@ class CsvImportTestBase extends MigrateTestBase {
     $this->installEntitySchema('quantity');
     $this->installEntitySchema('taxonomy_term');
     $this->installEntitySchema('user');
-    $this->installConfig(['farm_format', 'farm_log_asset', 'farm_quantity_standard', 'farm_import_csv']);
+    $this->installConfig(['farm_format', 'farm_log_asset', 'farm_quantity_standard', 'farm_animal_type', 'farm_import_csv', 'farm_import_csv_test']);
     $this->installSchema('migrate_tools', ['migrate_tools_sync_source_ids']);
     $this->installSchema('farm_import_csv', ['farm_import_csv_entity']);
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/TermCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/TermCsvImportTest.php
@@ -17,16 +17,8 @@ class TermCsvImportTest extends CsvImportTestBase {
   /**
    * {@inheritdoc}
    */
-  protected static $modules = [
-    'farm_animal_type',
-  ];
-
-  /**
-   * {@inheritdoc}
-   */
   public function setUp(): void {
     parent::setUp();
-    $this->installConfig(['farm_animal_type']);
 
     // Create parent term to test asset_lookup.
     $term = Term::create(['name' => 'Sheep', 'vid' => 'animal_type']);
@@ -49,15 +41,18 @@ class TermCsvImportTest extends CsvImportTestBase {
       2 => [
         'name' => 'Cow',
         'description' => 'Cow description',
+        'test_config_field' => 'foo',
       ],
       3 => [
         'name' => 'Pig',
         'description' => 'Pig description',
+        'test_config_field' => 'bar',
       ],
       4 => [
         'name' => 'Galway',
         'description' => 'Large polled white-faced sheep',
         'parent' => 'Sheep',
+        'test_config_field' => '',
       ],
     ];
     foreach ($terms as $id => $term) {
@@ -76,6 +71,7 @@ class TermCsvImportTest extends CsvImportTestBase {
       else {
         $this->assertEmpty($term->get('parent')->referencedEntities());
       }
+      $this->assertEquals($expected_values[$id]['test_config_field'], $term->get('test_config_field')->value);
     }
   }
 


### PR DESCRIPTION
This automatically adds config fields (fields that are defined via configuration, rather than base/bundle fields) to default CSV importers.

It builds on the work that was done in #916. It requires #958 because the logic for excluding "hidden" fields will exclude config fields as well.

It also adds support for number fields (`integer` and `decimal`). This allows the `plant_type` config fields to become available for import (`crop_family`, `companions`, `maturity_days`, `harvest_days`, `transplant_days`).