### PR TITLE
Fix logic for forcing entity revision creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ requirements (inherited from Drupal 11):
 ### Fixed
 
 - [Fix plan_record bundle field providers #969](https://github.com/farmOS/farmOS/pull/969)
+- [Fix logic for forcing entity revision creation #988](https://github.com/farmOS/farmOS/pull/969)
 
 ## farmOS 3.x
 

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_api\Kernel;
 
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\asset\Entity\AssetInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -208,6 +210,55 @@ class FarmApiTest extends KernelTestBase {
   }
 
   /**
+   * Test that entity revisions are created with PATCH requests.
+   */
+  public function testEntityRevisions() {
+
+    // Test creating an asset.
+    $asset_type = 'asset--test';
+    $payload = [
+      'type' => $asset_type,
+      'attributes' => [
+        'name' => 'Test asset',
+      ],
+    ];
+    $data = $this->apiRequest('/api/asset/test', 'POST', $payload);
+    $this->assertNotEmpty($data['data']['id']);
+    $this->assertNotEmpty($data['data']['attributes']['drupal_internal__id']);
+    $this->assertEquals($asset_type, $data['data']['type']);
+    $this->assertEquals($payload['attributes']['name'], $data['data']['attributes']['name']);
+
+    // Load the asset.
+    $asset_storage = \Drupal::entityTypeManager()->getStorage('asset');
+    $asset_id = $data['data']['attributes']['drupal_internal__id'];
+    $asset = $asset_storage->load($asset_id);
+    $this->assertInstanceOf(AssetInterface::class, $asset);
+
+    // Confirm that there is a single revision.
+    $revision_ids = $this->revisionIds($asset);
+    $this->assertCount(1, $revision_ids);
+
+    // Update the asset via the API.
+    $payload = [
+      'type' => $asset_type,
+      'id' => $data['data']['id'],
+      'attributes' => [
+        'name' => 'Test asset update',
+      ],
+    ];
+    $data = $this->apiRequest('/api/asset/test/' . $data['data']['id'], 'PATCH', $payload);
+    $data = $this->apiRequest('/api/asset/test/' . $data['data']['id']);
+    $this->assertEquals($payload['attributes']['name'], $data['data']['attributes']['name']);
+
+    // Reload the asset.
+    $asset = $asset_storage->load($asset_id);
+
+    // Confirm that there are two revisions.
+    $revision_ids = $this->revisionIds($asset);
+    $this->assertCount(2, $revision_ids);
+  }
+
+  /**
    * Helper function for performing an API request.
    *
    * @param string $endpoint
@@ -246,6 +297,28 @@ class FarmApiTest extends KernelTestBase {
     }
     $this->assertEquals($expected_response, $response->getStatusCode());
     return Json::decode($response->getContent());
+  }
+
+  /**
+   * Loads all revision IDs of an entity sorted by revision ID descending.
+   *
+   * This is copied+modified from RevisionControllerTrait::revisionIds().
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return mixed[]
+   *   Returns a list of revision IDs.
+   */
+  protected function revisionIds(EntityInterface $entity) {
+    $entity_type = $entity->getEntityType();
+    $result = \Drupal::entityTypeManager()->getStorage($entity_type->id())->getQuery()
+      ->allRevisions()
+      ->condition($entity_type->getKey('id'), $entity->id())
+      ->sort($entity_type->getKey('revision'), 'DESC')
+      ->accessCheck(TRUE)
+      ->execute();
+    return array_keys($result);
   }
 
 }

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -149,11 +149,11 @@ function farm_entity_entity_presave(EntityInterface $entity) {
   // @see https://www.drupal.org/project/drupal/issues/2993557
   // @see https://www.drupal.org/project/drupal/issues/2795279
   // @see https://github.com/json-api/json-api/pull/824
-  $entity_type = $entity->get('type')->getEntity();
+  $entity_type = $entity->get($entity->getEntityType()->getKey('bundle'))->entity;
   if (
     $entity_type instanceof RevisionableEntityBundleInterface
     && $entity_type->shouldCreateNewRevision()
-    && $entity_type->getEntityType()->isRevisionable()
+    && $entity->getEntityType()->isRevisionable()
   ) {
 
     // Always create a new revision.

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -145,10 +145,8 @@ function farm_entity_entity_presave(EntityInterface $entity) {
     return;
   }
 
-  // Force create new revision as json api doesn't do that by default.
-  // @see https://www.drupal.org/project/drupal/issues/2993557
-  // @see https://www.drupal.org/project/drupal/issues/2795279
-  // @see https://github.com/json-api/json-api/pull/824
+  // Always create new revisions when an entity is saved.
+  // This ensures a proper audit trail is available for important records.
   $entity_type = $entity->get($entity->getEntityType()->getKey('bundle'))->entity;
   if (
     $entity_type instanceof RevisionableEntityBundleInterface

--- a/modules/core/entity/tests/modules/farm_entity_test/config/install/quantity.type.test.yml
+++ b/modules/core/entity/tests/modules/farm_entity_test/config/install/quantity.type.test.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: test
+label: Test
+description: ''
+new_revision: true

--- a/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Quantity/QuantityType/TestQuantity.php
+++ b/modules/core/entity/tests/modules/farm_entity_test/src/Plugin/Quantity/QuantityType/TestQuantity.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity_test\Plugin\Quantity\QuantityType;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\QuantityType;
+use Drupal\farm_entity\Plugin\Quantity\QuantityType\FarmQuantityType;
+
+/**
+ * Provides the test quantity type.
+ */
+#[QuantityType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
+class TestQuantity extends FarmQuantityType {
+
+}

--- a/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_entity\Kernel;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests farmOS entity revisions.
+ *
+ * @group farm
+ */
+class FarmEntityRevisionsTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'farm';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'asset',
+    'entity',
+    'farm_entity',
+    'farm_entity_test',
+    'farm_field',
+    'fraction',
+    'log',
+    'options',
+    'plan',
+    'quantity',
+    'state_machine',
+    'taxonomy',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp():void {
+    parent::setUp();
+    $this->installEntitySchema('asset');
+    $this->installEntitySchema('log');
+    $this->installEntitySchema('plan');
+    $this->installEntitySchema('quantity');
+    $this->installConfig(['farm_entity_test']);
+  }
+
+  /**
+   * Test farmOS entity revisions.
+   */
+  public function testFarmEntityRevisions() {
+
+    // Define the entity types and bundles we want to test.
+    $entity_types = [
+      'asset' => 'test',
+      'log' => 'test',
+      'plan' => 'test',
+      'quantity' => 'test',
+    ];
+
+    // Test that new revisions are automatically created whenever an entity is
+    // saved.
+    foreach ($entity_types as $entity_type => $bundle) {
+      $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+      $entity = $storage->create([
+        'name' => 'Test',
+        'type' => $bundle,
+      ]);
+      $entity->save();
+      $this->assertCount(1, $this->revisionIds($entity));
+      $entity->save();
+      $this->assertCount(2, $this->revisionIds($entity));
+    }
+
+  }
+
+  /**
+   * Loads all revision IDs of an entity sorted by revision ID descending.
+   *
+   * This is copied+modified from RevisionControllerTrait::revisionIds().
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity.
+   *
+   * @return mixed[]
+   *   Returns a list of revision IDs.
+   */
+  protected function revisionIds(EntityInterface $entity) {
+    $entity_type = $entity->getEntityType();
+    $result = \Drupal::entityTypeManager()->getStorage($entity_type->id())->getQuery()
+      ->allRevisions()
+      ->condition($entity_type->getKey('id'), $entity->id())
+      ->sort($entity_type->getKey('revision'), 'DESC')
+      ->accessCheck(TRUE)
+      ->execute();
+    return array_keys($result);
+  }
+
+}


### PR DESCRIPTION
Back in 2021, during the 2.x upgrade, we added logic to the `farm_entity` module to force the creation of entity revisions. This was done to ensure that revisions are created via API requests.

Original issue for more context: https://www.drupal.org/node/3216766

A recent commit broke this logic. This PR fixes it and adds an automated test to prevent future regressions.

It also moves the two hooks responsible for this logic from `farm_entity.module` to `farm_api.module`. My reasoning is: this is only necessary for API requests (but unfortunately we can't tell where the update is happening, so we take a heavy-handed approach), and now that the API is optional (#974), we can allow normal revision logic when the API is not in use. It also makes sense for the automated test for this to live in the `farm_api` module's kernel tests IMO. 

Here is the commit that broke the logic: https://github.com/farmOS/farmOS/commit/a512c3042e7eff93c6b628882f20df5db08c6bed

There are two things wrong with the current logic which causes the hook to bail early:

1. `$entity_type = $entity->get('type')->getEntity();` loads the content entity, not the bundle config entity. This causes `$entity_type instanceof RevisionableEntityBundleInterface` to return `FALSE`
2. The `$entity->getEntityType()->isRevisionable()` check changed to `$entity_type->getEntityType()->isRevisionable()`, which does not work if `$entity_type` is a bundle config entity (as it should be).

(Note that this PR builds on top of #980, because it touches code that changed in that PR, so it includes all of those commits as well. This PR only adds 2 commits by itself.)