### PR TITLE
Add support for attributes in farmOS plugin types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)
+
 ### Changed
 
 - farmOS 4.x requires PHP 8.3+.
+
+### Deprecated
+
+- [farmOS core plugin type annotations are deprecated](https://www.drupal.org/node/3523485)
 
 ### Removed
 

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -46,6 +46,8 @@ return static function (RectorConfig $rectorConfig): void {
   // Ensure that annotations are not used when attributes are available.
   // @todo Remove this if/when PHPStan or PHP CodeSniffer can check for it.
   $rectorConfig->ruleWithConfiguration(AnnotationToAttributeRector::class, [
+
+    // Drupal core attributes.
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'Action', 'Drupal\Core\Action\Attribute\Action'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'Block', 'Drupal\Core\Block\Attribute\Block'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'Constraint', 'Drupal\Core\Validation\Attribute\Constraint'),
@@ -56,5 +58,15 @@ return static function (RectorConfig $rectorConfig): void {
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateDestination', 'Drupal\migrate\Attribute\MigrateDestination'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateProcessPlugin', 'Drupal\migrate\Attribute\MigrateProcess'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsDisplayExtender', 'Drupal\views\Attribute\ViewsDisplayExtender'),
+
+    // farmOS attributes.
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'AssetType', 'Drupal\farm_entity\Attribute\AssetType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'DataStreamType', 'Drupal\data_stream\Attribute\DataStreamType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'LogType', 'Drupal\log\Attribute\LogType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'NotificationCondition', 'Drupal\data_stream_notification\Attribute\NotificationCondition'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'NotificationDelivery', 'Drupal\data_stream_notification\Attribute\NotificationDelivery'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'PlanType', 'Drupal\plan\Attribute\PlanType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'QuantityType', 'Drupal\plan\Attribute\QuantityType'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'QuickForm', 'Drupal\farm_quick\Attribute\QuickForm'),
   ]);
 };

--- a/docs/development/module/entities.md
+++ b/docs/development/module/entities.md
@@ -39,16 +39,17 @@ new_revision: true
 
 namespace Drupal\farm_activity\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the activity log type.
- *
- * @LogType(
- *   id = "activity",
- *   label = @Translation("Activity"),
- * )
  */
+#[LogType(
+  id: 'activity',
+  label: new TranslatableMarkup('Activity'),
+)]
 class Activity extends FarmLogType {
 
 }

--- a/docs/development/module/quick.md
+++ b/docs/development/module/quick.md
@@ -47,22 +47,23 @@ namespace Drupal\farm_quick_harvest\Plugin\QuickForm;
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickLogTrait;
 
 /**
  * Harvest quick form.
- *
- * @QuickForm(
- *   id = "harvest",
- *   label = @Translation("Harvest"),
- *   description = @Translation("Record when a harvest takes place."),
- *   helpText = @Translation("Use this form to record a harvest."),
- *   permissions = {
- *     "create harvest log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'harvest',
+  label: new TranslatableMarkup('Harvest'),
+  description: new TranslatableMarkup('Record when a harvest takes place.'),
+  helpText: new TranslatableMarkup('Use this form to record a harvest.'),
+  permissions: [
+    'create harvest log',
+  ],
+)]
 class Harvest extends QuickFormBase {
 
   use QuickLogTrait;
@@ -257,6 +258,8 @@ namespace Drupal\farm_quick_harvest\Plugin\QuickForm;
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\ConfigurableQuickFormTrait;
@@ -264,17 +267,16 @@ use Drupal\farm_quick\Traits\QuickLogTrait;
 
 /**
  * Harvest quick form.
- *
- * @QuickForm(
- *   id = "harvest",
- *   label = @Translation("Harvest"),
- *   description = @Translation("Record when a harvest takes place."),
- *   helpText = @Translation("Use this form to record a harvest."),
- *   permissions = {
- *     "create harvest log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'harvest',
+  label: new TranslatableMarkup('Harvest'),
+  description: new TranslatableMarkup('Record when a harvest takes place.'),
+  helpText: new TranslatableMarkup('Use this form to record a harvest.'),
+  permissions: [
+    'create harvest log',
+  ],
+)]
 class Harvest extends QuickFormBase implements ConfigurableQuickFormInterface {
 
   use ConfigurableQuickFormTrait;
@@ -555,23 +557,24 @@ namespace Drupal\farm_quick_harvest\Plugin\QuickForm;
 
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickLogTrait;
 use Drupal\farm_quick\Traits\QuickPrepopulateTrait;
 
 /**
  * Harvest quick form.
- *
- * @QuickForm(
- *   id = "harvest",
- *   label = @Translation("Harvest"),
- *   description = @Translation("Record when a harvest takes place."),
- *   helpText = @Translation("Use this form to record a harvest."),
- *   permissions = {
- *     "create harvest log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'harvest',
+  label: new TranslatableMarkup('Harvest'),
+  description: new TranslatableMarkup('Record when a harvest takes place.'),
+  helpText: new TranslatableMarkup('Use this form to record a harvest.'),
+  permissions: [
+    'create harvest log',
+  ],
+)]
 class Harvest extends QuickFormBase {
 
   use QuickLogTrait;

--- a/docs/development/module/quick.md
+++ b/docs/development/module/quick.md
@@ -477,18 +477,19 @@ for prepopulating the "Asset" field would be provided as follows:
 
 namespace Drupal\farm_quick_harvest\Plugin\Action;
 
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_quick\Plugin\Action\QuickFormActionBase;
 
 /**
  * Action for recording harvests.
- *
- * @Action(
- *   id = "harvest",
- *   label = @Translation("Record harvest"),
- *   type = "asset",
- *   confirm_form_route_name = "farm.quick.harvest"
- * )
  */
+#[Action(
+  id: 'harvest',
+  action_label: new TranslatableMarkup('Record harvest'),
+  type: 'asset',
+  confirm_form_route_name: 'farm.quick.harvest',
+)]
 class Harvest extends QuickFormActionBase {
 
   /**

--- a/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/animal/src/Plugin/Asset/AssetType/Animal.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_animal\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the animal asset type.
- *
- * @AssetType(
- *   id = "animal",
- *   label = @Translation("Animal"),
- * )
  */
+#[AssetType(
+  id: 'animal',
+  label: new TranslatableMarkup('Animal'),
+)]
 class Animal extends FarmAssetType {
 
   /**

--- a/modules/asset/compost/src/Plugin/Asset/AssetType/Compost.php
+++ b/modules/asset/compost/src/Plugin/Asset/AssetType/Compost.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_compost\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the compost asset type.
- *
- * @AssetType(
- *   id = "compost",
- *   label = @Translation("Compost"),
- * )
  */
+#[AssetType(
+  id: 'compost',
+  label: new TranslatableMarkup('Compost'),
+)]
 class Compost extends FarmAssetType {
 
 }

--- a/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
+++ b/modules/asset/equipment/src/Plugin/Asset/AssetType/Equipment.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_equipment\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the equipment asset type.
- *
- * @AssetType(
- *   id = "equipment",
- *   label = @Translation("Equipment"),
- * )
  */
+#[AssetType(
+  id: 'equipment',
+  label: new TranslatableMarkup('Equipment'),
+)]
 class Equipment extends FarmAssetType {
 
   /**

--- a/modules/asset/equipment/tests/modules/farm_entity_test/src/Plugin/Log/LogType/Test.php
+++ b/modules/asset/equipment/tests/modules/farm_entity_test/src/Plugin/Log/LogType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_equipment_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test log type.
- *
- * @LogType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmLogType {
 
 }

--- a/modules/asset/group/src/Plugin/Asset/AssetType/Group.php
+++ b/modules/asset/group/src/Plugin/Asset/AssetType/Group.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the group asset type.
- *
- * @AssetType(
- *   id = "group",
- *   label = @Translation("Group"),
- * )
  */
+#[AssetType(
+  id: 'group',
+  label: new TranslatableMarkup('Group'),
+)]
 class Group extends FarmAssetType {
 
 }

--- a/modules/asset/group/tests/modules/farm_group_test/src/Plugin/Asset/AssetType/Animal.php
+++ b/modules/asset/group/tests/modules/farm_group_test/src/Plugin/Asset/AssetType/Animal.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the animal asset type.
- *
- * @AssetType(
- *   id = "animal",
- *   label = @Translation("Animal"),
- * )
  */
