### PR TITLE
Rename primary tab in edit forms to General

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ requirements (inherited from Drupal 11):
 - [The farm_account_admin role has moved to a new farm_account_admin module](https://www.drupal.org/node/3527786)
 - [The farm_manager, farm_worker, and farm_viewer roles have moved to their own modules](https://www.drupal.org/node/3527787)
 - [Allow plans without active status in farm_plan View #978](https://github.com/farmOS/farmOS/pull/978)
+- [Rename primary tab in edit forms to General #985](https://github.com/farmOS/farmOS/pull/985)
 
 ### Deprecated
 

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -89,7 +89,7 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
     $field_groups = [
       'default' => [
         'location' => 'main',
-        'title' => 'Default',
+        'title' => $this->t('General'),
         'weight' => -50,
       ],
       'meta' => [
@@ -143,11 +143,6 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
       // Disable HTML5 validation on the form element since it does not work
       // with vertical tabs.
       $form['#attributes']['novalidate'] = 'novalidate';
-
-      // Vary field group titles based on entity and bundle.
-      if (isset($field_groups['default'])) {
-        $field_groups['default']['title'] = $this->getBundleEntity()?->label() ?? $this->entity->getEntityType()->getLabel();
-      }
 
       // Create parent for all tabs.
       $form['tabs'] = [


### PR DESCRIPTION
## Context

#770 implemented the Gin content form for our entity types (assets, logs, etc) and moved fields to vertical tabs within the form and sidebar. More discussion here for context: https://farmos.discourse.group/t/ui-improvements-editing-forms/1743

One of the decisions made during this work was to set the title of the primary vertical tab (the one at the top that is visible by default) to the label of the bundle being edited.

For example, if you are editing an Activity log, the label of the primary tab is "Activity". See the green text in the following screenshot:

<img width="945" height="392" alt="Screenshot from 2025-07-31 14-34-28" src="https://github.com/user-attachments/assets/0f982f2d-1f54-4d8e-9c14-f70b6d90809b" />

Or, if you're editing an Animal asset, the label of the primary tab is "Animal":

<img width="945" height="392" alt="Screenshot from 2025-07-31 14-35-26" src="https://github.com/user-attachments/assets/e2f9928d-6d12-4134-a1d3-d8720a70bf77" />

## Proposal

I would like to propose that we rename this tab to simply "General".

Here is a screenshot of this change:

<img width="945" height="392" alt="Screenshot from 2025-07-31 14-42-05" src="https://github.com/user-attachments/assets/d12c4567-a083-42da-95fc-38de09590ff1" />

### Reasoning

My reasoning is two-fold...

First, I worry that the current titles (which vary based on the bundle) can potentially cause confusion/ambiguity in the form. If the tab is "Plant", that implies that it contains information about the Plant asset. But in reality, it's just "general" information about the plant asset. And all the other tabs ALSO contain information about the plant asset. So it feels a bit odd.

Second, while this strangeness is probably overcome quickly by new users, after they've had a chance to wrap their mind around the form and what is included, specifically in the context of core assets and logs, I think the ambiguity becomes greater with *plan* entities.

For example, this is what it looks like where you're adding a Crop plan (from https://www.drupal.org/project/farm_crop_plan):

<img width="945" height="392" alt="Screenshot from 2025-07-31 15-02-25" src="https://github.com/user-attachments/assets/7bc8a9ff-2f28-4ae4-8532-9aad553c5f68" />

... and adding a Grazing plan (from https://www.drupal.org/project/farm_grazing_plan):

<img width="945" height="392" alt="Screenshot from 2025-07-31 15-02-29" src="https://github.com/user-attachments/assets/dac81807-f613-40b9-ac3b-544ab8f62362" />

The fact that "plan" is not included in the name makes "Crop" even more confusing. This is sort of a separate issue with the way plans types are named generally (which I may also propose a change for in a separate PR soon), but it serves to emphasize the ambiguity of using the bundle name as the title of the primary tab (and was my primary motivation for suggesting this change).