### PR TITLE
Convert MigrateSource annotations to attributes

### DIFF
--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -59,6 +59,7 @@ return static function (RectorConfig $rectorConfig): void {
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'FieldWidget', 'Drupal\Core\Field\Attribute\FieldWidget'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateDestination', 'Drupal\migrate\Attribute\MigrateDestination'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateProcessPlugin', 'Drupal\migrate\Attribute\MigrateProcess'),
+    new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'MigrateSource', 'Drupal\migrate\Attribute\MigrateSource'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsArgument', 'Drupal\views\Attribute\ViewsArgument'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsDisplayExtender', 'Drupal\views\Attribute\ViewsDisplayExtender'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'ViewsField', 'Drupal\views\Attribute\ViewsField'),

--- a/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_import_csv\Plugin\migrate\source;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\Attribute\MigrateSource;
 use Drupal\migrate\MigrateException;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate_source_csv\Plugin\migrate\source\CSV;
@@ -17,12 +18,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * This extends the CSV source plugin provided by migrate_source_csv, and
  * automatically handles assigning a file entity ID and row number to the
  * unique IDs of each row.
- *
- * @MigrateSource(
- *   id = "csv_file",
- *   source_module = "farm_import_csv"
- * )
  */
+#[MigrateSource(
+  id: 'csv_file',
+  source_module: 'farm_import_csv',
+)]
 class CSVFile extends CSV implements ContainerFactoryPluginInterface {
 
   /**

--- a/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
@@ -21,7 +21,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 #[MigrateSource(
   id: 'csv_file',
-  source_module: 'farm_import_csv',
 )]
 class CSVFile extends CSV implements ContainerFactoryPluginInterface {
 


### PR DESCRIPTION
This is a follow up to the Drupal 11 upgrade PR (#967), which converts `ContentEntityType` and `ConfigEntityType` annotations to attributes (see https://www.drupal.org/node/3505422). The `MigrateSource` plugin annotation is not converted to an annotation until Drupal 11.2, which hasn't been released yet (see https://www.drupal.org/node/3505424). So this PR is a draft until Drupal 11.2 is released and we update farmOS to it.