+#[AssetType(
+  id: 'animal',
+  label: new TranslatableMarkup('Animal'),
+)]
 class Animal extends FarmAssetType {
 
 }

--- a/modules/asset/group/tests/modules/farm_group_test/src/Plugin/Asset/AssetType/Pasture.php
+++ b/modules/asset/group/tests/modules/farm_group_test/src/Plugin/Asset/AssetType/Pasture.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the pasture asset type.
- *
- * @AssetType(
- *   id = "pasture",
- *   label = @Translation("Pasture"),
- * )
  */
+#[AssetType(
+  id: 'pasture',
+  label: new TranslatableMarkup('Pasture'),
+)]
 class Pasture extends FarmAssetType {
 
 }

--- a/modules/asset/group/tests/modules/farm_group_test/src/Plugin/Log/LogType/Test.php
+++ b/modules/asset/group/tests/modules/farm_group_test/src/Plugin/Log/LogType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test log type.
- *
- * @LogType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmLogType {
 
 }

--- a/modules/asset/land/src/Plugin/Asset/AssetType/Land.php
+++ b/modules/asset/land/src/Plugin/Asset/AssetType/Land.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_land\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the land asset type.
- *
- * @AssetType(
- *   id = "land",
- *   label = @Translation("Land"),
- * )
  */
+#[AssetType(
+  id: 'land',
+  label: new TranslatableMarkup('Land'),
+)]
 class Land extends FarmAssetType {
 
   /**

--- a/modules/asset/material/src/Plugin/Asset/AssetType/Material.php
+++ b/modules/asset/material/src/Plugin/Asset/AssetType/Material.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_material\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the material asset type.
- *
- * @AssetType(
- *   id = "material",
- *   label = @Translation("Material"),
- * )
  */
+#[AssetType(
+  id: 'material',
+  label: new TranslatableMarkup('Material'),
+)]
 class Material extends FarmAssetType {
 
   /**

--- a/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
+++ b/modules/asset/plant/src/Plugin/Asset/AssetType/Plant.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_plant\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the plant asset type.
- *
- * @AssetType(
- *   id = "plant",
- *   label = @Translation("Plant"),
- * )
  */
+#[AssetType(
+  id: 'plant',
+  label: new TranslatableMarkup('Plant'),
+)]
 class Plant extends FarmAssetType {
 
   /**

--- a/modules/asset/product/src/Plugin/Asset/AssetType/Product.php
+++ b/modules/asset/product/src/Plugin/Asset/AssetType/Product.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_product\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the product asset type.
- *
- * @AssetType(
- *   id = "product",
- *   label = @Translation("Product"),
- * )
  */
+#[AssetType(
+  id: 'product',
+  label: new TranslatableMarkup('Product'),
+)]
 class Product extends FarmAssetType {
 
   /**

--- a/modules/asset/seed/src/Plugin/Asset/AssetType/Seed.php
+++ b/modules/asset/seed/src/Plugin/Asset/AssetType/Seed.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_seed\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the seed asset type.
- *
- * @AssetType(
- *   id = "seed",
- *   label = @Translation("Seed"),
- * )
  */
+#[AssetType(
+  id: 'seed',
+  label: new TranslatableMarkup('Seed'),
+)]
 class Seed extends FarmAssetType {
 
   /**

--- a/modules/asset/sensor/src/Plugin/Asset/AssetType/Sensor.php
+++ b/modules/asset/sensor/src/Plugin/Asset/AssetType/Sensor.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_sensor\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\data_stream\Entity\DataStream;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the sensor asset type.
- *
- * @AssetType(
- *   id = "sensor",
- *   label = @Translation("Sensor"),
- * )
  */
+#[AssetType(
+  id: 'sensor',
+  label: new TranslatableMarkup('Sensor'),
+)]
 class Sensor extends FarmAssetType {
 
   /**

--- a/modules/asset/structure/src/Plugin/Asset/AssetType/Structure.php
+++ b/modules/asset/structure/src/Plugin/Asset/AssetType/Structure.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_structure\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the structure asset type.
- *
- * @AssetType(
- *   id = "structure",
- *   label = @Translation("Structure"),
- * )
  */
+#[AssetType(
+  id: 'structure',
+  label: new TranslatableMarkup('Structure'),
+)]
 class Structure extends FarmAssetType {
 
   /**

--- a/modules/asset/water/src/Plugin/Asset/AssetType/Water.php
+++ b/modules/asset/water/src/Plugin/Asset/AssetType/Water.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_water\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the water asset type.
- *
- * @AssetType(
- *   id = "water",
- *   label = @Translation("Water"),
- * )
  */
+#[AssetType(
+  id: 'water',
+  label: new TranslatableMarkup('Water'),
+)]
 class Water extends FarmAssetType {
 
 }

