### PR TITLE
Require PHP 8.4

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -102,8 +102,8 @@ jobs:
         run: docker run ${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-amd64 phpcs /opt/drupal/web/profiles/farm
       - name: Check PHP compatibility of contrib modules and themes (ignore warnings)
         run: |
-          docker run ${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-amd64 phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/modules
-          docker run ${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-amd64 phpcs --standard=PHPCompatibility --runtime-set testVersion 8.3- --warning-severity=0 /opt/drupal/web/themes
+          docker run ${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-amd64 phpcs --standard=PHPCompatibility --runtime-set testVersion 8.4- --warning-severity=0 /opt/drupal/web/modules
+          docker run ${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-amd64 phpcs --standard=PHPCompatibility --runtime-set testVersion 8.4- --warning-severity=0 /opt/drupal/web/themes
 
   phpstan:
     name: PHPStan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,8 @@ fixed. See
 [farmOS coding standards](https://farmos.org/development/environment/code/) for
 more information.
 
-Drupal 11 requires PHP 8.3+, and has the following minimum database version
-requirements:
+farmOS v3 requires PHP 8.4, and has the following minimum database version
+requirements (inherited from Drupal 11):
 
 - PostgreSQL 16+
 - MariaDB 10.6+
@@ -48,7 +48,7 @@ requirements:
 
 ### Changed
 
-- farmOS 4.x requires PHP 8.3+.
+- [farmOS 4.x requires PHP 8.4 #979](https://github.com/farmOS/farmOS/pull/979)
 - [Issue #3488916: Update Drupal core to 11.x](https://www.drupal.org/project/farm/issues/3488916)
 - [Convert equipment to a base field #956](https://github.com/farmOS/farmOS/pull/956)
 - [Convert quick to a base field #957](https://github.com/farmOS/farmOS/pull/957)

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "drupal/admin_toolbar": "^3.5",
         "drupal/core": "11.1.7",
         "drupal/config_update": "^2.0@alpha",
-        "drupal/consumers": "^1.19",
+        "drupal/consumers": "1.19",
         "drupal/csv_serialization": "^4.0.1",
         "drupal/date_popup": "^2.0",
         "drupal/entity": "1.6",
@@ -56,6 +56,9 @@
             "drupal/core": "-p2"
         },
         "patches": {
+            "drupal/consumers": {
+                "Issue #3496751: PHP 8.4: Implicitly nullable parameter declarations deprecated": "https://www.drupal.org/files/issues/2025-05-08/consumers-php8.4-3496751.patch"
+            },
             "drupal/core": {
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2025-03-31/2339235-11.1.x-93.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/inspire_tree": "^1.0.6",
         "drupal/jsonapi_schema": "^1.0",
         "drupal/log": "^2.3.1",
-        "drupal/migrate_plus": "^6.0.5",
+        "drupal/migrate_plus": "6.0.5",
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_source_ui": "^1.1",
         "drupal/migrate_tools": "^6.0.5",
@@ -73,6 +73,9 @@
             },
             "drupal/gin": {
                 "Issue #3342164: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch"
+            },
+            "drupal/migrate_plus": {
+                "Issue #3508679: PHP 8.4 implicit nullable deprecation": "https://www.drupal.org/files/issues/2025-04-10/migrate_plus-3508679.patch"
             },
             "itamair/geophp": {
                 "Use BCMath (where available) for all float arithmetic #115": "https://patch-diff.githubusercontent.com/raw/phayes/geoPHP/pull/115.patch"

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "drupal/migrate_plus": "6.0.5",
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_source_ui": "^1.1",
-        "drupal/migrate_tools": "^6.0.5",
+        "drupal/migrate_tools": "6.0.5",
         "drupal/role_delegation": "^1.3",
         "drupal/simple_oauth": "^6.0",
         "drupal/simple_oauth_password_grant": "^2.1",
@@ -76,6 +76,9 @@
             },
             "drupal/migrate_plus": {
                 "Issue #3508679: PHP 8.4 implicit nullable deprecation": "https://www.drupal.org/files/issues/2025-04-10/migrate_plus-3508679.patch"
+            },
+            "drupal/migrate_tools": {
+                "Issue #3411051: Fix PHPCS issues": "https://git.drupalcode.org/project/migrate_tools/-/commit/fe834c7295b3e028e755f1b399b1b9d2272b4c2b.patch"
             },
             "itamair/geophp": {
                 "Use BCMath (where available) for all float arithmetic #115": "https://patch-diff.githubusercontent.com/raw/phayes/geoPHP/pull/115.patch"

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "drush/drush": "^13.0",
         "ext-simplexml": "*",
         "itamair/geophp": "1.6",
-        "php": ">=8.3"
+        "php": ">=8.4"
     },
     "extra": {
         "patchLevel": {

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "drupal/simple_oauth": "^6.0",
         "drupal/simple_oauth_password_grant": "^2.1",
         "drupal/state_machine": "^1.12",
-        "drupal/subrequests": "^3.0.12",
+        "drupal/subrequests": "3.0.12",
         "drupal/token": "^1.15",
         "drupal/views_geojson": "^1.3",
         "drush/drush": "^13.0",
@@ -79,6 +79,9 @@
             },
             "drupal/migrate_tools": {
                 "Issue #3411051: Fix PHPCS issues": "https://git.drupalcode.org/project/migrate_tools/-/commit/fe834c7295b3e028e755f1b399b1b9d2272b4c2b.patch"
+            },
+            "drupal/subrequests": {
+                "Issue #3524429: PHP 8.4 deprecation: Implicitly marking parameter as nullable": "https://git.drupalcode.org/issue/subrequests-3524429/-/commit/784ccfe8af7d803f392263d2dbf7dcd89f9566d5.patch"
             },
             "itamair/geophp": {
                 "Use BCMath (where available) for all float arithmetic #115": "https://patch-diff.githubusercontent.com/raw/phayes/geoPHP/pull/115.patch"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Alias the Drupal base image for use in other build stages.
 # We do this so that the Drupal image version only needs to be updated here.
-FROM drupal:11.1-php8.3 AS baseimage
+FROM drupal:11.1-php8.4 AS baseimage
 
 # Define common paths.
 # BUILD_PATH is where the farmOS codebase will be built.

--- a/docker/dev/files/phpcs.xml
+++ b/docker/dev/files/phpcs.xml
@@ -26,6 +26,6 @@
     </properties>
   </rule>
   <rule ref="PHPCompatibility"/>
-  <config name="testVersion" value="8.3-"/>
+  <config name="testVersion" value="8.4-"/>
   <rule ref="Internal.Tokenizer.Exception"><severity>0</severity></rule>
 </ruleset>

--- a/docs/hosting/requirements.md
+++ b/docs/hosting/requirements.md
@@ -16,7 +16,7 @@ the same [requirements](https://drupal.org/docs/system-requirements).
 In addition to Drupal's basic requirements, farmOS has the following server
 dependencies. The [farmOS Docker images](/hosting/docker/) include these.
 
-- **PHP 8.3+**
+- **PHP 8.4**
 - **PHP configuration** - The following PHP settings are recommended:
     - `memory_limit=256M`
     - `max_execution_time=240`


### PR DESCRIPTION
This updates farmOS to run on PHP 8.4 in the Docker image, and to require it in `composer.json`.