### PR TITLE
Update Gin to 4.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "drupal/entity_reference_validators": "^2.0",
         "drupal/fraction": "^3.0",
         "drupal/geofield": "^1.62",
-        "drupal/gin": "4.0.6",
+        "drupal/gin": "4.1.0",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/inspire_tree": "^1.0.6",
         "drupal/jsonapi_schema": "^1.0",


### PR DESCRIPTION
This PR updates Gin to 4.1.0. This is necessary because we pin and patch it.

https://www.drupal.org/project/gin/releases/4.1.0