### PR TITLE
Change drupal_internal__* to internal_* in JSON:API responses

### DIFF
--- a/modules/core/api/src/EventSubscriber/JsonApiBuildSubscriber.php
+++ b/modules/core/api/src/EventSubscriber/JsonApiBuildSubscriber.php
@@ -35,7 +35,10 @@ class JsonApiBuildSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
-    $events[ResourceTypeBuildEvents::BUILD][] = ['disableResources'];
+    $events[ResourceTypeBuildEvents::BUILD] = [
+      ['disableResources'],
+      ['renameInternals'],
+    ];
     return $events;
   }
 
@@ -51,6 +54,26 @@ class JsonApiBuildSubscriber implements EventSubscriberInterface {
     $entity_type = explode('--', $event->getResourceTypeName())[0];
     if (!in_array($entity_type, $allowed_entity_types)) {
       $event->disableResourceType();
+    }
+  }
+
+  /**
+   * Rename drupal_internal__* to internal__*.
+   *
+   * @param \Drupal\jsonapi\ResourceType\ResourceTypeBuildEvent $event
+   *   The build resource build event.
+   */
+  public function renameInternals(ResourceTypeBuildEvent $event) {
+
+    // Iterate through all fields of this resource type.
+    $fields = $event->getFields();
+    foreach ($fields as $field) {
+
+      // If the field's public name starts with "drupal_internal_", remove the
+      // "drupal_" prefix, so it is just "internal_*".
+      if (str_starts_with($field->getPublicName(), 'drupal_internal_')) {
+        $event->setPublicFieldName($field, substr($field->getPublicName(), strlen('drupal_')));
+      }
     }
   }
 


### PR DESCRIPTION
This PR proposes changing `drupal_internal__*` properties in the farmOS JSON:API to `internal__*`, removing the `drupal_` prefix.

IMO there is no need to include `drupal_`. A prefix of `internal__*` is enough to indicate that the properties are internal.

The two main attributes that are affected by this are `drupal_internal__id` and `drupal_internal__revision_id`.

Notably, there is one other instance of `drupal_internal__*` that appears deeper in the JSON structures, which this PR currently does NOT fix. Some `relationships` include a `meta.drupal_internal__target_id` to indicate the internal ID of the referenced entity. This appears under `relationships` like `asset_type` (and other similar ones like `log_type`) and `uid` (but notably not in any of the `entity_reference` relationships farmOS adds). Here is the Drupal core change record that added it: https://www.drupal.org/node/3218910

The problem is that it is added in `\Drupal\jsonapi\JsonApiResource\ResourceIdentifier::toResourceIdentifier()`, but there is no way to modify it from another module, and all JSON:API classes are marked as `@internal` with an explicit warning:

```
 * @internal JSON:API maintains no PHP API. The API is the HTTP API. This class
 *   may change at any time and could break any dependencies on it.
 *
 * @see https://www.drupal.org/project/drupal/issues/3032787
 ```

Drupal 11.2 included a new feature that allows *adding* to high-level `meta` properties (https://www.drupal.org/project/drupal/issues/3100732), but it doesn't sound like this would help. @bradjones1 commented to this effect in an issue he created to propose allowing "opt-out of automatic meta.drupal_internal__target_id on entity relationships": https://www.drupal.org/project/drupal/issues/3257608#comment-14463720

So... the question is: should we consider changing `drupal_internal__*` to `internal_*` in the high-level JSON:API resources, but leave `drupal_internal__target_id` alone? Or try to find another (heavier-handed) way of fixing that case? Or should we just leave `drupal_internal__*` and scrap this idea?

This PR still needs tests, but I figure those will be pretty easy to add, if we decide this is worth pursuing.