--- a/modules/core/api/tests/modules/farm_api_test/src/Plugin/Asset/AssetType/Test.php
+++ b/modules/core/api/tests/modules/farm_api_test/src/Plugin/Asset/AssetType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_api_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the test asset type.
- *
- * @AssetType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[AssetType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmAssetType {
 
 }

--- a/modules/core/api/tests/modules/farm_api_test/src/Plugin/Log/LogType/Test.php
+++ b/modules/core/api/tests/modules/farm_api_test/src/Plugin/Log/LogType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_api_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test log type.
- *
- * @LogType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmLogType {
 
 }

--- a/modules/core/data_stream/modules/notification/src/Annotation/NotificationCondition.php
+++ b/modules/core/data_stream/modules/notification/src/Annotation/NotificationCondition.php
@@ -9,6 +9,11 @@ use Drupal\Component\Annotation\Plugin;
 /**
  * Defines a notification condition annotation object.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @Annotation
  */
 class NotificationCondition extends Plugin {

--- a/modules/core/data_stream/modules/notification/src/Annotation/NotificationDelivery.php
+++ b/modules/core/data_stream/modules/notification/src/Annotation/NotificationDelivery.php
@@ -9,6 +9,11 @@ use Drupal\Component\Annotation\Plugin;
 /**
  * Defines a notification delivery annotation object.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @Annotation
  */
 class NotificationDelivery extends Plugin {

--- a/modules/core/data_stream/modules/notification/src/Attribute/NotificationCondition.php
+++ b/modules/core/data_stream/modules/notification/src/Attribute/NotificationCondition.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\data_stream_notification\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Notification Condition plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class NotificationCondition extends Plugin {
+
+  /**
+   * Constructs a notification condition attribute.
+   *
+   * @param string $id
+   *   The notification condition ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The notification condition label.
+   * @param \Drupal\Core\Plugin\Context\ContextDefinitionInterface[] $context_definitions
+   *   (optional) An array of context definitions describing the context used by
+   *   the plugin. The array is keyed by context names.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly array $context_definitions = [],
+  ) {}
+
+}

--- a/modules/core/data_stream/modules/notification/src/Attribute/NotificationDelivery.php
+++ b/modules/core/data_stream/modules/notification/src/Attribute/NotificationDelivery.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\data_stream_notification\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Notification Delivery plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class NotificationDelivery extends Plugin {
+
+  /**
+   * Constructs a notification delivery attribute.
+   *
+   * @param string $id
+   *   The notification delivery ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The notification delivery label.
+   * @param \Drupal\Core\Plugin\Context\ContextDefinitionInterface[] $context_definitions
+   *   (optional) An array of context definitions describing the context used by
+   *   the plugin. The array is keyed by context names.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly array $context_definitions = [],
+  ) {}
+
+}

--- a/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
@@ -9,6 +9,7 @@ use Drupal\Core\Executable\ExecutableException;
 use Drupal\Core\Executable\ExecutableInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\data_stream_notification\Attribute\NotificationCondition;
 use Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition\NotificationConditionInterface;
 
 /**
@@ -33,6 +34,7 @@ class NotificationConditionManager extends DefaultPluginManager implements Notif
       $namespaces,
       $module_handler,
       'Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition\NotificationConditionInterface',
+      NotificationCondition::class,
       'Drupal\data_stream_notification\Annotation\NotificationCondition',
     );
     $this->alterInfo('data_stream_notification_condition_info');

--- a/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
@@ -13,7 +13,7 @@ use Drupal\data_stream_notification\Attribute\NotificationCondition;
 use Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition\NotificationConditionInterface;
 
 /**
- * Plugin manager for notification condition plugins.
+ * Notification Condition plugin manager.
  */
 class NotificationConditionManager extends DefaultPluginManager implements NotificationConditionManagerInterface {
 
@@ -33,7 +33,7 @@ class NotificationConditionManager extends DefaultPluginManager implements Notif
       'Plugin/DataStream/NotificationCondition',
       $namespaces,
       $module_handler,
-      'Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition\NotificationConditionInterface',
+      NotificationConditionInterface::class,
       NotificationCondition::class,
       'Drupal\data_stream_notification\Annotation\NotificationCondition',
     );

--- a/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
@@ -7,6 +7,8 @@ namespace Drupal\data_stream_notification;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\data_stream_notification\Attribute\NotificationDelivery;
+use Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\NotificationDeliveryInterface;
 
 /**
  * Plugin manager for notification delivery plugins.
@@ -30,6 +32,7 @@ class NotificationDeliveryManager extends DefaultPluginManager implements Notifi
       $namespaces,
       $module_handler,
       'Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\NotificationDeliveryInterface',
+      NotificationDelivery::class,
       'Drupal\data_stream_notification\Annotation\NotificationDelivery',
     );
     $this->alterInfo('data_stream_notification_delivery_info');

--- a/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
@@ -11,7 +11,7 @@ use Drupal\data_stream_notification\Attribute\NotificationDelivery;
 use Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\NotificationDeliveryInterface;
 
 /**
- * Plugin manager for notification delivery plugins.
+ * Notification Delivery plugin manager.
  */
 class NotificationDeliveryManager extends DefaultPluginManager implements NotificationDeliveryManagerInterface {
 
@@ -31,7 +31,7 @@ class NotificationDeliveryManager extends DefaultPluginManager implements Notifi
       'Plugin/DataStream/NotificationDelivery',
       $namespaces,
       $module_handler,
-      'Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\NotificationDeliveryInterface',
+      NotificationDeliveryInterface::class,
       NotificationDelivery::class,
       'Drupal\data_stream_notification\Annotation\NotificationDelivery',
     );

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationCondition/NumericCondition.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationCondition/NumericCondition.php
@@ -5,18 +5,20 @@ declare(strict_types=1);
 namespace Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\data_stream_notification\Attribute\NotificationCondition;
 
 /**
  * Numeric notification condition.
- *
- * @NotificationCondition(
- *   id = "numeric",
- *   label = @Translation("Numeric"),
- *   context_definitions = {
- *     "value" = @ContextDefinition("float", label = @Translation("value"))
- *   }
- * )
  */
+#[NotificationCondition(
+  id: 'numeric',
+  label: new TranslatableMarkup('Numeric'),
+  context_definitions: [
+    'value' => new ContextDefinition('float', label: new TranslatableMarkup('value')),
+  ],
+)]
 class NumericCondition extends NotificationConditionBase {
 
   /**

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
@@ -8,22 +8,25 @@ use Drupal\Component\Utility\EmailValidatorInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\data_stream_notification\Attribute\NotificationDelivery;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Email notification delivery.
- *
- * @NotificationDelivery(
- *   id = "email",
- *   label = @Translation("Email"),
- *   context_definitions = {
- *     "value" = @ContextDefinition("float", label = @Translation("value")),
- *     "data_stream" = @ContextDefinition("entity:data_stream", label = @Translation("Data stream")),
- *     "data_stream_notification" = @ContextDefinition("entity:data_stream_notification", label = @Translation("Data stream notification")),
- *     "condition_summaries" = @ContextDefinition("list", label = @Translation("Condition summaries"))
- *   }
- * )
  */
+#[NotificationDelivery(
+  id: 'email',
+  label: new TranslatableMarkup('Email'),
+  context_definitions: [
+    'value' => new ContextDefinition('float', label: new TranslatableMarkup('value')),
+    'data_stream' => new EntityContextDefinition('data_stream', new TranslatableMarkup('Data stream')),
+    'data_stream_notification' => new EntityContextDefinition('data_stream_notification', new TranslatableMarkup('Data stream notification')),
+    'condition_summaries' => new ContextDefinition('list', label: new TranslatableMarkup('Condition summaries')),
+  ]
+)]
 class Email extends NotificationDeliveryBase implements ContainerFactoryPluginInterface {
 
   /**

--- a/modules/core/data_stream/modules/notification/tests/modules/data_stream_notification_test/src/Plugin/DataStream/NotificationDelivery/Error.php
+++ b/modules/core/data_stream/modules/notification/tests/modules/data_stream_notification_test/src/Plugin/DataStream/NotificationDelivery/Error.php
@@ -4,23 +4,26 @@ declare(strict_types=1);
 
 namespace Drupal\data_stream_notification_test\Plugin\DataStream\NotificationDelivery;
 
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Plugin\Context\EntityContextDefinition;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\data_stream_notification\Attribute\NotificationDelivery;
 use Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\NotificationDeliveryBase;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * Delivery plugin for testing that raises an error.
- *
- * @NotificationDelivery(
- *   id = "error",
- *   label = @Translation("Error"),
- *   context_definitions = {
- *     "value" = @ContextDefinition("float", label = @Translation("value")),
- *     "data_stream" = @ContextDefinition("entity:data_stream", label = @Translation("Data stream")),
- *     "data_stream_notification" = @ContextDefinition("entity:data_stream_notification", label = @Translation("Data stream notification")),
- *     "condition_summaries" = @ContextDefinition("list", label = @Translation("Condition summaries"))
- *   }
- * )
  */
+#[NotificationDelivery(
+  id: 'error',
+  label: new TranslatableMarkup('Error'),
+  context_definitions: [
+    'value' => new ContextDefinition('float', label: new TranslatableMarkup('value')),
+    'data_stream' => new EntityContextDefinition('data_stream', new TranslatableMarkup('Data stream')),
+    'data_stream_notification' => new EntityContextDefinition('data_stream_notification', new TranslatableMarkup('Data stream notification')),
+    'condition_summaries' => new ContextDefinition('list', label: new TranslatableMarkup('Condition summaries')),
+  ],
+)]
 class Error extends NotificationDeliveryBase {
 
   /**

--- a/modules/core/data_stream/src/Annotation/DataStreamType.php
+++ b/modules/core/data_stream/src/Annotation/DataStreamType.php
@@ -11,6 +11,11 @@ use Drupal\Component\Annotation\Plugin;
  *
  * Plugin namespace: Plugin\DataStream\DataStreamType.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @see plugin_api
  *
  * @Annotation

--- a/modules/core/data_stream/src/Attribute/DataStreamType.php
+++ b/modules/core/data_stream/src/Attribute/DataStreamType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\data_stream\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Data Stream Type plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class DataStreamType extends Plugin {
+
+  /**
+   * Constructs a data stream type attribute.
+   *
+   * @param string $id
+   *   The data stream type ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The data stream type label.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+  ) {}
+
+}

--- a/modules/core/data_stream/src/DataStreamTypeManager.php
+++ b/modules/core/data_stream/src/DataStreamTypeManager.php
@@ -8,12 +8,10 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\data_stream\Attribute\DataStreamType;
 
 /**
  * Manages discovery and instantiation of data stream type plugins.
- *
- * @see \Drupal\data_stream\Annotation\DataStreamType
- * @see plugin_api
  */
 class DataStreamTypeManager extends DefaultPluginManager {
 
@@ -29,7 +27,7 @@ class DataStreamTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/DataStream/DataStreamType', $namespaces, $module_handler, 'Drupal\data_stream\Plugin\DataStream\DataStreamType\DataStreamTypeInterface', 'Drupal\data_stream\Annotation\DataStreamType');
+    parent::__construct('Plugin/DataStream/DataStreamType', $namespaces, $module_handler, 'Drupal\data_stream\Plugin\DataStream\DataStreamType\DataStreamTypeInterface', DataStreamType::class, 'Drupal\data_stream\Annotation\DataStreamType');
 
     $this->alterInfo('data_stream_type_info');
     $this->setCacheBackend($cache_backend, 'data_stream_type_plugins');

--- a/modules/core/data_stream/src/DataStreamTypeManager.php
+++ b/modules/core/data_stream/src/DataStreamTypeManager.php
@@ -9,9 +9,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\data_stream\Attribute\DataStreamType;
+use Drupal\data_stream\Plugin\DataStream\DataStreamType\DataStreamTypeInterface;
 
 /**
- * Manages discovery and instantiation of data stream type plugins.
+ * Data Stream Type plugin manager.
  */
 class DataStreamTypeManager extends DefaultPluginManager {
 
@@ -27,8 +28,14 @@ class DataStreamTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/DataStream/DataStreamType', $namespaces, $module_handler, 'Drupal\data_stream\Plugin\DataStream\DataStreamType\DataStreamTypeInterface', DataStreamType::class, 'Drupal\data_stream\Annotation\DataStreamType');
-
+    parent::__construct(
+      'Plugin/DataStream/DataStreamType',
+      $namespaces,
+      $module_handler,
+      DataStreamTypeInterface::class,
+      DataStreamType::class,
+      'Drupal\data_stream\Annotation\DataStreamType',
+    );
     $this->alterInfo('data_stream_type_info');
     $this->setCacheBackend($cache_backend, 'data_stream_type_plugins');
   }

--- a/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
+++ b/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
@@ -7,6 +7,8 @@ namespace Drupal\data_stream\Plugin\DataStream\DataStreamType;
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\data_stream\Attribute\DataStreamType;
 use Drupal\data_stream\DataStreamApiInterface;
 use Drupal\data_stream\DataStreamEventDispatcherInterface;
 use Drupal\data_stream\DataStreamStorageInterface;
@@ -26,12 +28,11 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 /**
  * Provides the basic data stream type.
- *
- * @DataStreamType(
- *   id = "basic",
- *   label = @Translation("Basic"),
- * )
  */
+#[DataStreamType(
+  id: 'basic',
+  label: new TranslatableMarkup('Basic'),
+)]
 class Basic extends DataStreamTypeBase implements DataStreamStorageInterface, DataStreamApiInterface, DataStreamEventDispatcherInterface {
 
   use DataStreamPrivateKeyAccess;

--- a/modules/core/entity/src/Annotation/AssetType.php
+++ b/modules/core/entity/src/Annotation/AssetType.php
@@ -11,6 +11,11 @@ use Drupal\Component\Annotation\Plugin;
  *
  * Plugin namespace: Plugin\Asset\AssetType.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @see plugin_api
  *
  * @Annotation

--- a/modules/core/entity/src/Annotation/LogType.php
+++ b/modules/core/entity/src/Annotation/LogType.php
@@ -11,6 +11,11 @@ use Drupal\Component\Annotation\Plugin;
  *
  * Plugin namespace: Plugin\Log\LogType.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @see plugin_api
  *
  * @Annotation

--- a/modules/core/entity/src/Annotation/PlanRecordType.php
+++ b/modules/core/entity/src/Annotation/PlanRecordType.php
@@ -11,6 +11,11 @@ use Drupal\Component\Annotation\Plugin;
  *
  * Plugin namespace: Plugin\PlanRecord\PlanRecordType.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @see plugin_api
  *
  * @Annotation

--- a/modules/core/entity/src/Annotation/PlanType.php
+++ b/modules/core/entity/src/Annotation/PlanType.php
@@ -11,6 +11,11 @@ use Drupal\Component\Annotation\Plugin;
  *
  * Plugin namespace: Plugin\Plan\PlanType.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @see plugin_api
  *
  * @Annotation

--- a/modules/core/entity/src/Annotation/QuantityType.php
+++ b/modules/core/entity/src/Annotation/QuantityType.php
@@ -11,6 +11,11 @@ use Drupal\Component\Annotation\Plugin;
  *
  * Plugin namespace: Plugin\Quantity\QuantityType.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @see plugin_api
  *
  * @Annotation

--- a/modules/core/entity/src/AssetTypeManager.php
+++ b/modules/core/entity/src/AssetTypeManager.php
@@ -8,6 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_entity\Attribute\AssetType;
 
 /**
  * Manages discovery and instantiation of asset type plugins.
@@ -29,7 +30,7 @@ class AssetTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Asset/AssetType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Asset\AssetType\AssetTypeInterface', 'Drupal\farm_entity\Annotation\AssetType');
+    parent::__construct('Plugin/Asset/AssetType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Asset\AssetType\AssetTypeInterface', AssetType::class, 'Drupal\farm_entity\Annotation\AssetType');
 
     $this->alterInfo('asset_type_info');
     $this->setCacheBackend($cache_backend, 'asset_type_plugins');

--- a/modules/core/entity/src/AssetTypeManager.php
+++ b/modules/core/entity/src/AssetTypeManager.php
@@ -9,12 +9,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\farm_entity\Attribute\AssetType;
+use Drupal\farm_entity\Plugin\Asset\AssetType\AssetTypeInterface;
 
 /**
- * Manages discovery and instantiation of asset type plugins.
- *
- * @see \Drupal\farm_entity\Annotation\AssetType
- * @see plugin_api
+ * Asset Type plugin manager.
  */
 class AssetTypeManager extends DefaultPluginManager {
 
@@ -30,8 +28,14 @@ class AssetTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Asset/AssetType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Asset\AssetType\AssetTypeInterface', AssetType::class, 'Drupal\farm_entity\Annotation\AssetType');
-
+    parent::__construct(
+      'Plugin/Asset/AssetType',
+      $namespaces,
+      $module_handler,
+      AssetTypeInterface::class,
+      AssetType::class,
+      'Drupal\farm_entity\Annotation\AssetType',
+    );
     $this->alterInfo('asset_type_info');
     $this->setCacheBackend($cache_backend, 'asset_type_plugins');
   }

--- a/modules/core/entity/src/Attribute/AssetType.php
+++ b/modules/core/entity/src/Attribute/AssetType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Asset Type plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class AssetType extends Plugin {
+
+  /**
+   * Constructs an asset type attribute.
+   *
+   * @param string $id
+   *   The asset type ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The asset type label.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+  ) {}
+
+}

--- a/modules/core/entity/src/Attribute/LogType.php
+++ b/modules/core/entity/src/Attribute/LogType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Log Type plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class LogType extends Plugin {
+
+  /**
+   * Constructs a log type attribute.
+   *
+   * @param string $id
+   *   The log type ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The log type label.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+  ) {}
+
+}

--- a/modules/core/entity/src/Attribute/PlanRecordType.php
+++ b/modules/core/entity/src/Attribute/PlanRecordType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Plan Record Type plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class PlanRecordType extends Plugin {
+
+  /**
+   * Constructs a plan record type attribute.
+   *
+   * @param string $id
+   *   The plan record type ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The plan record type label.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+  ) {}
+
+}

--- a/modules/core/entity/src/Attribute/PlanType.php
+++ b/modules/core/entity/src/Attribute/PlanType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Plan Type plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class PlanType extends Plugin {
+
+  /**
+   * Constructs a plan type attribute.
+   *
+   * @param string $id
+   *   The plan type ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The plan type label.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+  ) {}
+
+}

--- a/modules/core/entity/src/Attribute/QuantityType.php
+++ b/modules/core/entity/src/Attribute/QuantityType.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Quantity Type plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class QuantityType extends Plugin {
+
+  /**
+   * Constructs a quantity type attribute.
+   *
+   * @param string $id
+   *   The quantity type ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The quantity type label.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+  ) {}
+
+}

--- a/modules/core/entity/src/LogTypeManager.php
+++ b/modules/core/entity/src/LogTypeManager.php
@@ -8,6 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_entity\Attribute\LogType;
 
 /**
  * Manages discovery and instantiation of log type plugins.
@@ -29,7 +30,7 @@ class LogTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Log/LogType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Log\LogType\LogTypeInterface', 'Drupal\farm_entity\Annotation\LogType');
+    parent::__construct('Plugin/Log/LogType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Log\LogType\LogTypeInterface', LogType::class, 'Drupal\farm_entity\Annotation\LogType');
 
     $this->alterInfo('log_type_info');
     $this->setCacheBackend($cache_backend, 'log_type_plugins');

--- a/modules/core/entity/src/LogTypeManager.php
+++ b/modules/core/entity/src/LogTypeManager.php
@@ -9,12 +9,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\farm_entity\Attribute\LogType;
+use Drupal\farm_entity\Plugin\Log\LogType\LogTypeInterface;
 
 /**
- * Manages discovery and instantiation of log type plugins.
- *
- * @see \Drupal\farm_entity\Annotation\LogType
- * @see plugin_api
+ * Log Type plugin manager.
  */
 class LogTypeManager extends DefaultPluginManager {
 
@@ -30,8 +28,14 @@ class LogTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Log/LogType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Log\LogType\LogTypeInterface', LogType::class, 'Drupal\farm_entity\Annotation\LogType');
-
+    parent::__construct(
+      'Plugin/Log/LogType',
+      $namespaces,
+      $module_handler,
+      LogTypeInterface::class,
+      LogType::class,
+      'Drupal\farm_entity\Annotation\LogType',
+    );
     $this->alterInfo('log_type_info');
     $this->setCacheBackend($cache_backend, 'log_type_plugins');
   }

--- a/modules/core/entity/src/PlanRecordTypeManager.php
+++ b/modules/core/entity/src/PlanRecordTypeManager.php
@@ -8,6 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_entity\Attribute\PlanRecordType;
 
 /**
  * Manages discovery and instantiation of plan record relationship type plugins.
@@ -29,7 +30,7 @@ class PlanRecordTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/PlanRecord/PlanRecordType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\PlanRecord\PlanRecordType\PlanRecordTypeInterface', 'Drupal\farm_entity\Annotation\PlanRecordType');
+    parent::__construct('Plugin/PlanRecord/PlanRecordType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\PlanRecord\PlanRecordType\PlanRecordTypeInterface', PlanRecordType::class, 'Drupal\farm_entity\Annotation\PlanRecordType');
 
     $this->alterInfo('plan_record_type_info');
     $this->setCacheBackend($cache_backend, 'plan_record_type_plugins');

--- a/modules/core/entity/src/PlanRecordTypeManager.php
+++ b/modules/core/entity/src/PlanRecordTypeManager.php
@@ -9,12 +9,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\farm_entity\Attribute\PlanRecordType;
+use Drupal\farm_entity\Plugin\PlanRecord\PlanRecordType\PlanRecordTypeInterface;
 
 /**
- * Manages discovery and instantiation of plan record relationship type plugins.
- *
- * @see \Drupal\farm_entity\Annotation\PlanType
- * @see plugin_api
+ * Plan Record Type plugin manager.
  */
 class PlanRecordTypeManager extends DefaultPluginManager {
 
@@ -30,8 +28,14 @@ class PlanRecordTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/PlanRecord/PlanRecordType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\PlanRecord\PlanRecordType\PlanRecordTypeInterface', PlanRecordType::class, 'Drupal\farm_entity\Annotation\PlanRecordType');
-
+    parent::__construct(
+      'Plugin/PlanRecord/PlanRecordType',
+      $namespaces,
+      $module_handler,
+      PlanRecordTypeInterface::class,
+      PlanRecordType::class,
+      'Drupal\farm_entity\Annotation\PlanRecordType',
+    );
     $this->alterInfo('plan_record_type_info');
     $this->setCacheBackend($cache_backend, 'plan_record_type_plugins');
   }

--- a/modules/core/entity/src/PlanTypeManager.php
+++ b/modules/core/entity/src/PlanTypeManager.php
@@ -8,6 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_entity\Attribute\PlanType;
 
 /**
  * Manages discovery and instantiation of plan type plugins.
@@ -29,7 +30,7 @@ class PlanTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Plan/PlanType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Plan\PlanType\PlanTypeInterface', 'Drupal\farm_entity\Annotation\PlanType');
+    parent::__construct('Plugin/Plan/PlanType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Plan\PlanType\PlanTypeInterface', PlanType::class, 'Drupal\farm_entity\Annotation\PlanType');
 
     $this->alterInfo('plan_type_info');
     $this->setCacheBackend($cache_backend, 'plan_type_plugins');

--- a/modules/core/entity/src/PlanTypeManager.php
+++ b/modules/core/entity/src/PlanTypeManager.php
@@ -9,12 +9,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\farm_entity\Attribute\PlanType;
+use Drupal\farm_entity\Plugin\Plan\PlanType\PlanTypeInterface;
 
 /**
- * Manages discovery and instantiation of plan type plugins.
- *
- * @see \Drupal\farm_entity\Annotation\PlanType
- * @see plugin_api
+ * Plan Type plugin manager.
  */
 class PlanTypeManager extends DefaultPluginManager {
 
@@ -30,8 +28,14 @@ class PlanTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Plan/PlanType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Plan\PlanType\PlanTypeInterface', PlanType::class, 'Drupal\farm_entity\Annotation\PlanType');
-
+    parent::__construct(
+      'Plugin/Plan/PlanType',
+      $namespaces,
+      $module_handler,
+      PlanTypeInterface::class,
+      PlanType::class,
+      'Drupal\farm_entity\Annotation\PlanType',
+    );
     $this->alterInfo('plan_type_info');
     $this->setCacheBackend($cache_backend, 'plan_type_plugins');
   }

--- a/modules/core/entity/src/QuantityTypeManager.php
+++ b/modules/core/entity/src/QuantityTypeManager.php
@@ -8,6 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_entity\Attribute\QuantityType;
 
 /**
  * Manages discovery and instantiation of quantity type plugins.
@@ -29,7 +30,7 @@ class QuantityTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Quantity/QuantityType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Quantity\QuantityType\QuantityTypeInterface', 'Drupal\farm_entity\Annotation\QuantityType');
+    parent::__construct('Plugin/Quantity/QuantityType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Quantity\QuantityType\QuantityTypeInterface', QuantityType::class, 'Drupal\farm_entity\Annotation\QuantityType');
 
     $this->alterInfo('quantity_type_info');
     $this->setCacheBackend($cache_backend, 'quantity_type_plugins');

--- a/modules/core/entity/src/QuantityTypeManager.php
+++ b/modules/core/entity/src/QuantityTypeManager.php
@@ -9,12 +9,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\farm_entity\Attribute\QuantityType;
+use Drupal\farm_entity\Plugin\Quantity\QuantityType\QuantityTypeInterface;
 
 /**
- * Manages discovery and instantiation of quantity type plugins.
- *
- * @see \Drupal\farm_entity\Annotation\QuantityType
- * @see plugin_api
+ * Quantity Type plugin manager.
  */
 class QuantityTypeManager extends DefaultPluginManager {
 
@@ -30,8 +28,14 @@ class QuantityTypeManager extends DefaultPluginManager {
    *   The module handler.
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Quantity/QuantityType', $namespaces, $module_handler, 'Drupal\farm_entity\Plugin\Quantity\QuantityType\QuantityTypeInterface', QuantityType::class, 'Drupal\farm_entity\Annotation\QuantityType');
-
+    parent::__construct(
+      'Plugin/Quantity/QuantityType',
+      $namespaces,
+      $module_handler,
+      QuantityTypeInterface::class,
+      QuantityType::class,
+      'Drupal\farm_entity\Annotation\QuantityType',
+    );
     $this->alterInfo('quantity_type_info');
     $this->setCacheBackend($cache_backend, 'quantity_type_plugins');
   }

--- a/modules/core/entity/tests/modules/farm_entity_bundle_fields_test/src/Plugin/Plan/PlanType/Second.php
+++ b/modules/core/entity/tests/modules/farm_entity_bundle_fields_test/src/Plugin/Plan/PlanType/Second.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_bundle_fields_test\Plugin\Plan\PlanType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\BundleFieldDefinition;
+use Drupal\farm_entity\Attribute\PlanType;
 use Drupal\farm_entity\Plugin\Plan\PlanType\FarmPlanType;
 
 /**
  * Provides the second test plan type.
- *
- * @PlanType(
- *   id = "second",
- *   label = @Translation("Second"),
- * )
  */
+#[PlanType(
+  id: 'second',
+  label: new TranslatableMarkup('Second'),
+)]
 class Second extends FarmPlanType {
 
   /**

--- a/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Asset/AssetType/Test.php
+++ b/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Asset/AssetType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the test asset type.
- *
- * @AssetType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[AssetType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmAssetType {
 
 }

--- a/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Log/LogType/Test.php
+++ b/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Log/LogType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test log type.
- *
- * @LogType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmLogType {
 
   /**

--- a/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Log/LogType/TestOverride.php
+++ b/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Log/LogType/TestOverride.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
+
 /**
  * Provides the test_override log type.
- *
- * @LogType(
- *   id = "test_override",
- *   label = @Translation("Test Override"),
- * )
  */
+#[LogType(
+  id: 'test_override',
+  label: new TranslatableMarkup('Test Override'),
+)]
 class TestOverride extends Test {
 
   /**

--- a/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Plan/PlanType/Test.php
+++ b/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Plan/PlanType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_test\Plugin\Plan\PlanType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\PlanType;
 use Drupal\farm_entity\Plugin\Plan\PlanType\FarmPlanType;
 
 /**
  * Provides the test plan type.
- *
- * @PlanType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[PlanType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmPlanType {
 
 }

--- a/modules/core/location/tests/modules/farm_location_test/src/Plugin/Asset/AssetType/Location.php
+++ b/modules/core/location/tests/modules/farm_location_test/src/Plugin/Asset/AssetType/Location.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the test location asset type.
- *
- * @AssetType(
- *   id = "location",
- *   label = @Translation("Location"),
- * )
  */
+#[AssetType(
+  id: 'location',
+  label: new TranslatableMarkup('Location'),
+)]
 class Location extends FarmAssetType {
 
 }

