### PR TITLE
Allow plans without active status in farm_plan View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ requirements (inherited from Drupal 11):
 - [Move QuantityCsvNormalizer to farm_csv module #977](https://github.com/farmOS/farmOS/pull/977)
 - [The farm_account_admin role has moved to a new farm_account_admin module](https://www.drupal.org/node/3527786)
 - [The farm_manager, farm_worker, and farm_viewer roles have moved to their own modules](https://www.drupal.org/node/3527787)
+- [Allow plans without active status in farm_plan View #978](https://github.com/farmOS/farmOS/pull/978)
 
 ### Deprecated
 

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -996,9 +996,9 @@ display:
           entity_type: plan
           entity_field: status
           plugin_id: state_machine_state
-          operator: in
+          operator: 'not in'
           value:
-            active: active
+            archived: archived
           group: 1
           exposed: false
           expose:

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -593,8 +593,7 @@ display:
           entity_field: status
           plugin_id: state_machine_state
           operator: in
-          value:
-            active: active
+          value: {  }
           group: 1
           exposed: true
           expose:


### PR DESCRIPTION
I'm working on a contrib module that adds its own plan type, and it will be providing it's own set of plan statuses via `mymodule.workflows.yml`. Specifically, it will replace the `active` status with a set of others that are specific to the planning process. The thought being that `active` is a simple default status for farmOS to provide, but contrib should be able to split that up into multiple statuses of its own definition, which by all accounts are still "active" (as opposed to "archived").

With my module installed, I see the following error when I go to `/plans`:

> Error message
> The submitted value active in the status element is not allowed. 

Screenshot:

![Screenshot from 2025-07-02 17-10-37](https://github.com/user-attachments/assets/68da6db3-ee95-474e-8e35-379ef0911bd8)

This happens because the `farm_plan` View includes an exposed filter that defaults to showing plans with an `active` status. However, `active` is not a valid status in my case.

Furthermore, the "Active Plans" block on the dashboard also won't work in this context, because it also explicitly filters to plans with an `active` status.

This PR proposes the following fixes (each in a separate commit):

1. Show plans of any status in farm_plan View by default.

Do not filter by `active` status in the `/plans` page.

This simply removes the default selection of the exposed "Status" filter, which means all plans show by default (including Archived plans). The user can then choose to filter as desired.

4. Show plans that do not have a status of "archived" in farm_plan View "Active Plans" block display.

This changes the (non-exposed) filter configuration of the "Active Plans" dashboard block so that it is "not archived" rather than "is active". This fixes the issue described, but it still expects `archived` to be an option. This is OK in this case though because it's not an exposed filter, so Drupal doesn't validate the dropdown list options.