### PR TITLE
Allow the "type" base field view display to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ requirements (inherited from Drupal 11):
 - [Allow plans without active status in farm_plan View #978](https://github.com/farmOS/farmOS/pull/978)
 - [Rename primary tab in edit forms to General #985](https://github.com/farmOS/farmOS/pull/985)
 - [Inject entity_type.manager and current_user service dependencies into QuickFormBase class #989](https://github.com/farmOS/farmOS/pull/989)
+- [Allow the "type" base field view display to be configured #990](https://github.com/farmOS/farmOS/pull/990)
 
 ### Deprecated
 

--- a/modules/core/entity/modules/fields/farm_entity_fields.module
+++ b/modules/core/entity/modules/fields/farm_entity_fields.module
@@ -123,4 +123,9 @@ function farm_entity_fields_entity_base_field_info_alter(&$fields, EntityTypeInt
     $fields[$name]->setDisplayOptions('form', $form_display_options);
     $fields[$name]->setDisplayOptions('view', $view_display_options);
   }
+
+  // Allow the "type" base field view display to be configured.
+  if (!empty($fields['type'])) {
+    $fields['type']->setDisplayConfigurable('view', TRUE);
+  }
 }


### PR DESCRIPTION
The `type` field on assets, logs, and plans is currently not configurable in view displays. This causes it to show up at the top of custom view displays, and it cannot be disabled.

This PR simply makes it configurable so it can be disabled in custom view displays.