### PR TITLE
Add Term Merge module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ requirements (inherited from Drupal 11):
 - [Allow API access to organizations #1010](https://github.com/farmOS/farmOS/pull/1010)
 - [Issue #3304608: Add an "abandoned" log status](https://www.drupal.org/project/farm/issues/3304608)
 - [Add default plan status options: "planning", "done", "abandoned" #986](https://github.com/farmOS/farmOS/pull/986)
+- [Add Term Merge module #961](https://github.com/farmOS/farmOS/pull/961)
 - [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)
 - [Add a hook for excluding fields from CSV importers #958](https://github.com/farmOS/farmOS/pull/958)
 - [Include config fields in CSV importers #959](https://github.com/farmOS/farmOS/pull/959)

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "drupal/simple_oauth_password_grant": "^2.1",
         "drupal/state_machine": "^1.12",
         "drupal/subrequests": "3.0.12",
+        "drupal/term_merge": "^2.0",
         "drupal/token": "^1.15",
         "drupal/views_geojson": "^1.3",
         "drush/drush": "^13.0",

--- a/modules/core/ui/farm_ui.info.yml
+++ b/modules/core/ui/farm_ui.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - farm:farm_ui_map
   - farm:farm_ui_menu
   - farm:farm_ui_metrics
+  - farm:farm_ui_term
   - farm:farm_ui_theme
   - farm:farm_ui_user
   - farm:farm_ui_views

--- a/modules/core/ui/farm_ui.post_update.php
+++ b/modules/core/ui/farm_ui.post_update.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Post update hooks for the farm_ui module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Install the farm_ui_term module.
+ */
+function farm_ui_post_update_install_farm_ui_term() {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_ui_term')) {
+    \Drupal::service('module_installer')->install(['farm_ui_term']);
+  }
+}

--- a/modules/core/ui/term/farm_ui_term.info.yml
+++ b/modules/core/ui/term/farm_ui_term.info.yml
@@ -1,0 +1,7 @@
+name: farmOS UI Terms
+description: Adds farmOS UI related to taxonomy terms.
+type: module
+package: farmOS UI
+core_version_requirement: ^11
+dependencies:
+  - term_merge:term_merge

--- a/modules/core/ui/term/farm_ui_term.managed_role_permissions.yml
+++ b/modules/core/ui/term/farm_ui_term.managed_role_permissions.yml
@@ -1,0 +1,3 @@
+farm_ui_term:
+  config_permissions:
+    - merge taxonomy terms


### PR DESCRIPTION
This adds the Drupal [Term Merge](https://www.drupal.org/project/term_merge) module to farmOS, along with a simple `farm_ui_term` module that depends on it and adds the necessary permission.

For more information, see this forum topic: https://farmos.discourse.group/t/merge-module-testing/1635