### PR TITLE
Inject entity_type.manager and current_user service dependencies into QuickFormBase class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ requirements (inherited from Drupal 11):
 - [The farm_manager, farm_worker, and farm_viewer roles have moved to their own modules](https://www.drupal.org/node/3527787)
 - [Allow plans without active status in farm_plan View #978](https://github.com/farmOS/farmOS/pull/978)
 - [Rename primary tab in edit forms to General #985](https://github.com/farmOS/farmOS/pull/985)
+- [Inject entity_type.manager and current_user service dependencies into QuickFormBase class #989](https://github.com/farmOS/farmOS/pull/989)
 
 ### Deprecated
 

--- a/docs/development/module/quick.md
+++ b/docs/development/module/quick.md
@@ -77,7 +77,7 @@ class Harvest extends QuickFormBase {
     $form['timestamp'] = [
       '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime('now', \Drupal::currentUser()->getTimeZone()),
+      '#default_value' => new DrupalDateTime('now', $this->currentUser->getTimeZone()),
       '#required' => TRUE,
     ];
 
@@ -300,7 +300,7 @@ class Harvest extends QuickFormBase implements ConfigurableQuickFormInterface {
     $form['timestamp'] = [
       '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime('now', \Drupal::currentUser()->getTimeZone()),
+      '#default_value' => new DrupalDateTime('now', $this->currentUser->getTimeZone()),
       '#required' => TRUE,
     ];
 
@@ -590,7 +590,7 @@ class Harvest extends QuickFormBase {
     $form['timestamp'] = [
       '#type' => 'datetime',
       '#title' => $this->t('Date'),
-      '#default_value' => new DrupalDateTime('now', \Drupal::currentUser()->getTimeZone()),
+      '#default_value' => new DrupalDateTime('now', $this->currentUser->getTimeZone()),
       '#required' => TRUE,
     ];
 

--- a/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
+++ b/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_quick\Plugin\QuickForm;
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Messenger\MessengerTrait;
@@ -30,6 +31,13 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
   protected string $quickId;
 
   /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -38,11 +46,14 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
     $this->messenger = $messenger;
   }
 
@@ -54,7 +65,8 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('messenger')
+      $container->get('entity_type.manager'),
+      $container->get('messenger'),
     );
   }
 

--- a/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
+++ b/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
@@ -38,6 +38,13 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
   protected $entityTypeManager;
 
   /**
+   * Current user object.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -48,12 +55,15 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
+    $this->currentUser = $current_user;
     $this->messenger = $messenger;
   }
 
@@ -66,6 +76,7 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('current_user'),
       $container->get('messenger'),
     );
   }

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -64,13 +64,6 @@ class Birth extends QuickFormBase {
   protected $assetLocation;
 
   /**
-   * Current user object.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
    * Group membership service.
    *
    * @var \Drupal\farm_group\GroupMembershipInterface|null
@@ -88,6 +81,8 @@ class Birth extends QuickFormBase {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
@@ -96,17 +91,14 @@ class Birth extends QuickFormBase {
    *   The config factory service.
    * @param \Drupal\farm_location\AssetLocationInterface $asset_location
    *   Asset location service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
    * @param \Drupal\farm_group\GroupMembershipInterface|null $group_membership
    *   Group membership service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, AccountInterface $current_user, ?GroupMembershipInterface $group_membership = NULL) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, ?GroupMembershipInterface $group_membership = NULL) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->moduleHandler = $module_handler;
     $this->configFactory = $config_factory;
     $this->assetLocation = $asset_location;
-    $this->currentUser = $current_user;
     $this->groupMembership = $group_membership;
   }
 
@@ -119,11 +111,11 @@ class Birth extends QuickFormBase {
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('current_user'),
       $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('config.factory'),
       $container->get('asset.location'),
-      $container->get('current_user'),
       // PHPStan level 3+ throws the following error on the next line:
       // Ternary operator condition is always true.
       // We ignore this because we know that the group.membership service will

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -43,13 +43,6 @@ class Birth extends QuickFormBase {
   use QuickStringTrait;
 
   /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * The module handler.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface
@@ -93,10 +86,10 @@ class Birth extends QuickFormBase {
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
@@ -108,9 +101,8 @@ class Birth extends QuickFormBase {
    * @param \Drupal\farm_group\GroupMembershipInterface|null $group_membership
    *   Group membership service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, AccountInterface $current_user, ?GroupMembershipInterface $group_membership = NULL) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
-    $this->entityTypeManager = $entity_type_manager;
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, AccountInterface $current_user, ?GroupMembershipInterface $group_membership = NULL) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
     $this->moduleHandler = $module_handler;
     $this->configFactory = $config_factory;
     $this->assetLocation = $asset_location;
@@ -126,8 +118,8 @@ class Birth extends QuickFormBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('messenger'),
       $container->get('entity_type.manager'),
+      $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('config.factory'),
       $container->get('asset.location'),

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -49,13 +49,6 @@ class Group extends QuickFormBase implements QuickFormInterface {
   protected $groupMembership;
 
   /**
-   * Current user object.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -66,17 +59,16 @@ class Group extends QuickFormBase implements QuickFormInterface {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
    *   Group membership service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, GroupMembershipInterface $group_membership, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, GroupMembershipInterface $group_membership) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->groupMembership = $group_membership;
-    $this->currentUser = $current_user;
   }
 
   /**
@@ -88,9 +80,9 @@ class Group extends QuickFormBase implements QuickFormInterface {
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('current_user'),
       $container->get('messenger'),
       $container->get('group.membership'),
-      $container->get('current_user'),
     );
   }
 

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -42,13 +42,6 @@ class Group extends QuickFormBase implements QuickFormInterface {
   use QuickStringTrait;
 
   /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * Group membership service.
    *
    * @var \Drupal\farm_group\GroupMembershipInterface
@@ -71,19 +64,17 @@ class Group extends QuickFormBase implements QuickFormInterface {
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
    *   Group membership service.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, GroupMembershipInterface $group_membership, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
-    $this->messenger = $messenger;
-    $this->entityTypeManager = $entity_type_manager;
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, GroupMembershipInterface $group_membership, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
     $this->groupMembership = $group_membership;
     $this->currentUser = $current_user;
   }
@@ -96,8 +87,8 @@ class Group extends QuickFormBase implements QuickFormInterface {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('messenger'),
       $container->get('entity_type.manager'),
+      $container->get('messenger'),
       $container->get('group.membership'),
       $container->get('current_user'),
     );

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -43,13 +43,6 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
   use QuickTermTrait;
 
   /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * Asset inventory service.
    *
    * @var \Drupal\farm_inventory\AssetInventoryInterface
@@ -72,19 +65,17 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    * @param \Drupal\farm_inventory\AssetInventoryInterface $asset_inventory
    *   Asset inventory service.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, AssetInventoryInterface $asset_inventory, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
-    $this->messenger = $messenger;
-    $this->entityTypeManager = $entity_type_manager;
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, AssetInventoryInterface $asset_inventory, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
     $this->assetInventory = $asset_inventory;
     $this->currentUser = $current_user;
   }
@@ -97,8 +88,8 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('messenger'),
       $container->get('entity_type.manager'),
+      $container->get('messenger'),
       $container->get('asset.inventory'),
       $container->get('current_user'),
     );

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -50,13 +50,6 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
   protected $assetInventory;
 
   /**
-   * Current user object.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -67,17 +60,16 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    * @param \Drupal\farm_inventory\AssetInventoryInterface $asset_inventory
    *   Asset inventory service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, AssetInventoryInterface $asset_inventory, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, AssetInventoryInterface $asset_inventory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->assetInventory = $asset_inventory;
-    $this->currentUser = $current_user;
   }
 
   /**
@@ -89,9 +81,9 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('current_user'),
       $container->get('messenger'),
       $container->get('asset.inventory'),
-      $container->get('current_user'),
     );
   }
 

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -44,13 +44,6 @@ class Movement extends QuickFormBase implements QuickFormInterface {
   use WktTrait;
 
   /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * Asset location service.
    *
    * @var \Drupal\farm_location\AssetLocationInterface
@@ -73,19 +66,17 @@ class Movement extends QuickFormBase implements QuickFormInterface {
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    * @param \Drupal\farm_location\AssetLocationInterface $asset_location
    *   Asset location service.
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
-    $this->messenger = $messenger;
-    $this->entityTypeManager = $entity_type_manager;
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, AssetLocationInterface $asset_location, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
     $this->assetLocation = $asset_location;
     $this->currentUser = $current_user;
   }
@@ -98,8 +89,8 @@ class Movement extends QuickFormBase implements QuickFormInterface {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('messenger'),
       $container->get('entity_type.manager'),
+      $container->get('messenger'),
       $container->get('asset.location'),
       $container->get('current_user'),
     );

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -51,13 +51,6 @@ class Movement extends QuickFormBase implements QuickFormInterface {
   protected $assetLocation;
 
   /**
-   * Current user object.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
    * Constructs a QuickFormBase object.
    *
    * @param array $configuration
@@ -68,17 +61,16 @@ class Movement extends QuickFormBase implements QuickFormInterface {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    * @param \Drupal\farm_location\AssetLocationInterface $asset_location
    *   Asset location service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, AssetLocationInterface $asset_location, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, AssetLocationInterface $asset_location) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->assetLocation = $asset_location;
-    $this->currentUser = $current_user;
   }
 
   /**
@@ -90,9 +82,9 @@ class Movement extends QuickFormBase implements QuickFormInterface {
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('current_user'),
       $container->get('messenger'),
       $container->get('asset.location'),
-      $container->get('current_user'),
     );
   }
 

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -53,13 +53,6 @@ class Planting extends QuickFormBase {
   protected $moduleHandler;
 
   /**
-   * Current user object.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
    * The state service.
    *
    * @var \Drupal\Core\State\StateInterface
@@ -77,20 +70,19 @@ class Planting extends QuickFormBase {
    *   The plugin implementation definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user object.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
    * @param \Drupal\Core\State\StateInterface $state
    *   The state service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, StateInterface $state, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, StateInterface $state) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->moduleHandler = $module_handler;
     $this->state = $state;
-    $this->currentUser = $current_user;
   }
 
   /**
@@ -102,10 +94,10 @@ class Planting extends QuickFormBase {
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('current_user'),
       $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('state'),
-      $container->get('current_user'),
     );
   }
 

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -46,13 +46,6 @@ class Planting extends QuickFormBase {
   use QuickFormElementsTrait;
 
   /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * The module handler.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface
@@ -82,10 +75,10 @@ class Planting extends QuickFormBase {
    *   The plugin_id for the plugin instance.
    * @param mixed $plugin_definition
    *   The plugin implementation definition.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
    *   The module handler.
    * @param \Drupal\Core\State\StateInterface $state
@@ -93,10 +86,8 @@ class Planting extends QuickFormBase {
    * @param \Drupal\Core\Session\AccountInterface $current_user
    *   Current user object.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MessengerInterface $messenger, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, StateInterface $state, AccountInterface $current_user) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $messenger);
-    $this->messenger = $messenger;
-    $this->entityTypeManager = $entity_type_manager;
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, StateInterface $state, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $messenger);
     $this->moduleHandler = $module_handler;
     $this->state = $state;
     $this->currentUser = $current_user;
@@ -110,8 +101,8 @@ class Planting extends QuickFormBase {
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('messenger'),
       $container->get('entity_type.manager'),
+      $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('state'),
       $container->get('current_user'),


### PR DESCRIPTION
The `QuickFormBase` class currently includes the `messenger` service via dependency injection, so that quick forms can set messages, but it doesn't include any other services. This means that downstream quick form developers often need to inject commonly needed services in every class.

This PR proposes that we inject two additional services into `QuickFormBase`:

- `entity_type.manager`
- `current_user`

Both of these are currently being injected separately into every quick form that farmOS core provides, so by moving them to `QuickFormBase` it reduces the amount of boilerplate needed in classes that extend from that.

- https://github.com/farmOS/farmOS/blob/286f13b607d20a0545e4fa0fa6b662f946a60cc6/modules/quick/birth/src/Plugin/QuickForm/Birth.php#L130-L134
- https://github.com/farmOS/farmOS/blob/286f13b607d20a0545e4fa0fa6b662f946a60cc6/modules/quick/group/src/Plugin/QuickForm/Group.php#L100-L102
- https://github.com/farmOS/farmOS/blob/286f13b607d20a0545e4fa0fa6b662f946a60cc6/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php#L101-L103
- https://github.com/farmOS/farmOS/blob/286f13b607d20a0545e4fa0fa6b662f946a60cc6/modules/quick/movement/src/Plugin/QuickForm/Movement.php#L102-L104
- https://github.com/farmOS/farmOS/blob/286f13b607d20a0545e4fa0fa6b662f946a60cc6/modules/quick/planting/src/Plugin/QuickForm/Planting.php#L99-L102

... and in contrib quick forms:

- https://git.drupalcode.org/project/farm_eggs/-/blob/2.x/src/Plugin/QuickForm/Eggs.php?ref_type=heads#L86
- https://git.drupalcode.org/project/farm_weather/-/blob/2.x/src/Plugin/QuickForm/Precipitation.php?ref_type=heads#L67
- (probably others)

The `entity_type.manager` service is often used to load entity storage, and the `current_user` service is used to get the current user's timezone for date fields.

This would be a breaking change, so I'm proposing it for 4.0.0.