--- a/modules/core/location/tests/modules/farm_location_test/src/Plugin/Asset/AssetType/ObjectAssetType.php
+++ b/modules/core/location/tests/modules/farm_location_test/src/Plugin/Asset/AssetType/ObjectAssetType.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the test object asset type.
- *
- * @AssetType(
- *   id = "object",
- *   label = @Translation("Object"),
- * )
  */
+#[AssetType(
+  id: 'object',
+  label: new TranslatableMarkup('Object'),
+)]
 class ObjectAssetType extends FarmAssetType {
 
 }

--- a/modules/core/location/tests/modules/farm_location_test/src/Plugin/Log/LogType/Activity.php
+++ b/modules/core/location/tests/modules/farm_location_test/src/Plugin/Log/LogType/Activity.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test activity log type.
- *
- * @LogType(
- *   id = "activity",
- *   label = @Translation("Activity"),
- * )
  */
+#[LogType(
+  id: 'activity',
+  label: new TranslatableMarkup('Activity'),
+)]
 class Activity extends FarmLogType {
 
 }

--- a/modules/core/location/tests/modules/farm_location_test/src/Plugin/Log/LogType/Movement.php
+++ b/modules/core/location/tests/modules/farm_location_test/src/Plugin/Log/LogType/Movement.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test movement log type.
- *
- * @LogType(
- *   id = "movement",
- *   label = @Translation("Movement"),
- * )
  */
