### PR TITLE
Add map layer for "Other Location" assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ requirements:
 - [Add a hook for excluding fields from CSV importers #958](https://github.com/farmOS/farmOS/pull/958)
 - [Include config fields in CSV importers #959](https://github.com/farmOS/farmOS/pull/959)
 - Add support for decimal and integer fields in CSV importers.
+- [Add map layer for "Other Location" assets #966](https://github.com/farmOS/farmOS/pull/966)
 
 ### Changed
 

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -97,10 +97,11 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
         'is_location' => 1,
       ];
 
-      // Add layer for all asset types are locations by default.
+      // Add separate layers for all asset types that are locations by default.
+      $other_location_asset_types = [];
       foreach ($this->assetTypes as $type) {
 
-        // Only add a layer if the asset type is a location by default.
+        // Add a dedicated layer if the asset type is a location by default.
         if ($type->getThirdPartySetting('farm_location', 'is_location', FALSE)) {
 
           // Load the map layer style.
@@ -119,6 +120,21 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
             'zoom' => TRUE,
           ];
         }
+        // Else save the asset type for the "Other locations" layer.
+        else {
+          $other_location_asset_types[] = $type->id();
+        }
+      }
+
+      // Add a layer of location assets of other asset types.
+      if (count($other_location_asset_types)) {
+        $layers['other_locations'] = [
+          'group' => $group,
+          'label' => $this->t('Other locations'),
+          'filters' => $filters + ['type' => $other_location_asset_types],
+          'color' => 'orange',
+          'zoom' => TRUE,
+        ];
       }
 
       // Add the asset_type_layers behavior.


### PR DESCRIPTION
Basically, any assets that are not an asset type that is a location by default (land, structure vs equipment, plant) will not be shown on the dashboard nor locations page. We can quite easily display these additional location assets by including them in a new "Other locations" layer on the map.

I think this could be especially useful for the map on location hierarchy form for organizations https://github.com/farmOS/farmOS/pull/849#issuecomment-2868168802