### PR TITLE
Pin Docker base image to Debian Bookworm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Alias the Drupal base image for use in other build stages.
 # We do this so that the Drupal image version only needs to be updated here.
-FROM drupal:11.1-php8.4 AS baseimage
+FROM drupal:11.1-php8.4-apache-bookworm AS baseimage
 
 # Define common paths.
 # BUILD_PATH is where the farmOS codebase will be built.


### PR DESCRIPTION
Debian Trixie was released on Aug 9: https://www.debian.org/News/2025/20250809

The official Drupal image on Docker Hub was updated to use Trixie by default yesterday: https://github.com/docker-library/drupal/pull/292

This caused our automated builds to start failing.

This PR fixes builds by pinning the farmOS Docker image's base to Debian Bookworm.

We can follow-up with a separate PR to update to Trixie. All future updates can now be intentional, like we recently did with PHP versions ( #923).