### PR TITLE
Move QuantityCsvNormalizer to farm_csv module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ requirements:
 - [Convert equipment to a base field #956](https://github.com/farmOS/farmOS/pull/956)
 - [Convert quick to a base field #957](https://github.com/farmOS/farmOS/pull/957)
 - [Make farmOS API OAuth2 Server optional #973](https://github.com/farmOS/farmOS/pull/973)
+- [Move QuantityCsvNormalizer to farm_csv module #977](https://github.com/farmOS/farmOS/pull/977)
 
 ### Deprecated
 

--- a/modules/core/csv/farm_csv.info.yml
+++ b/modules/core/csv/farm_csv.info.yml
@@ -5,3 +5,4 @@ package: farmOS
 core_version_requirement: ^11
 dependencies:
   - csv_serialization:csv_serialization
+  - farm:farm_log_quantity

--- a/modules/core/csv/farm_csv.services.yml
+++ b/modules/core/csv/farm_csv.services.yml
@@ -8,6 +8,11 @@ services:
     tags:
       - { name: normalizer, priority: 10 }
     arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager']
+  farm_csv.normalizer.quantity_normalizer:
+    class: Drupal\farm_csv\Normalizer\QuantityNormalizer
+    tags:
+      - { name: normalizer, priority: 15 }
+    arguments: [ '@entity_type.manager', '@entity_type.repository', '@entity_field.manager' ]
   farm_csv.normalizer.fraction_field_item:
     class: Drupal\farm_csv\Normalizer\FractionFieldItemNormalizer
     tags:

--- a/modules/core/csv/src/Normalizer/QuantityNormalizer.php
+++ b/modules/core/csv/src/Normalizer/QuantityNormalizer.php
@@ -2,15 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Drupal\farm_export_csv\Normalizer;
+namespace Drupal\farm_csv\Normalizer;
 
-use Drupal\farm_csv\Normalizer\ContentEntityNormalizer;
 use Drupal\quantity\Entity\QuantityInterface;
 
 /**
  * Normalizes quantity entities for CSV exports.
  */
-class QuantityCsvNormalizer extends ContentEntityNormalizer {
+class QuantityNormalizer extends ContentEntityNormalizer {
 
   /**
    * {@inheritdoc}

--- a/modules/core/export/modules/csv/farm_export_csv.services.yml
+++ b/modules/core/export/modules/csv/farm_export_csv.services.yml
@@ -1,6 +1,0 @@
-services:
-  farm_export_csv.normalizer.quantity_csv_normalizer:
-    class: Drupal\farm_export_csv\Normalizer\QuantityCsvNormalizer
-    tags:
-      - { name: normalizer, priority: 15 }
-    arguments: [ '@entity_type.manager', '@entity_type.repository', '@entity_field.manager' ]


### PR DESCRIPTION
This allows it to be used by other modules even if `farm_export_csv` is not enabled.

This also adds a dependency on `farm_log_quantity`, which was missing from `farm_export_csv` as well.