+#[LogType(
+  id: 'movement',
+  label: new TranslatableMarkup('Movement'),
+)]
 class Movement extends FarmLogType {
 
 }

--- a/modules/core/map/tests/modules/farm_map_test/src/Plugin/Log/LogType/Test.php
+++ b/modules/core/map/tests/modules/farm_map_test/src/Plugin/Log/LogType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_map_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test log type.
- *
- * @LogType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmLogType {
 
 }

--- a/modules/core/map/tests/modules/farm_map_test/src/Plugin/QuickForm/Test.php
+++ b/modules/core/map/tests/modules/farm_map_test/src/Plugin/QuickForm/Test.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Drupal\farm_map_test\Plugin\QuickForm;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickLogTrait;
 
 /**
  * Test quick form.
- *
- * @QuickForm(
- *   id = "test",
- *   label = @Translation("Test quick form"),
- *   description = @Translation("Test quick form description."),
- *   helpText = @Translation("Test quick form help text."),
- *   permissions = {
- *     "create test log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'test',
+  label: new TranslatableMarkup('Test quick form'),
+  description: new TranslatableMarkup('Test quick form description.'),
+  helpText: new TranslatableMarkup('Test quick form help text.'),
+  permissions: [
+    'create test log',
+  ],
+)]
 class Test extends QuickFormBase {
 
   use QuickLogTrait;

--- a/modules/core/quick/src/Annotation/QuickForm.php
+++ b/modules/core/quick/src/Annotation/QuickForm.php
@@ -9,6 +9,11 @@ use Drupal\Component\Annotation\Plugin;
 /**
  * Defines a quick form annotation object.
  *
+ * @deprecated in farm:4.0.0 and is removed from farm:5.0.0.
+ *   Use Attributes moving forward.
+ * @see https://www.drupal.org/node/3523485
+ * @see https://www.drupal.org/project/farm/issues/3461548
+ *
  * @Annotation
  */
 class QuickForm extends Plugin {

--- a/modules/core/quick/src/Attribute/QuickForm.php
+++ b/modules/core/quick/src/Attribute/QuickForm.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_quick\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The Quick Form plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class QuickForm extends Plugin {
+
+  /**
+   * Constructs a quick form attribute.
+   *
+   * @param string $id
+   *   The quick form ID.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
+   *   The quick form label.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $description
+   *   The quick form description.
+   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $helpText
+   *   The quick form help text.
+   * @param string[] $permissions
+   *   An array of access permissions for the quick form.
+   * @param bool $requiresEntity
+   *   Require a quick form instance entity to instantiate.
+   */
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $label,
+    public readonly ?TranslatableMarkup $description = NULL,
+    public readonly ?TranslatableMarkup $helpText = NULL,
+    public readonly array $permissions = [],
+    public readonly bool $requiresEntity = FALSE,
+  ) {}
+
+}

