### PR TITLE
Update Docker base image to Debian Trixie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ requirements (inherited from Drupal 11):
 
 - [farmOS 4.x requires PHP 8.4 #979](https://github.com/farmOS/farmOS/pull/979)
 - [Issue #3488916: Update Drupal core to 11.x](https://www.drupal.org/project/farm/issues/3488916)
+- [Update Docker base image to Debian Trixie #992](https://github.com/farmOS/farmOS/pull/992)
 - [Change how assets and plans are archived #986](https://github.com/farmOS/farmOS/pull/986)
 - [Convert equipment to a base field #956](https://github.com/farmOS/farmOS/pull/956)
 - [Convert quick to a base field #957](https://github.com/farmOS/farmOS/pull/957)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,15 +64,6 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 
-# Update SQLite4 to 3.45.1 for Drupal 11.
-# @todo Remove when the drupal:11.x Docker image is based on Debian 13.
-ARG TARGETARCH
-RUN SQLITE_VERSION=3.45.1 \
-  && if [ "${TARGETARCH}" = "arm" ]; then SQLITE_ARCH="armhf"; else SQLITE_ARCH="${TARGETARCH}"; fi \
-  && curl -Lo /tmp/libsqlite3-0.deb "https://snapshot.debian.org/archive/debian/20240506T211830Z/pool/main/s/sqlite3/libsqlite3-0_${SQLITE_VERSION}-1_${SQLITE_ARCH}.deb" \
-  && dpkg -i /tmp/libsqlite3-0.deb \
-  && rm /tmp/libsqlite3-0.deb
-
 # Set the COMPOSER_MEMORY_LIMIT environment variable to unlimited.
 ENV COMPOSER_MEMORY_LIMIT=-1
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM baseimage AS php-dependencies
 
 # Build and install the GEOS PHP extension.
 # See https://git.osgeo.org/gitea/geos/php-geos
-ARG PHP_GEOS_VERSION=e77d5a16abbf89a59d947d1fe49381a944762c9d
+ARG PHP_GEOS_VERSION=dfe1ab17b0f155cc315bc13c75689371676e02e1
 ADD https://github.com/libgeos/php-geos/archive/${PHP_GEOS_VERSION}.tar.gz /opt/php-geos.tar.gz
 RUN apt-get update && apt-get install -y libgeos-dev \
   && ( tar xzf /opt/php-geos.tar.gz -C /opt/ \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -59,8 +59,8 @@ RUN apt-get update && apt-get install -y \
     git unzip \
     # Install postgresql-client so Drush can connect to the database.
     postgresql-client \
-    # Install libgeos-c1v5 so geos php extension can use libgeos_c.so.1.
-    libgeos-c1v5 \
+    # Install libgeos-c1t64 so geos php extension can use libgeos_c.so.1.
+    libgeos-c1t64 \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Alias the Drupal base image for use in other build stages.
 # We do this so that the Drupal image version only needs to be updated here.
-FROM drupal:11.1-php8.4-apache-bookworm AS baseimage
+FROM drupal:11.1-php8.4-apache-trixie AS baseimage
 
 # Define common paths.
 # BUILD_PATH is where the farmOS codebase will be built.


### PR DESCRIPTION
This is a follow-up to #991, which pinned our Docker base image to Debian Bookworm in order to fix build failures when Trixie was merged into the upstream `drupal` base image from Docker Hub (see https://github.com/docker-library/drupal/pull/292).

This PR takes the next step of intentionally updating to Debian Trixie and fixing the build issues.

The build failures were caused by `geos-php`, and were fixed by updating to the latest commit of https://github.com/libgeos/php-geos, and replacing the `libgeos-c1v5` package with `libgeos-c1t64`.

This PR also removes the temporary workaround we put into place to update SQLite3 so that it would be compatible with Drupal 11 (in #967).