### PR TITLE
Document farm_ext_ module namespacing guidance

### DIFF
--- a/docs/development/module/index.md
+++ b/docs/development/module/index.md
@@ -29,6 +29,13 @@ For example, if you were to build a module that adds a new log type called
 this module is made to work with farmOS, and is not designed to be installed in
 other Drupal sites more generally.
 
+Since future versions of farmOS may include new modules (as a normal process of
+its development - maintenance or adding features), it is also important to consider
+whether your module name is likely to conflict and whether you want to avoid that
+upfront. External contrib modules may use the module name prefix `farm_ext_` to
+avoid such future conflicts. farmOS will never include a module named with that
+prefix to reserve it for external contrib modules.
+
 ## File structure
 
 A farmOS (Drupal) module only requires one file for it to be recognized as a


### PR DESCRIPTION
The existing module development namespacing guidance actually makes it more likely that contrib modules will eventually conflict with core farmOS modules.

This change describes a new prefix `farm_ext_` for external contrib modules and promises that farmOS itself will never ship a module thus named as part of core.