--- a/modules/core/quick/src/QuickFormPluginManager.php
+++ b/modules/core/quick/src/QuickFormPluginManager.php
@@ -7,6 +7,7 @@ namespace Drupal\farm_quick;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_quick\Attribute\QuickForm;
 
 /**
  * Quick form manager class.
@@ -30,6 +31,7 @@ class QuickFormPluginManager extends DefaultPluginManager {
       $namespaces,
       $module_handler,
       'Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface',
+      QuickForm::class,
       'Drupal\farm_quick\Annotation\QuickForm'
     );
     $this->alterInfo('quick_form_info');

--- a/modules/core/quick/src/QuickFormPluginManager.php
+++ b/modules/core/quick/src/QuickFormPluginManager.php
@@ -8,9 +8,10 @@ use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\farm_quick\Attribute\QuickForm;
+use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
 
 /**
- * Quick form manager class.
+ * Quick Form plugin manager.
  */
 class QuickFormPluginManager extends DefaultPluginManager {
 
@@ -30,7 +31,7 @@ class QuickFormPluginManager extends DefaultPluginManager {
       'Plugin/QuickForm',
       $namespaces,
       $module_handler,
-      'Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface',
+      QuickFormInterface::class,
       QuickForm::class,
       'Drupal\farm_quick\Annotation\QuickForm'
     );

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Asset/AssetType/Test.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Asset/AssetType/Test.php
@@ -4,17 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_test\Plugin\Asset\AssetType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\BundleFieldDefinition;
+use Drupal\farm_entity\Attribute\AssetType;
 use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
 
 /**
  * Provides the test asset type.
- *
- * @AssetType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[AssetType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmAssetType {
 
   /**

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Log/LogType/Test.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Log/LogType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the test log type.
- *
- * @LogType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmLogType {
 
 }

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Quantity/QuantityType/Test.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Quantity/QuantityType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_test\Plugin\Quantity\QuantityType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\QuantityType;
 use Drupal\farm_entity\Plugin\Quantity\QuantityType\FarmQuantityType;
 
 /**
  * Provides the test quantity type.
- *
- * @QuantityType(
- *   id = "test",
- *   label = @Translation("Test"),
- * )
  */
+#[QuantityType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmQuantityType {
 
 }

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Quantity/QuantityType/Test2.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/Quantity/QuantityType/Test2.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_test\Plugin\Quantity\QuantityType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\QuantityType;
 use Drupal\farm_entity\Plugin\Quantity\QuantityType\FarmQuantityType;
 
 /**
  * Provides the test2 quantity type.
- *
- * @QuantityType(
- *   id = "test2",
- *   label = @Translation("Test2"),
- * )
  */
