### PR TITLE
Fix plan_record bundle field providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ requirements:
 - Remove [EXIF Orientation](https://www.drupal.org/project/exif_orientation) module (see [Automatically rotate derivative images based on EXIF Orientation #941](https://github.com/farmOS/farmOS/pull/941)).
 - Remove [JSON:API Extras](https://www.drupal.org/project/jsonapi_extras) module (see [Remove dependency on JSON:API Extras module #964](https://github.com/farmOS/farmOS/pull/964)).
 
+### Fixed
+
+- [Fix plan_record bundle field providers #969](https://github.com/farmOS/farmOS/pull/969)
+
 ## farmOS 3.x
 
 farmOS 3.x release notes are available in the 3.x branch's

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -92,7 +92,7 @@ function farm_entity_entity_type_build(array &$entity_types) {
 function farm_entity_entity_field_storage_info_alter(&$fields, EntityTypeInterface $entity_type) {
 
   // Bail if not a farm entity type that allows bundle plugins.
-  if (!in_array($entity_type->id(), ['log', 'asset', 'plan', 'quantity'])) {
+  if (!in_array($entity_type->id(), ['asset', 'log', 'plan', 'plan_record', 'quantity'])) {
     return;
   }
 


### PR DESCRIPTION
This issue was discovered in https://github.com/farmOS/farmOS/pull/967#discussion_r2110930522

Basically, we should have added `plan_record` to the list of entity types in `farm_entity_entity_field_storage_info_alter()` when we added it to `farm_entity_entity_type_build()` in https://github.com/farmOS/farmOS/commit/79704c3c7c0e67dd60468ce54c59fc39f0fc95d0 (part of #781).

`farm_entity_entity_field_storage_info_alter()` is responsible for setting the `provider` information on bundle fields provided by `hook_farm_entity_bundle_field_info()`.

Some notes from @paul121 in chat:

> and re: this bug.... I think it's hard to notice because often times many modules are all installed at the same time
> but if you installed a module that provides a new bundle field to an existing `plan_record` bundle..... that might cause an error..... when you go to uninstall the "new module"
> so I'm not sure how important the bug/bug fix is
> maybe it just requires rebuilding the bundle field map? which now happens on cache rebuild?

Here is the commit that originally added that hook: https://github.com/farmOS/farmOS/commit/e0b22414cb8ef7a08c6f82810ee576148d098e95