### PR TITLE
Allow more granular access to views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ requirements (inherited from Drupal 11):
 - [Convert all procedural hook implementations to Hook classes #1007](https://github.com/farmOS/farmOS/pull/1007)
 - [Implement ManagedRolePermissions access policy and simple_oauth scope granularity #922](https://github.com/farmOS/farmOS/pull/922)
 - [Change farmOS Update config revert logic from opt-out to opt-in #1011](https://github.com/farmOS/farmOS/pull/1011)
+- [Issue #3413263: Use Entity API query access handler to filter entity queries based on user permissions](https://www.drupal.org/project/farm/issues/3413263)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ requirements (inherited from Drupal 11):
 - [Implement ManagedRolePermissions access policy and simple_oauth scope granularity #922](https://github.com/farmOS/farmOS/pull/922)
 - [Change farmOS Update config revert logic from opt-out to opt-in #1011](https://github.com/farmOS/farmOS/pull/1011)
 - [Issue #3413263: Use Entity API query access handler to filter entity queries based on user permissions](https://www.drupal.org/project/farm/issues/3413263)
+- [Allow more granular access to views #965](https://github.com/farmOS/farmOS/pull/965)
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/inspire_tree": "^1.0.6",
         "drupal/jsonapi_schema": "^1.0",
-        "drupal/log": "^2.3.1",
+        "drupal/log": "^3.0",
         "drupal/migrate_plus": "^6.0.8",
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_tools": "^6.1.2",

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -64,6 +64,7 @@ return static function (RectorConfig $rectorConfig): void {
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateProcessPlugin', 'Drupal\migrate\Attribute\MigrateProcess'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateSource', 'Drupal\migrate\Attribute\MigrateSource'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'RenderElement', 'Drupal\Core\Render\Attribute\RenderElement'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsAccess', 'Drupal\views\Attribute\ViewsAccess'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsArgument', 'Drupal\views\Attribute\ViewsArgument'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsDisplayExtender', 'Drupal\views\Attribute\ViewsDisplayExtender'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsField', 'Drupal\views\Attribute\ViewsField'),

--- a/modules/asset/group/config/optional/views.view.farm_group_members.yml
+++ b/modules/asset/group/config/optional/views.view.farm_group_members.yml
@@ -6,11 +6,11 @@ dependencies:
     - image.style.thumbnail
   module:
     - asset
+    - farm_entity_access
     - farm_group
     - farm_location
     - image
     - options
-    - user
 id: farm_group_members
 label: 'Farm Group Members'
 module: views
@@ -634,9 +634,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any asset'
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }

--- a/modules/asset/group/config/optional/views.view.farm_group_reference.yml
+++ b/modules/asset/group/config/optional/views.view.farm_group_reference.yml
@@ -5,6 +5,7 @@ dependencies:
     - asset.type.group
   module:
     - asset
+    - farm_entity_access
   enforced:
     module:
       - farm_entity
@@ -117,8 +118,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: none
-        options: {  }
+        type: farm_entity_collection
+        options:
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }
@@ -215,6 +218,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions
       tags: {  }
   entity_reference:
     id: entity_reference
@@ -240,4 +244,5 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user.permissions
       tags: {  }

--- a/modules/asset/group/farm_group.info.yml
+++ b/modules/asset/group/farm_group.info.yml
@@ -6,5 +6,6 @@ core_version_requirement: ^11
 dependencies:
   - farm:asset
   - farm:farm_entity
+  - farm:farm_entity_access
   - farm:farm_location
   - farm:farm_log

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\farm_test\Kernel\FarmAssetTestTrait;
 use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\log\Entity\Log;
@@ -22,6 +23,7 @@ class GroupTest extends KernelTestBase {
   use StringTranslationTrait;
   use FarmAssetTestTrait;
   use FarmEntityCacheTestTrait;
+  use UserCreationTrait;
   use WktTrait;
 
   /**
@@ -58,6 +60,8 @@ class GroupTest extends KernelTestBase {
   protected static $modules = [
     'asset',
     'log',
+    'entity',
+    'farm_entity_access',
     'farm_field',
     'farm_group',
     'farm_group_test',
@@ -481,6 +485,13 @@ class GroupTest extends KernelTestBase {
    * Test that circular group membership is prevented.
    */
   public function testCircularGroupMembership() {
+
+    // Create and login a user with access to view any asset. This is necessary
+    // to validate the log entities below, because the entity reference fields
+    // use Views to validate that entities are referencable, and the Views use
+    // the farm_entity_collection Views access plugin.
+    $user = $this->createUser(['view any asset']);
+    $this->container->get('current_user')->setAccount($user);
 
     // Create two group assets.
     /** @var \Drupal\asset\Entity\AssetInterface $first_group */

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -35,6 +35,7 @@ class FarmApiTest extends KernelTestBase {
     'farm_api',
     'farm_api_test',
     'farm_entity',
+    'farm_entity_access',
     'farm_field',
     'farm_log_asset',
     'farm_manager',

--- a/modules/core/asset/asset.permissions.yml
+++ b/modules/core/asset/asset.permissions.yml
@@ -1,3 +1,7 @@
+access asset collection:
+  title: 'View asset collection'
+  description: 'View a collection of asset entities.'
+
 administer assets:
   title: 'Administer assets'
   description: 'Admin access to all asset entities.'

--- a/modules/core/asset/src/Entity/Asset.php
+++ b/modules/core/asset/src/Entity/Asset.php
@@ -80,6 +80,7 @@ use Drupal\views\EntityViewsData;
     'version-history' => '/asset/{asset}/revisions',
   ],
   admin_permission: 'administer assets',
+  collection_permission: 'access asset collection',
   permission_granularity: 'bundle',
   bundle_entity_type: 'asset_type',
   bundle_label: new TranslatableMarkup('Asset type'),

--- a/modules/core/asset/src/Entity/Asset.php
+++ b/modules/core/asset/src/Entity/Asset.php
@@ -17,6 +17,7 @@ use Drupal\asset\AssetListBuilder;
 use Drupal\asset\AssetStorage;
 use Drupal\asset\Form\AssetForm;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
+use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
 use Drupal\entity\Routing\RevisionRouteProvider;
@@ -50,6 +51,7 @@ use Drupal\views\EntityViewsData;
     'access' => UncacheableEntityAccessControlHandler::class,
     'list_builder' => AssetListBuilder::class,
     'permission_provider' => UncacheableEntityPermissionProvider::class,
+    'query_access' => UncacheableQueryAccessHandler::class,
     'view_builder' => EntityViewBuilder::class,
     'views_data' => EntityViewsData::class,
     'form' => [

--- a/modules/core/data_stream/src/Entity/DataStream.php
+++ b/modules/core/data_stream/src/Entity/DataStream.php
@@ -17,6 +17,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\data_stream\Form\DataStreamForm;
 use Drupal\entity\EntityViewsData;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
+use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
 use Drupal\entity\UncacheableEntityAccessControlHandler;
 use Drupal\entity\UncacheableEntityPermissionProvider;
@@ -40,6 +41,7 @@ use Drupal\entity\UncacheableEntityPermissionProvider;
   handlers: [
     'access' => UncacheableEntityAccessControlHandler::class,
     'permission_provider' => UncacheableEntityPermissionProvider::class,
+    'query_access' => UncacheableQueryAccessHandler::class,
     'view_builder' => EntityViewBuilder::class,
     'views_data' => EntityViewsData::class,
     'form' => [

--- a/modules/core/entity/farm_entity.info.yml
+++ b/modules/core/entity/farm_entity.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^11
 dependencies:
   - entity:entity
   - entity_reference_integrity:entity_reference_integrity_enforce
+  - farm:farm_entity_access
   - farm:farm_entity_fields
   - farm:farm_entity_views
   - farm:farm_log

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -28,3 +28,12 @@ function farm_entity_post_update_enforce_organization_eri(&$sandbox) {
   $config->set('enabled_entity_type_ids', $entity_types);
   $config->save();
 }
+
+/**
+ * Install the farm_entity_access module.
+ */
+function farm_entity_post_update_install_farm_entity_access(&$sandbox) {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_entity_access')) {
+    \Drupal::service('module_installer')->install(['farm_entity_access']);
+  }
+}

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -22,3 +22,23 @@ services:
   plugin.manager.quantity_type:
     class: Drupal\farm_entity\QuantityTypeManager
     parent: default_plugin_manager
+  farm_entity.asset_collection_access:
+    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
+    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'asset' ]
+    tags:
+      - { name: access_check, applies_to: _asset_collection_access }
+  farm_entity.log_collection_access:
+    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
+    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'log' ]
+    tags:
+      - { name: access_check, applies_to: _log_collection_access }
+  farm_entity.plan_collection_access:
+    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
+    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'plan' ]
+    tags:
+      - { name: access_check, applies_to: _plan_collection_access }
+  farm_entity.quantity_collection_access:
+    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
+    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'quantity' ]
+    tags:
+      - { name: access_check, applies_to: _quantity_collection_access }

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -24,26 +24,31 @@ services:
     parent: default_plugin_manager
   farm_entity.asset_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', 'asset' ]
+    arguments:
+      $entityTypeId: asset
     tags:
       - { name: access_check, applies_to: _asset_collection_access }
   farm_entity.log_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', 'log' ]
+    arguments:
+      $entityTypeId: 'log'
     tags:
       - { name: access_check, applies_to: _log_collection_access }
   farm_entity.organization_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', 'organization' ]
+    arguments:
+      $entityTypeId: 'organization'
     tags:
       - { name: access_check, applies_to: _organization_collection_access }
   farm_entity.plan_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', 'plan' ]
+    arguments:
+      $entityTypeId: 'plan'
     tags:
       - { name: access_check, applies_to: _plan_collection_access }
   farm_entity.quantity_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', 'quantity' ]
+    arguments:
+      $entityTypeId: 'quantity'
     tags:
       - { name: access_check, applies_to: _quantity_collection_access }

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -32,6 +32,11 @@ services:
     arguments: [ '@current_user', '@entity_type.manager', 'log' ]
     tags:
       - { name: access_check, applies_to: _log_collection_access }
+  farm_entity.organization_collection_access:
+    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
+    arguments: [ '@current_user', '@entity_type.manager', 'organization' ]
+    tags:
+      - { name: access_check, applies_to: _organization_collection_access }
   farm_entity.plan_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
     arguments: [ '@current_user', '@entity_type.manager', 'plan' ]

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -22,33 +22,3 @@ services:
   plugin.manager.quantity_type:
     class: Drupal\farm_entity\QuantityTypeManager
     parent: default_plugin_manager
-  farm_entity.asset_collection_access:
-    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments:
-      $entityTypeId: asset
-    tags:
-      - { name: access_check, applies_to: _asset_collection_access }
-  farm_entity.log_collection_access:
-    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments:
-      $entityTypeId: 'log'
-    tags:
-      - { name: access_check, applies_to: _log_collection_access }
-  farm_entity.organization_collection_access:
-    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments:
-      $entityTypeId: 'organization'
-    tags:
-      - { name: access_check, applies_to: _organization_collection_access }
-  farm_entity.plan_collection_access:
-    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments:
-      $entityTypeId: 'plan'
-    tags:
-      - { name: access_check, applies_to: _plan_collection_access }
-  farm_entity.quantity_collection_access:
-    class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments:
-      $entityTypeId: 'quantity'
-    tags:
-      - { name: access_check, applies_to: _quantity_collection_access }

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -24,21 +24,21 @@ services:
     parent: default_plugin_manager
   farm_entity.asset_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'asset' ]
+    arguments: [ '@current_user', '@entity_type.manager', 'asset' ]
     tags:
       - { name: access_check, applies_to: _asset_collection_access }
   farm_entity.log_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'log' ]
+    arguments: [ '@current_user', '@entity_type.manager', 'log' ]
     tags:
       - { name: access_check, applies_to: _log_collection_access }
   farm_entity.plan_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'plan' ]
+    arguments: [ '@current_user', '@entity_type.manager', 'plan' ]
     tags:
       - { name: access_check, applies_to: _plan_collection_access }
   farm_entity.quantity_collection_access:
     class: Drupal\farm_entity\Access\EntityCollectionAccessCheck
-    arguments: [ '@current_user', '@entity_type.manager', '@entity_type.bundle.info', 'quantity' ]
+    arguments: [ '@current_user', '@entity_type.manager', 'quantity' ]
     tags:
       - { name: access_check, applies_to: _quantity_collection_access }

--- a/modules/core/entity/modules/access/config/schema/farm_entity_access.schema.yml
+++ b/modules/core/entity/modules/access/config/schema/farm_entity_access.schema.yml
@@ -1,4 +1,4 @@
-# Schema for views access plugins.
+# Schema for Views access plugin.
 views.access.farm_entity_collection:
   type: mapping
   label: 'Entity collection access'

--- a/modules/core/entity/modules/access/farm_entity_access.info.yml
+++ b/modules/core/entity/modules/access/farm_entity_access.info.yml
@@ -1,0 +1,5 @@
+name: farmOS Entity Access
+description: Access logic for farmOS entities.
+type: module
+package: farmOS
+core_version_requirement: ^11

--- a/modules/core/entity/modules/access/farm_entity_access.services.yml
+++ b/modules/core/entity/modules/access/farm_entity_access.services.yml
@@ -1,0 +1,33 @@
+services:
+  _defaults:
+    autowire: true
+  farm_entity_access.asset_collection_access:
+    class: Drupal\farm_entity_access\Access\EntityCollectionAccessCheck
+    arguments:
+      $entityTypeId: asset
+    tags:
+      - { name: access_check, applies_to: _asset_collection_access }
+  farm_entity_access.log_collection_access:
+    class: Drupal\farm_entity_access\Access\EntityCollectionAccessCheck
+    arguments:
+      $entityTypeId: 'log'
+    tags:
+      - { name: access_check, applies_to: _log_collection_access }
+  farm_entity_access.organization_collection_access:
+    class: Drupal\farm_entity_access\Access\EntityCollectionAccessCheck
+    arguments:
+      $entityTypeId: 'organization'
+    tags:
+      - { name: access_check, applies_to: _organization_collection_access }
+  farm_entity_access.plan_collection_access:
+    class: Drupal\farm_entity_access\Access\EntityCollectionAccessCheck
+    arguments:
+      $entityTypeId: 'plan'
+    tags:
+      - { name: access_check, applies_to: _plan_collection_access }
+  farm_entity_access.quantity_collection_access:
+    class: Drupal\farm_entity_access\Access\EntityCollectionAccessCheck
+    arguments:
+      $entityTypeId: 'quantity'
+    tags:
+      - { name: access_check, applies_to: _quantity_collection_access }

--- a/modules/core/entity/modules/access/src/Access/EntityCollectionAccessCheck.php
+++ b/modules/core/entity/modules/access/src/Access/EntityCollectionAccessCheck.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\farm_entity\Access;
+namespace Drupal\farm_entity_access\Access;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Access\AccessResultInterface;

--- a/modules/core/entity/modules/access/src/Access/EntityCollectionAccessCheck.php
+++ b/modules/core/entity/modules/access/src/Access/EntityCollectionAccessCheck.php
@@ -36,8 +36,18 @@ class EntityCollectionAccessCheck implements AccessInterface {
     }
 
     // Check if the route is expecting a specific bundle.
+    // The name of the bundle parameter may be either the bundle entity type
+    // machine name (eg: "asset_type", "log_type", etc.), "entity_bundle", or
+    // "arg_0". Take the first one we find.
     $entity_type = $this->entityTypeManager->getDefinition($this->entityTypeId);
-    $bundle = $route_match->getParameter($entity_type->getBundleEntityType()) ?: $route_match->getParameter('arg_0');
+    $bundle_parameters = [
+      $entity_type->getBundleEntityType(),
+      'entity_bundle',
+      'arg_0',
+    ];
+    $bundle = array_reduce($bundle_parameters, function ($carry, $parameter) use ($route_match) {
+      return $carry ?: $route_match->getParameter($parameter);
+    });
 
     // Return entity collection access result.
     return self::checkEntityCollectionAccess($this->currentUser, $this->entityTypeId, $bundle);

--- a/modules/core/entity/modules/access/src/Access/EntityCollectionAccessCheck.php
+++ b/modules/core/entity/modules/access/src/Access/EntityCollectionAccessCheck.php
@@ -32,7 +32,6 @@ class EntityCollectionAccessCheck implements AccessInterface {
 
     // Bail if the entity type does not exist.
     if (!$this->entityTypeManager->hasDefinition($this->entityTypeId)) {
-      // TODO: Cache tag for when entity type is later installed?
       return AccessResult::forbidden();
     }
 
@@ -62,7 +61,6 @@ class EntityCollectionAccessCheck implements AccessInterface {
     // Bail if the entity type does not exist.
     $entity_type_manager = \Drupal::entityTypeManager();
     if (!$entity_type_manager->hasDefinition($entity_type_id)) {
-      // TODO: Cache tag for when entity type is later installed?
       return AccessResult::forbidden();
     }
 

--- a/modules/core/entity/modules/access/src/Plugin/views/access/EntityCollection.php
+++ b/modules/core/entity/modules/access/src/Plugin/views/access/EntityCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Drupal\farm_entity_views\Plugin\views\access;
+namespace Drupal\farm_entity_access\Plugin\views\access;
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheableDependencyInterface;
@@ -10,7 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\farm_entity\Access\EntityCollectionAccessCheck;
+use Drupal\farm_entity_access\Access\EntityCollectionAccessCheck;
 use Drupal\views\Attribute\ViewsAccess;
 use Drupal\views\Plugin\views\access\AccessPluginBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;

--- a/modules/core/entity/modules/views/config/schema/farm_entity_views.schema.yml
+++ b/modules/core/entity/modules/views/config/schema/farm_entity_views.schema.yml
@@ -1,0 +1,11 @@
+# Schema for views access plugins.
+views.access.farm_entity_collection:
+  type: mapping
+  label: 'Entity collection access'
+  mapping:
+    entity_type:
+      type: sequence
+      label: 'Entity types'
+      sequence:
+        type: string
+        label: 'Entity type'

--- a/modules/core/entity/modules/views/src/Plugin/views/access/EntityCollection.php
+++ b/modules/core/entity/modules/views/src/Plugin/views/access/EntityCollection.php
@@ -31,28 +31,13 @@ class EntityCollection extends AccessPluginBase implements CacheableDependencyIn
    */
   protected $usesOptions = TRUE;
 
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * Constructs an EntityCollection object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/entity/modules/views/src/Plugin/views/access/EntityCollection.php
+++ b/modules/core/entity/modules/views/src/Plugin/views/access/EntityCollection.php
@@ -117,6 +117,7 @@ class EntityCollection extends AccessPluginBase implements CacheableDependencyIn
     $supported_entity_types = [
       'asset',
       'log',
+      'organization',
       'plan',
       'quantity',
     ];

--- a/modules/core/entity/modules/views/src/Plugin/views/access/EntityCollection.php
+++ b/modules/core/entity/modules/views/src/Plugin/views/access/EntityCollection.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity_views\Plugin\views\access;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheableDependencyInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Access\EntityCollectionAccessCheck;
+use Drupal\views\Attribute\ViewsAccess;
+use Drupal\views\Plugin\views\access\AccessPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Routing\Route;
+
+/**
+ * Checks access for entity collections.
+ */
+#[ViewsAccess(
+  id: 'farm_entity_collection',
+  title: new TranslatableMarkup('Entity Collection'),
+  help: new TranslatableMarkup('Access will be granted to users having both the collection permission and at least one view permission for the given entity type.'),
+)]
+class EntityCollection extends AccessPluginBase implements CacheableDependencyInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $usesOptions = TRUE;
+
+  /**
+   * Entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs an EntityCollection object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summaryTitle() {
+    return implode(', ', $this->options['entity_type']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defineOptions() {
+    $options = parent::defineOptions();
+    $options['entity_type'] = ['default' => []];
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(AccountInterface $account) {
+    // Check entity collection access when the view is rendered.
+    // Because the current display is not set we cannot check for dynamic
+    // view arguments.
+    foreach ($this->options['entity_type'] ?? [] as $entity_type) {
+      if (!EntityCollectionAccessCheck::checkEntityCollectionAccess($account, $entity_type, NULL)->isAllowed()) {
+        return FALSE;
+      }
+    }
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRouteDefinition(Route $route) {
+    // Alter the view route definition when building routes if the view
+    // provides a page.
+    foreach ($this->options['entity_type'] ?? [] as $entity_type) {
+      $route->setRequirement("_{$entity_type}_collection_access", 'TRUE');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    $supported_entity_types = [
+      'asset',
+      'log',
+      'plan',
+      'quantity',
+    ];
+
+    // Build options from each available supported entity type.
+    $options = [];
+    foreach ($supported_entity_types as $entity_type) {
+      if ($this->entityTypeManager->hasDefinition($entity_type)) {
+        $options[$entity_type] = $this->entityTypeManager->getDefinition($entity_type)->getLabel();
+      }
+    }
+    $form['entity_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Entity type'),
+      '#options' => $options,
+      '#multiple' => TRUE,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheMaxAge() {
+    return Cache::PERMANENT;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheContexts() {
+    return ['user.permissions'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return [];
+  }
+
+}

--- a/modules/core/entity/src/Access/EntityCollectionAccessCheck.php
+++ b/modules/core/entity/src/Access/EntityCollectionAccessCheck.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+
+/**
+ * Checks access for the specified entity type collection.
+ */
+class EntityCollectionAccessCheck implements AccessInterface {
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity type bundle info service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
+   */
+  protected $entityTypeBundleInfo;
+
+  /**
+   * The entity type ID.
+   *
+   * @var string
+   */
+  protected $entityTypeId;
+
+  /**
+   * FarmAssetLogViewsAccessCheck constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(AccountProxyInterface $current_user, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfo $entity_type_bundle_info, string $entity_type_id) {
+    $this->currentUser = $current_user;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityTypeBundleInfo = $entity_type_bundle_info;
+    $this->entityTypeId = $entity_type_id;
+  }
+
+  /**
+   * A custom access check.
+   *
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
+   */
+  public function access(RouteMatchInterface $route_match) {
+
+    // Bail if the entity type does not exist.
+    if (!$this->entityTypeManager->hasDefinition($this->entityTypeId)) {
+      // TODO: Cache tag for when entity type is later installed?
+      return AccessResult::forbidden();
+    }
+
+    // Load entity type.
+    $entity_type = $this->entityTypeManager->getDefinition($this->entityTypeId);
+
+    // Check that user has the access {entity_type} collection permission.
+    $collection_permission = AccessResult::allowedIfHasPermission($this->currentUser, $entity_type->getCollectionPermission());
+
+    // View any/own {entity_type} permissions grant access to all bundles.
+    $view_permissions = [
+      "view any $this->entityTypeId",
+      "view own $this->entityTypeId",
+    ];
+
+    // Load available bundles for the entity type.
+    $entity_bundles = $this->entityTypeBundleInfo->getBundleInfo($this->entityTypeId);
+    $all_bundles = array_keys($entity_bundles);
+
+    // Check if the route is expecting a specific bundle.
+    $bundle = $route_match->getParameter($entity_type->getBundleEntityType()) ?: $route_match->getParameter('arg_0');
+    if ($bundle && in_array($bundle, $all_bundles)) {
+      $view_permissions[] = "view any $bundle $this->entityTypeId";
+      $view_permissions[] = "view own $bundle $this->entityTypeId";
+    }
+    // Else add view permissions for all bundles.
+    else {
+      foreach ($all_bundles as $bundle) {
+        $view_permissions[] = "view any $bundle $this->entityTypeId";
+        $view_permissions[] = "view own $bundle $this->entityTypeId";
+      }
+    }
+
+    // Grant permission if the user has at least one of the view permissions.
+    $view_permission = AccessResult::allowedIfHasPermissions($this->currentUser, $view_permissions, 'OR');
+    return $collection_permission->andIf($view_permission);
+  }
+
+}

--- a/modules/core/entity/src/Access/EntityCollectionAccessCheck.php
+++ b/modules/core/entity/src/Access/EntityCollectionAccessCheck.php
@@ -10,45 +10,17 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Session\AccountProxyInterface;
 
 /**
  * Checks access for the specified entity type collection.
  */
 class EntityCollectionAccessCheck implements AccessInterface {
 
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountProxyInterface
-   */
-  protected $currentUser;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity type ID.
-   *
-   * @var string
-   */
-  protected $entityTypeId;
-
-  /**
-   * FarmAssetLogViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
-  public function __construct(AccountProxyInterface $current_user, EntityTypeManagerInterface $entity_type_manager, string $entity_type_id) {
-    $this->currentUser = $current_user;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityTypeId = $entity_type_id;
-  }
+  public function __construct(
+    protected AccountInterface $currentUser,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected string $entityTypeId,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/entity/src/Access/EntityCollectionAccessCheck.php
+++ b/modules/core/entity/src/Access/EntityCollectionAccessCheck.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Drupal\farm_entity\Access;
 
 use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Entity\EntityTypeBundleInfo;
+use Drupal\Core\Access\AccessResultInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\Access\AccessInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 
 /**
@@ -31,13 +32,6 @@ class EntityCollectionAccessCheck implements AccessInterface {
   protected $entityTypeManager;
 
   /**
-   * The entity type bundle info service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  /**
    * The entity type ID.
    *
    * @var string
@@ -50,10 +44,9 @@ class EntityCollectionAccessCheck implements AccessInterface {
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
    */
-  public function __construct(AccountProxyInterface $current_user, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfo $entity_type_bundle_info, string $entity_type_id) {
+  public function __construct(AccountProxyInterface $current_user, EntityTypeManagerInterface $entity_type_manager, string $entity_type_id) {
     $this->currentUser = $current_user;
     $this->entityTypeManager = $entity_type_manager;
-    $this->entityTypeBundleInfo = $entity_type_bundle_info;
     $this->entityTypeId = $entity_type_id;
   }
 
@@ -71,38 +64,69 @@ class EntityCollectionAccessCheck implements AccessInterface {
       return AccessResult::forbidden();
     }
 
-    // Load entity type.
+    // Check if the route is expecting a specific bundle.
     $entity_type = $this->entityTypeManager->getDefinition($this->entityTypeId);
+    $bundle = $route_match->getParameter($entity_type->getBundleEntityType()) ?: $route_match->getParameter('arg_0');
+
+    // Return entity collection access result.
+    return self::checkEntityCollectionAccess($this->currentUser, $this->entityTypeId, $bundle);
+  }
+
+  /**
+   * Helper function to check entity collection access.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user to check access for.
+   * @param string $entity_type_id
+   *   The entity type ID.
+   * @param string|null $bundle
+   *   An optional bundle to limit collection access checking to.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public static function checkEntityCollectionAccess(AccountInterface $user, string $entity_type_id, ?string $bundle): AccessResultInterface {
+
+    // Bail if the entity type does not exist.
+    $entity_type_manager = \Drupal::entityTypeManager();
+    if (!$entity_type_manager->hasDefinition($entity_type_id)) {
+      // TODO: Cache tag for when entity type is later installed?
+      return AccessResult::forbidden();
+    }
+
+    // Load entity type.
+    $entity_type = $entity_type_manager->getDefinition($entity_type_id);
 
     // Check that user has the access {entity_type} collection permission.
-    $collection_permission = AccessResult::allowedIfHasPermission($this->currentUser, $entity_type->getCollectionPermission());
+    $collection_permission = AccessResult::allowedIfHasPermission($user, $entity_type->getCollectionPermission());
 
     // View any/own {entity_type} permissions grant access to all bundles.
     $view_permissions = [
-      "view any $this->entityTypeId",
-      "view own $this->entityTypeId",
+      "view any $entity_type_id",
+      "view own $entity_type_id",
     ];
 
     // Load available bundles for the entity type.
-    $entity_bundles = $this->entityTypeBundleInfo->getBundleInfo($this->entityTypeId);
+    /** @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info */
+    $entity_type_bundle_info = \Drupal::service('entity_type.bundle.info');
+    $entity_bundles = $entity_type_bundle_info->getBundleInfo($entity_type_id);
     $all_bundles = array_keys($entity_bundles);
 
     // Check if the route is expecting a specific bundle.
-    $bundle = $route_match->getParameter($entity_type->getBundleEntityType()) ?: $route_match->getParameter('arg_0');
     if ($bundle && in_array($bundle, $all_bundles)) {
-      $view_permissions[] = "view any $bundle $this->entityTypeId";
-      $view_permissions[] = "view own $bundle $this->entityTypeId";
+      $view_permissions[] = "view any $bundle $entity_type_id";
+      $view_permissions[] = "view own $bundle $entity_type_id";
     }
     // Else add view permissions for all bundles.
     else {
       foreach ($all_bundles as $bundle) {
-        $view_permissions[] = "view any $bundle $this->entityTypeId";
-        $view_permissions[] = "view own $bundle $this->entityTypeId";
+        $view_permissions[] = "view any $bundle $entity_type_id";
+        $view_permissions[] = "view own $bundle $entity_type_id";
       }
     }
 
     // Grant permission if the user has at least one of the view permissions.
-    $view_permission = AccessResult::allowedIfHasPermissions($this->currentUser, $view_permissions, 'OR');
+    $view_permission = AccessResult::allowedIfHasPermissions($user, $view_permissions, 'OR');
     return $collection_permission->andIf($view_permission);
   }
 

--- a/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
@@ -96,7 +96,7 @@ class FarmEntityRevisionsTest extends KernelTestBase {
       ->allRevisions()
       ->condition($entity_type->getKey('id'), $entity->id())
       ->sort($entity_type->getKey('revision'), 'DESC')
-      ->accessCheck(TRUE)
+      ->accessCheck(FALSE)
       ->execute();
     return array_keys($result);
   }

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
@@ -34,6 +34,7 @@ class CsvImportTestBase extends MigrateTestBase {
     'entity_reference_validators',
     'farm_animal_type',
     'farm_entity_fields',
+    'farm_entity_access',
     'farm_field',
     'farm_format',
     'farm_import',

--- a/modules/core/location/config/optional/views.view.farm_asset_geojson.yml
+++ b/modules/core/location/config/optional/views.view.farm_asset_geojson.yml
@@ -3,10 +3,10 @@ status: true
 dependencies:
   module:
     - asset
+    - farm_entity_access
     - farm_location
     - geofield
     - rest
-    - user
     - views_geojson
   enforced:
     module:
@@ -304,9 +304,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any asset'
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }

--- a/modules/core/location/config/optional/views.view.farm_location_reference.yml
+++ b/modules/core/location/config/optional/views.view.farm_location_reference.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   module:
     - asset
+    - farm_entity_access
   enforced:
     module:
       - farm_location
@@ -115,8 +116,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: none
-        options: {  }
+        type: farm_entity_collection
+        options:
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }
@@ -211,6 +214,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions
       tags: {  }
   entity_reference:
     id: entity_reference
@@ -236,4 +240,5 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user.permissions
       tags: {  }

--- a/modules/core/location/farm_location.info.yml
+++ b/modules/core/location/farm_location.info.yml
@@ -6,6 +6,7 @@ core_version_requirement: ^11
 dependencies:
   - drupal:views
   - farm:asset
+  - farm:farm_entity_access
   - farm:farm_field
   - farm:farm_geo
   - farm:farm_log

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -8,6 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\farm_test\Kernel\FarmAssetTestTrait;
 use Drupal\Tests\farm_test\Kernel\FarmEntityCacheTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\log\Entity\Log;
@@ -22,6 +23,7 @@ class LocationTest extends KernelTestBase {
   use StringTranslationTrait;
   use FarmEntityCacheTestTrait;
   use FarmAssetTestTrait;
+  use UserCreationTrait;
   use WktTrait;
 
   /**
@@ -66,6 +68,8 @@ class LocationTest extends KernelTestBase {
     'asset',
     'geofield',
     'log',
+    'entity',
+    'farm_entity_access',
     'farm_field',
     'farm_location',
     'farm_location_test',
@@ -676,6 +680,13 @@ class LocationTest extends KernelTestBase {
    * Test that circular asset location is prevented.
    */
   public function testCircularAssetLocation() {
+
+    // Create and login a user with access to view any asset. This is necessary
+    // to validate the log entities below, because the entity reference fields
+    // use Views to validate that entities are referencable, and the Views use
+    // the farm_entity_collection Views access plugin.
+    $user = $this->createUser(['view any asset']);
+    $this->container->get('current_user')->setAccount($user);
 
     // First, make sure we can't create a movement log that references the same
     // asset in both the asset and location fields.

--- a/modules/core/log/modules/asset/config/optional/views.view.farm_asset_reference.yml
+++ b/modules/core/log/modules/asset/config/optional/views.view.farm_asset_reference.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   module:
     - asset
+    - farm_entity_access
   enforced:
     module:
       - farm_log_asset
@@ -115,8 +116,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: none
-        options: {  }
+        type: farm_entity_collection
+        options:
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }
@@ -171,6 +174,7 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url.query_args
+        - user.permissions
       tags: {  }
   entity_reference:
     id: entity_reference
@@ -196,4 +200,5 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - user.permissions
       tags: {  }

--- a/modules/core/log/modules/asset/farm_log_asset.info.yml
+++ b/modules/core/log/modules/asset/farm_log_asset.info.yml
@@ -5,5 +5,6 @@ package: farmOS
 core_version_requirement: ^11
 dependencies:
   - farm:asset
+  - farm:farm_entity_access
   - farm:farm_field
   - log:log

--- a/modules/core/organization/organization.permissions.yml
+++ b/modules/core/organization/organization.permissions.yml
@@ -1,3 +1,7 @@
+access organization collection:
+  title: 'View organization collection'
+  description: 'View a collection of organization entities.'
+
 administer organizations:
   title: 'Administer organizations'
   description: 'Admin access to all organization entities.'

--- a/modules/core/organization/src/Entity/Organization.php
+++ b/modules/core/organization/src/Entity/Organization.php
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\RevisionLogEntityTrait;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
+use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
 use Drupal\entity\Routing\RevisionRouteProvider;
@@ -48,6 +49,7 @@ use Drupal\views\EntityViewsData;
     'access' => UncacheableEntityAccessControlHandler::class,
     'list_builder' => OrganizationListBuilder::class,
     'permission_provider' => UncacheableEntityPermissionProvider::class,
+    'query_access' => UncacheableQueryAccessHandler::class,
     'view_builder' => EntityViewBuilder::class,
     'views_data' => EntityViewsData::class,
     'form' => [
@@ -76,6 +78,7 @@ use Drupal\views\EntityViewsData;
     'version-history' => '/organization/{organization}/revisions',
   ],
   admin_permission: 'administer organizations',
+  collection_permission: 'access organization collection',
   permission_granularity: 'bundle',
   bundle_entity_type: 'organization_type',
   bundle_label: new TranslatableMarkup('Organization type'),

--- a/modules/core/plan/plan.permissions.yml
+++ b/modules/core/plan/plan.permissions.yml
@@ -1,3 +1,7 @@
+access plan collection:
+  title: 'View plan collection'
+  description: 'View a collection of plan entities.'
+
 administer plans:
   title: 'Administer plans'
   description: 'Admin access to all plan entities.'

--- a/modules/core/plan/src/Entity/Plan.php
+++ b/modules/core/plan/src/Entity/Plan.php
@@ -78,6 +78,7 @@ use Drupal\views\EntityViewsData;
     'version-history' => '/plan/{plan}/revisions',
   ],
   admin_permission: 'administer plans',
+  collection_permission: 'access plan collection',
   permission_granularity: 'bundle',
   bundle_entity_type: 'plan_type',
   bundle_label: new TranslatableMarkup('Plan type'),

--- a/modules/core/plan/src/Entity/Plan.php
+++ b/modules/core/plan/src/Entity/Plan.php
@@ -14,6 +14,7 @@ use Drupal\Core\Entity\RevisionLogEntityTrait;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
+use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
 use Drupal\entity\Routing\RevisionRouteProvider;
@@ -48,6 +49,7 @@ use Drupal\views\EntityViewsData;
     'access' => UncacheableEntityAccessControlHandler::class,
     'list_builder' => PlanListBuilder::class,
     'permission_provider' => UncacheableEntityPermissionProvider::class,
+    'query_access' => UncacheableQueryAccessHandler::class,
     'view_builder' => EntityViewBuilder::class,
     'views_data' => EntityViewsData::class,
     'form' => [

--- a/modules/core/quantity/quantity.permissions.yml
+++ b/modules/core/quantity/quantity.permissions.yml
@@ -1,3 +1,7 @@
+access quantity collection:
+  title: 'View quantity collection'
+  description: 'View a collection of quantity entities.'
+
 administer quantity:
   title: 'Administer quantity'
 

--- a/modules/core/quantity/src/Entity/Quantity.php
+++ b/modules/core/quantity/src/Entity/Quantity.php
@@ -75,6 +75,7 @@ use Drupal\user\EntityOwnerTrait;
     'delete-multiple-form' => '/quantity/delete',
   ],
   admin_permission: 'administer quantity',
+  collection_permission: 'access quantity collection',
   permission_granularity: 'bundle',
   bundle_entity_type: 'quantity_type',
   base_table: 'quantity',

--- a/modules/core/quantity/src/Entity/Quantity.php
+++ b/modules/core/quantity/src/Entity/Quantity.php
@@ -15,6 +15,7 @@ use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
+use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
 use Drupal\entity\Routing\RevisionRouteProvider;
@@ -52,6 +53,7 @@ use Drupal\user\EntityOwnerTrait;
     'inline_form' => QuantityInlineForm::class,
     'list_builder' => QuantityListBuilder::class,
     'permission_provider' => UncacheableEntityPermissionProvider::class,
+    'query_access' => UncacheableQueryAccessHandler::class,
     'view_builder' => QuantityViewBuilder::class,
     'views_data' => QuantityViewsData::class,
     'form' => [

--- a/modules/core/quick/tests/src/Kernel/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\farm_quick\Kernel;
 
 use Drupal\Core\Form\FormState;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\farm_quick\Form\QuickFormEntityForm;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
 
@@ -15,6 +16,8 @@ use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
  * @group farm
  */
 class QuickFormTest extends KernelTestBase {
+
+  use UserCreationTrait;
 
   /**
    * The quick form instance manager.
@@ -41,6 +44,7 @@ class QuickFormTest extends KernelTestBase {
     'options',
     'quantity',
     'state_machine',
+    'system',
     'taxonomy',
     'text',
     'user',
@@ -108,6 +112,13 @@ class QuickFormTest extends KernelTestBase {
    * Test quick form submission.
    */
   public function testQuickFormSubmission() {
+
+    // Create and login a user with access to view any quantity. This is
+    // necessary because quick form entity creation traits validate entities
+    // before saving them, and the entity module's query access handler enforces
+    // view access to referenced entities during validation.
+    $user = $this->createUser(['view any quantity']);
+    $this->container->get('current_user')->setAccount($user);
 
     // Programmatically submit the test quick form.
     $form_state = (new FormState())->setValues([

--- a/modules/core/quick/tests/src/Kernel/QuickFormTestBase.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTestBase.php
@@ -62,6 +62,7 @@ abstract class QuickFormTestBase extends KernelTestBase {
     'entity',
     'entity_reference_revisions',
     'farm_entity',
+    'farm_entity_access',
     'farm_entity_fields',
     'farm_field',
     'farm_format',

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -207,6 +207,7 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
 
           // View.
           if (!empty($entity_settings['view all'])) {
+            $perms[] = "access $entity_type collection";
             $perms[] = 'view any ' . $entity_type;
             $perms[] = 'view own ' . $entity_type;
             $perms[] = 'view all ' . $entity_type . ' revisions';

--- a/modules/core/ui/location/farm_ui_location.routing.yml
+++ b/modules/core/ui/location/farm_ui_location.routing.yml
@@ -5,6 +5,7 @@ farm.locations:
     _form: \Drupal\farm_ui_location\Form\LocationHierarchyForm
   requirements:
     _permission: 'access locations overview'
+    _asset_collection_access: 'TRUE'
 
 farm.asset.locations:
   path: '/asset/{asset}/locations'

--- a/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
@@ -163,11 +163,6 @@ abstract class BaseLocationHierarchyForm extends FormBase {
     $assets = $this->entityTypeManager->getStorage('asset')
       ->loadMultiple($asset_ids);
 
-    // Filter out assets that the user cannot view.
-    $assets = array_filter($assets, function ($asset) {
-      return $asset->access('view');
-    });
-
     // Sort assets by name, using natural sort algorithm.
     usort($assets, function ($a, $b) {
       return strnatcmp($a->label(), $b->label());

--- a/modules/core/ui/views/config/install/views.view.farm_asset.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_asset.yml
@@ -7,11 +7,11 @@ dependencies:
   module:
     - asset
     - entity_browser
+    - farm_entity_access
     - farm_location
     - farm_ui_views
     - image
     - options
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -706,9 +706,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any asset'
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -5,11 +5,11 @@ dependencies:
     - system.menu.admin
   module:
     - entity_reference_revisions
+    - farm_entity_access
     - farm_ui_views
     - log
     - options
     - state_machine
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -781,9 +781,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any log'
+          entity_type:
+            log: log
       cache:
         type: tag
         options: {  }

--- a/modules/core/ui/views/config/install/views.view.farm_log_quantity.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log_quantity.yml
@@ -5,13 +5,13 @@ dependencies:
     - system.menu.admin
     - taxonomy.vocabulary.unit
   module:
+    - farm_entity_access
     - fraction
     - log
     - options
     - quantity
     - state_machine
     - taxonomy
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -895,9 +895,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any quantity'
+          entity_type:
+            quantity: quantity
       cache:
         type: tag
         options: {  }
@@ -1587,13 +1588,12 @@ display:
           content: 'Displaying @start - @end of @total'
       display_extenders: {  }
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }
   page:
@@ -1630,13 +1630,12 @@ display:
         parent: farm.records
         context: '0'
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }
   page_type:
@@ -1710,12 +1709,11 @@ display:
           collapsible: true
       path: log-quantities/%
     cache_metadata:
-      max-age: -1
+      max-age: 0
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }

--- a/modules/core/ui/views/config/optional/views.view.farm_inventory.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_inventory.yml
@@ -4,13 +4,13 @@ dependencies:
   config:
     - taxonomy.vocabulary.unit
   module:
+    - farm_entity_access
     - fraction
     - log
     - options
     - quantity
     - state_machine
     - taxonomy
-    - user
   enforced:
     module:
       - farm_inventory
@@ -905,9 +905,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any quantity'
+          entity_type:
+            quantity: quantity
       cache:
         type: tag
         options: {  }
@@ -1606,7 +1607,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }
   page_asset:
@@ -1636,6 +1636,5 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
-        - user
         - user.permissions
       tags: {  }

--- a/modules/core/ui/views/config/optional/views.view.farm_organization.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_organization.yml
@@ -4,8 +4,8 @@ dependencies:
   config:
     - system.menu.admin
   module:
+    - farm_entity_access
     - organization
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -307,9 +307,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any organization'
+          entity_type:
+            organization: organization
       cache:
         type: tag
         options: {  }

--- a/modules/core/ui/views/config/optional/views.view.farm_organization_asset.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_organization_asset.yml
@@ -6,10 +6,10 @@ dependencies:
     - organization.type.farm
   module:
     - asset
+    - farm_entity_access
     - farm_location
     - image
     - options
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -704,9 +704,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any asset'
+          entity_type:
+            asset: asset
       cache:
         type: tag
         options: {  }

--- a/modules/core/ui/views/config/optional/views.view.farm_organization_log.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_organization_log.yml
@@ -5,11 +5,11 @@ dependencies:
     - organization.type.farm
   module:
     - entity_reference_revisions
+    - farm_entity_access
     - farm_farm
     - log
     - options
     - state_machine
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -781,9 +781,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any log'
+          entity_type:
+            log: log
       cache:
         type: tag
         options: {  }

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -4,10 +4,10 @@ dependencies:
   config:
     - system.menu.admin
   module:
+    - farm_entity_access
     - options
     - plan
     - state_machine
-    - user
   enforced:
     module:
       - farm_ui_views
@@ -504,9 +504,10 @@ display:
           sort_asc_label: Asc
           sort_desc_label: Desc
       access:
-        type: perm
+        type: farm_entity_collection
         options:
-          perm: 'view any plan'
+          entity_type:
+            plan: plan
       cache:
         type: tag
         options: {  }

--- a/modules/core/ui/views/farm_ui_views.info.yml
+++ b/modules/core/ui/views/farm_ui_views.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - entity_browser:entity_browser
   - farm:asset
   - farm:farm_entity
+  - farm:farm_entity_access
   - farm:farm_flag
   - farm:farm_location
   - farm:farm_ui_menu

--- a/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
@@ -54,8 +54,8 @@ class DashboardTasksTest extends FarmBrowserTestBase {
     $this->user = $this->createUser(['access farm dashboard']);
     $this->drupalLogin($this->user);
 
-    // Create a role that has permission to view log.
-    $this->role = $this->drupalCreateRole(['access farm dashboard', 'view any log']);
+    // Create a role that has permission to view logs.
+    $this->role = $this->drupalCreateRole(['access farm dashboard', 'access log collection', 'view any log']);
 
     // Create a log that is done.
     $this->log = Log::create([

--- a/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
+++ b/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
@@ -40,6 +40,10 @@ class FarmUiViewsTest extends FarmBrowserTestBase {
 
     // Create and login a user with necessary permissions.
     $user = $this->createUser([
+      'access asset collection',
+      'access log collection',
+      'access organization collection',
+      'access quantity collection',
       'view any asset',
       'view any log',
       'view any organization',

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -47,7 +47,7 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
     $this->drupalPlaceBlock('local_tasks_block');
 
     // Create/login a user with permission to access taxonomy pages and assets.
-    $this->user = $this->createUser(['access content', 'view any asset']);
+    $this->user = $this->createUser(['access content', 'access asset collection', 'view any asset']);
     $this->drupalLogin($this->user);
 
     $entity_type_manager = $this->container->get('entity_type.manager');

--- a/modules/log/birth/tests/src/Kernel/BirthTest.php
+++ b/modules/log/birth/tests/src/Kernel/BirthTest.php
@@ -31,6 +31,7 @@ class BirthTest extends KernelTestBase {
     'farm_animal_type',
     'farm_birth',
     'farm_entity',
+    'farm_entity_access',
     'farm_entity_fields',
     'farm_field',
     'farm_id_tag',

--- a/modules/log/birth/tests/src/Kernel/BirthTest.php
+++ b/modules/log/birth/tests/src/Kernel/BirthTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\farm_birth\Kernel;
 
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
@@ -16,6 +17,8 @@ use Drupal\taxonomy\Entity\Term;
  * @group farm
  */
 class BirthTest extends KernelTestBase {
+
+  use UserCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -171,6 +174,13 @@ class BirthTest extends KernelTestBase {
    * Test that only one birth log can reference an asset.
    */
   public function testUniqueBirthLogConstraint() {
+
+    // Create and login a user with access to view any asset and access
+    // taxonomy terms. This is necessary to validate the log entities below,
+    // because the entity module's query access handler enforces view access to
+    // referenced entities during validation.
+    $user = $this->createUser(['view any asset', 'access content']);
+    $this->container->get('current_user')->setAccount($user);
 
     // Create a Cow animal type term.
     /** @var \Drupal\taxonomy\TermInterface $cow */

--- a/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
+++ b/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
@@ -55,7 +55,7 @@ class InputViewMaterialTypeTest extends FarmBrowserTestBase {
     parent::setUp();
 
     // Create and login a user with permission to view logs.
-    $this->user = $this->createUser(['view any log']);
+    $this->user = $this->createUser(['access log collection', 'view any log']);
     $this->drupalLogin($this->user);
 
     // Create material type terms.

--- a/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
+++ b/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
@@ -29,6 +29,7 @@ class FieldConstraintsTest extends KernelTestBase {
     'entity',
     'entity_reference_validators',
     'farm_entity',
+    'farm_entity_access',
     'farm_farm',
     'farm_farm_test',
     'farm_field',

--- a/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
+++ b/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_farm\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\farm_farm\Plugin\Validation\Constraint\AssetGroupAssignmentFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\AssetMovementFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\AssetParentFarm;
@@ -17,6 +18,8 @@ use Drupal\farm_farm\Plugin\Validation\Constraint\LogMovementFarm;
  * @group farm
  */
 class FieldConstraintsTest extends KernelTestBase {
+
+  use UserCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -51,6 +54,7 @@ class FieldConstraintsTest extends KernelTestBase {
     $this->installEntitySchema('asset');
     $this->installEntitySchema('log');
     $this->installEntitySchema('organization');
+    $this->installEntitySchema('user');
     $this->installConfig([
       'farm_farm',
       'farm_farm_test',
@@ -58,6 +62,13 @@ class FieldConstraintsTest extends KernelTestBase {
       'farm_location',
       'farm_log_asset',
     ]);
+
+    // Create and login a user with access to view any organization. This is
+    // necessary to validate the asset entities below, because the entity
+    // module's query access handler enforces view access to referenced entities
+    // during validation.
+    $user = $this->createUser(['view any organization']);
+    $this->container->get('current_user')->setAccount($user);
   }
 
   /**


### PR DESCRIPTION
For more background see this issue: [Allow more granular access on default farmOS Views](https://www.drupal.org/project/farm/issues/3415653)

This PR also includes a few simple commits adding entity `query_access` handlers to our main farmOS core entity types. Borrowed (and rebased) from the old MR here: https://www.drupal.org/project/farm/issues/3413263

Overview of these (proposed!) changes:

1. Add a collection permission for all core entity types eg: `access {entity_type} collection`.

This pattern was recently adopted/supported by Drupal core: https://www.drupal.org/node/2955178.

Notably, Drupal core does not have a way to "provide" this permission, unlike what we are accustomed to seeing via the `entity` module's `permission_provider` system. In some ways the `entity` module was already trying to do this via the `access {entity_type} overview` permission that they provide (and is currently present in farmOS). However, we have never used this permission, and IMO would be better to follow the Drupal core pattern going forward.

---

2. Provide a custom routing access check that ensures users have "entity collection access"

The logic for this access check is as follows:
- Require that the user has the `access {entity_type} collection` permission
- Require that the user has at least ONE of the following view permissions: `view any {entity_type}` or `view own {entity_type}` or (for any 1 bundle) `view any {bundle} {entity_type}` or `view own {bundle} {entity_type}`
- OR if a the route is only designed to display a single bundle - then require that the user has a view permission for that specific bundle, if not either of the higher level `view any {entity_type}` or `view own {entity_type}` permissions

The rationale for this logic is that if we have a page listing a collection of *all* or *many* asset types, we don't want to require that the user has the `view any asset` permission. As long as the user has access to at least one `view * * asset` permission, this listing of all assets should still be visible to them. Thanks to entity `query_access` handlers, all the assets on this page will be filtered to only show those that the user has proper view permissions for (`any/own` and `bundle any/own`).

We also cannot depend on only the collection permission `access asset collection` by itself. Even though we can rely on `query_access` handlers for fundamental security, there is still a UX issue where if a page/view is only going to display `equipment` assets, but the user has no access to see any `equipment` assets, this page would still be accessible in menus and routes. Denying access solves this issue.

Implementing this as a custom access check is nice because it allows this logic to be re-used in many contexts, even outside of views. All you need to do is set the access check like so:

```yaml
module.route:
  path: '/path'
  #... standard routing definition
  requirements:
    _asset_collection_access: 'TRUE'
```
---

3. Provide a `farm_entity_collection` views access plugin 

This is the last step required to connect the entity collection access check to all of our default views routes. While it would be possible to manually and tediously alter each and every view route via a `RoutingSubscriber`.... I think implementing a custom views access plugin will be much easier. This also has the added benefit that this "entity collection access" logic can more easily be used by contrib views, as well as views that don't create pages (blocks, attachments, etc).