+#[QuantityType(
+  id: 'test2',
+  label: new TranslatableMarkup('Test2'),
+)]
 class Test2 extends FarmQuantityType {
 
 }

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/ConfigurableTest.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/ConfigurableTest.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Drupal\farm_quick_test\Plugin\QuickForm;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
 use Drupal\farm_quick\Traits\ConfigurableQuickFormTrait;
 
 /**
  * Test configurable quick form.
- *
- * @QuickForm(
- *   id = "configurable_test",
- *   label = @Translation("Test configurable quick form"),
- *   description = @Translation("Test configurable quick form description."),
- *   helpText = @Translation("Test configurable quick form help text."),
- *   permissions = {
- *     "create test log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'configurable_test',
+  label: new TranslatableMarkup('Test configurable quick form'),
+  description: new TranslatableMarkup('Test configurable quick form description.'),
+  helpText: new TranslatableMarkup('Test configurable quick form help text.'),
+  permissions: [
+    'create test log',
+  ],
+)]
 class ConfigurableTest extends Test implements ConfigurableQuickFormInterface {
 
   use ConfigurableQuickFormTrait;

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/RequiresEntityTest.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/RequiresEntityTest.php
@@ -4,20 +4,22 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_test\Plugin\QuickForm;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
+
 /**
  * Test quick form that requires a configuration entity.
- *
- * @QuickForm(
- *   id = "requires_entity_test",
- *   label = @Translation("Test requiresEntity quick form"),
- *   description = @Translation("Test requiresEntity quick form description."),
- *   helpText = @Translation("Test requiresEntity quick form help text."),
- *   permissions = {
- *     "create test log",
- *   },
- *   requiresEntity = True
- * )
  */
+#[QuickForm(
+  id: 'requires_entity_test',
+  label: new TranslatableMarkup('Test requiresEntity quick form'),
+  description: new TranslatableMarkup('Test requiresEntity quick form description.'),
+  helpText: new TranslatableMarkup('Test requiresEntity quick form help text.'),
+  permissions: [
+    'create test log',
+  ],
+  requiresEntity: TRUE,
+)]
 class RequiresEntityTest extends Test {
 
 }

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/Test.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/Test.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\farm_quick_test\Plugin\QuickForm;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickAssetTrait;
 use Drupal\farm_quick\Traits\QuickLogTrait;
@@ -13,17 +15,16 @@ use Drupal\farm_quick\Traits\QuickTermTrait;
 
 /**
  * Test quick form.
- *
- * @QuickForm(
- *   id = "test",
- *   label = @Translation("Test quick form"),
- *   description = @Translation("Test quick form description."),
- *   helpText = @Translation("Test quick form help text."),
- *   permissions = {
- *     "create test log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'test',
+  label: new TranslatableMarkup('Test quick form'),
+  description: new TranslatableMarkup('Test quick form description.'),
+  helpText: new TranslatableMarkup('Test quick form help text.'),
+  permissions: [
+    'create test log',
+  ],
+)]
 class Test extends QuickFormBase {
 
   use QuickAssetTrait;

--- a/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/TestEntityValidation.php
+++ b/modules/core/quick/tests/modules/farm_quick_test/src/Plugin/QuickForm/TestEntityValidation.php
@@ -5,22 +5,23 @@ declare(strict_types=1);
 namespace Drupal\farm_quick_test\Plugin\QuickForm;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickAssetTrait;
 
 /**
  * Test Entity Validation quick form.
- *
- * @QuickForm(
- *   id = "test_entity_validation",
- *   label = @Translation("Test entity validation quick form"),
- *   description = @Translation("Test entity validation quick form description."),
- *   helpText = @Translation("Test entity validation quick form help text."),
- *   permissions = {
- *     "create test log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'test_entity_validation',
+  label: new TranslatableMarkup('Test entity validation quick form'),
+  description: new TranslatableMarkup('Test entity validation quick form description.'),
+  helpText: new TranslatableMarkup('Test entity validation quick form help text.'),
+  permissions: [
+    'create test log',
+  ],
+)]
 class TestEntityValidation extends QuickFormBase {
 
   use QuickAssetTrait;

--- a/modules/log/activity/src/Plugin/Log/LogType/Activity.php
+++ b/modules/log/activity/src/Plugin/Log/LogType/Activity.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_activity\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the activity log type.
- *
- * @LogType(
- *   id = "activity",
- *   label = @Translation("Activity"),
- * )
  */
+#[LogType(
+  id: 'activity',
+  label: new TranslatableMarkup('Activity'),
+)]
 class Activity extends FarmLogType {
 
 }

--- a/modules/log/birth/src/Plugin/Log/LogType/Birth.php
+++ b/modules/log/birth/src/Plugin/Log/LogType/Birth.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_birth\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the birth log type.
- *
- * @LogType(
- *   id = "birth",
- *   label = @Translation("Birth"),
- * )
  */
+#[LogType(
+  id: 'birth',
+  label: new TranslatableMarkup('Birth'),
+)]
 class Birth extends FarmLogType {
 
   /**

--- a/modules/log/harvest/src/Plugin/Log/LogType/Harvest.php
+++ b/modules/log/harvest/src/Plugin/Log/LogType/Harvest.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_harvest\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the harvest log type.
- *
- * @LogType(
- *   id = "harvest",
- *   label = @Translation("Harvest"),
- * )
  */
+#[LogType(
+  id: 'harvest',
+  label: new TranslatableMarkup('Harvest'),
+)]
 class Harvest extends FarmLogType {
 
   /**

--- a/modules/log/input/src/Plugin/Log/LogType/Input.php
+++ b/modules/log/input/src/Plugin/Log/LogType/Input.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_input\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the input log type.
- *
- * @LogType(
- *   id = "input",
- *   label = @Translation("Input"),
- * )
  */
+#[LogType(
+  id: 'input',
+  label: new TranslatableMarkup('Input'),
+)]
 class Input extends FarmLogType {
 
   /**

--- a/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
+++ b/modules/log/lab_test/src/Plugin/Log/LogType/LabTest.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_lab_test\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the lab test log type.
- *
- * @LogType(
- *   id = "lab_test",
- *   label = @Translation("LabTest"),
- * )
  */
+#[LogType(
+  id: 'lab_test',
+  label: new TranslatableMarkup('LabTest'),
+)]
 class LabTest extends FarmLogType {
 
   /**

--- a/modules/log/maintenance/src/Plugin/Log/LogType/Maintenance.php
+++ b/modules/log/maintenance/src/Plugin/Log/LogType/Maintenance.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_maintenance\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the maintenance log type.
- *
- * @LogType(
- *   id = "maintenance",
- *   label = @Translation("Maintenance"),
- * )
  */
+#[LogType(
+  id: 'maintenance',
+  label: new TranslatableMarkup('Maintenance'),
+)]
 class Maintenance extends FarmLogType {
 
 }

--- a/modules/log/medical/src/Plugin/Log/LogType/Medical.php
+++ b/modules/log/medical/src/Plugin/Log/LogType/Medical.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_medical\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the medical log type.
- *
- * @LogType(
- *   id = "medical",
- *   label = @Translation("Medical"),
- * )
  */
+#[LogType(
+  id: 'medical',
+  label: new TranslatableMarkup('Medical'),
+)]
 class Medical extends FarmLogType {
 
   /**

--- a/modules/log/observation/src/Plugin/Log/LogType/Observation.php
+++ b/modules/log/observation/src/Plugin/Log/LogType/Observation.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_observation\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the observation log type.
- *
- * @LogType(
- *   id = "observation",
- *   label = @Translation("Observation"),
- * )
  */
+#[LogType(
+  id: 'observation',
+  label: new TranslatableMarkup('Observation'),
+)]
 class Observation extends FarmLogType {
 
 }

