### PR TITLE
Make the farmOS API optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ requirements:
 - [Convert equipment to a base field #956](https://github.com/farmOS/farmOS/pull/956)
 - [Convert quick to a base field #957](https://github.com/farmOS/farmOS/pull/957)
 - [Make farmOS API OAuth2 Server optional #973](https://github.com/farmOS/farmOS/pull/973)
+- [Make the farmOS API optional #974](https://github.com/farmOS/farmOS/pull/973)
 - [Move QuantityCsvNormalizer to farm_csv module #977](https://github.com/farmOS/farmOS/pull/977)
 
 ### Deprecated

--- a/docs/development/api/index.md
+++ b/docs/development/api/index.md
@@ -3,6 +3,10 @@
 farmOS provides an API that other applications and systems can use to read and
 write records via HTTP requests.
 
+## Install
+
+Install the farmOS API module (`farm_api`) to enable API endpoints.
+
 ## Client Libraries
 
 Client libraries are available for interacting with the farmOS API:

--- a/farm.profile
+++ b/farm.profile
@@ -21,7 +21,6 @@ declare(strict_types=1);
 function farm_modules() {
   return [
     'base' => [
-      'farm_api' => t('farmOS API'),
       'farm_login' => t('Login with username or email.'),
       'farm_settings' => t('farmOS Settings forms'),
       'farm_setup' => t('farmOS Setup pages'),
@@ -66,6 +65,7 @@ function farm_modules() {
       'farm_comment_log' => t('Log comments'),
       'farm_comment_plan' => t('Plan comments'),
       'farm_map_mapbox' => t('Mapbox map layers: Satellite, Outdoors'),
+      'farm_api' => t('farmOS API'),
       'farm_api_oauth' => t('farmOS API OAuth2 Server'),
       'farm_api_default_consumer' => t('Default API Consumer'),
       'farm_fieldkit' => t('Field Kit integration'),


### PR DESCRIPTION
This PR makes the `farm_api` module optional, so site administrators can choose whether or not to install it.

If you are not using the API, it is not necessary to provide all of the `/api/*` endpoints, and by removing them it reduces potential attack surface / vulnerabilities.

This is a follow-up to #973, and includes its commit.