--- a/modules/log/seeding/src/Plugin/Log/LogType/Seeding.php
+++ b/modules/log/seeding/src/Plugin/Log/LogType/Seeding.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_seeding\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the seeding log type.
- *
- * @LogType(
- *   id = "seeding",
- *   label = @Translation("Seeding"),
- * )
  */
+#[LogType(
+  id: 'seeding',
+  label: new TranslatableMarkup('Seeding'),
+)]
 class Seeding extends FarmLogType {
 
   /**

--- a/modules/log/transplanting/src/Plugin/Log/LogType/Transplanting.php
+++ b/modules/log/transplanting/src/Plugin/Log/LogType/Transplanting.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_transplanting\Plugin\Log\LogType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
 use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
 
 /**
  * Provides the transplanting log type.
- *
- * @LogType(
- *   id = "transplanting",
- *   label = @Translation("Transplanting"),
- * )
  */
+#[LogType(
+  id: 'transplanting',
+  label: new TranslatableMarkup('Transplanting'),
+)]
 class Transplanting extends FarmLogType {
 
 }

--- a/modules/quantity/material/src/Plugin/Quantity/QuantityType/Material.php
+++ b/modules/quantity/material/src/Plugin/Quantity/QuantityType/Material.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quantity_material\Plugin\Quantity\QuantityType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\QuantityType;
 use Drupal\farm_entity\Plugin\Quantity\QuantityType\FarmQuantityType;
 
 /**
  * Provides the material quantity type.
- *
- * @QuantityType(
- *   id = "material",
- *   label = @Translation("Material"),
- * )
  */
+#[QuantityType(
+  id: 'material',
+  label: new TranslatableMarkup('Material'),
+)]
 class Material extends FarmQuantityType {
 
   /**

--- a/modules/quantity/standard/src/Plugin/Quantity/QuantityType/Standard.php
+++ b/modules/quantity/standard/src/Plugin/Quantity/QuantityType/Standard.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quantity_standard\Plugin\Quantity\QuantityType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\QuantityType;
 use Drupal\farm_entity\Plugin\Quantity\QuantityType\FarmQuantityType;
 
 /**
  * Provides the standard quantity type.
- *
- * @QuantityType(
- *   id = "standard",
- *   label = @Translation("Standard"),
- * )
  */
+#[QuantityType(
+  id: 'standard',
+  label: new TranslatableMarkup('Standard'),
+)]
 class Standard extends FarmQuantityType {
 
 }

--- a/modules/quantity/test/src/Plugin/Quantity/QuantityType/Test.php
+++ b/modules/quantity/test/src/Plugin/Quantity/QuantityType/Test.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quantity_test\Plugin\Quantity\QuantityType;
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\QuantityType;
 use Drupal\farm_entity\Plugin\Quantity\QuantityType\FarmQuantityType;
 
 /**
  * Provides the test quantity type.
- *
- * @QuantityType(
- *   id = "test",
- *   label = @Translation("Test measurement"),
- * )
  */
+#[QuantityType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
 class Test extends FarmQuantityType {
 
   /**

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -12,8 +12,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_group\GroupMembershipInterface;
 use Drupal\farm_location\AssetLocationInterface;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickAssetTrait;
 use Drupal\farm_quick\Traits\QuickLogTrait;
@@ -22,19 +24,18 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Birth quick form.
- *
- * @QuickForm(
- *   id = "birth",
- *   label = @Translation("Birth"),
- *   description = @Translation("Record an animal birth."),
- *   helpText = @Translation("Use this form to record the birth of one or more animals. A new birth log will be created, along with the new child animal asset records."),
- *   permissions = {
- *     "create animal asset",
- *     "create birth log",
- *     "create observation log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'birth',
+  label: new TranslatableMarkup('Birth'),
+  description: new TranslatableMarkup('Record an animal birth.'),
+  helpText: new TranslatableMarkup('Use this form to record the birth of one or more animals. A new birth log will be created, along with the new child animal asset records.'),
+  permissions: [
+    'create animal asset',
+    'create birth log',
+    'create observation log',
+  ],
+)]
 class Birth extends QuickFormBase {
 
   use QuickAssetTrait;

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -10,8 +10,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_group\GroupMembershipInterface;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
 use Drupal\farm_quick\Traits\QuickFormElementsTrait;
@@ -22,17 +24,16 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Group quick form.
- *
- * @QuickForm(
- *   id = "group",
- *   label = @Translation("Group membership"),
- *   description = @Translation("Record asset group membership changes."),
- *   helpText = @Translation("Use this form to assign assets to a group. A new observation log will be created to record the group membership change."),
- *   permissions = {
- *     "create observation log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'group',
+  label: new TranslatableMarkup('Group membership'),
+  description: new TranslatableMarkup('Record asset group membership changes.'),
+  helpText: new TranslatableMarkup('Use this form to assign assets to a group. A new observation log will be created to record the group membership change.'),
+  permissions: [
+    'create observation log',
+  ],
+)]
 class Group extends QuickFormBase implements QuickFormInterface {
 
   use QuickLogTrait;

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -11,8 +11,10 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_inventory\AssetInventoryInterface;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\ConfigurableQuickFormTrait;
@@ -25,15 +27,14 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Inventory quick form.
- *
- * @QuickForm(
- *   id = "inventory",
- *   label = @Translation("Inventory"),
- *   description = @Translation("Record asset inventory adjustments."),
- *   helpText = @Translation("Use this form to increment, decrement, or reset the inventory of an asset. A new log will be created to record the adjustment."),
- *   permissions = {}
- * )
  */
+#[QuickForm(
+  id: 'inventory',
+  label: new TranslatableMarkup('Inventory'),
+  description: new TranslatableMarkup('Record asset inventory adjustments.'),
+  helpText: new TranslatableMarkup('Use this form to increment, decrement, or reset the inventory of an asset. A new log will be created to record the adjustment.'),
+  permissions: [],
+)]
 class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface {
 
   use ConfigurableQuickFormTrait;

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -10,9 +10,11 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\farm_location\AssetLocationInterface;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
 use Drupal\farm_quick\Traits\QuickFormElementsTrait;
@@ -23,17 +25,16 @@ use Psr\Container\ContainerInterface;
 
 /**
  * Movement quick form.
- *
- * @QuickForm(
- *   id = "movement",
- *   label = @Translation("Movement"),
- *   description = @Translation("Record the movement of assets."),
- *   helpText = @Translation("Use this form to record the movement of assets to a new location."),
- *   permissions = {
- *     "create activity log",
- *   }
- * )
  */
+#[QuickForm(
+  id: 'movement',
+  label: new TranslatableMarkup('Movement'),
+  description: new TranslatableMarkup('Record the movement of assets.'),
+  helpText: new TranslatableMarkup('Use this form to record the movement of assets to a new location.'),
+  permissions: [
+    'create activity log',
+  ],
+)]
 class Movement extends QuickFormBase implements QuickFormInterface {
 
   use QuickLogTrait;

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -12,6 +12,8 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_quick\Attribute\QuickForm;
 use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickAssetTrait;
 use Drupal\farm_quick\Traits\QuickFormElementsTrait;
@@ -24,18 +26,17 @@ use Psr\Container\ContainerInterface;
 /**
  * Planting quick form.
  *
- * @QuickForm(
- *   id = "planting",
- *   label = @Translation("Planting"),
- *   description = @Translation("Record a planting."),
- *   helpText = @Translation("This form will create a plant asset, along with optional logs to represent seeding date, harvest date, etc."),
- *   permissions = {
- *     "create plant asset",
- *   }
- * )
- *
  * @internal
  */
+#[QuickForm(
+  id: 'planting',
+  label: new TranslatableMarkup('Planting'),
+  description: new TranslatableMarkup('Record a planting'),
+  helpText: new TranslatableMarkup('This form will create a plant asset, along with optional logs to represent seeding date, harvest date, etc.'),
+  permissions: [
+    'create plant asset',
+  ],
+)]
 class Planting extends QuickFormBase {
 
   use QuickAssetTrait;


### PR DESCRIPTION
See https://www.drupal.org/project/farm/issues/3461548

This adds support for attributes to all of our core plugin types. Contrib is still able to use annotations, but we will drop support for this in a future release.