### PR TITLE
Fix CSV importer compatibility with migrate_source_ui v1.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ requirements (inherited from Drupal 11):
 
 - [Fix plan_record bundle field providers #969](https://github.com/farmOS/farmOS/pull/969)
 - [Fix logic for forcing entity revision creation #988](https://github.com/farmOS/farmOS/pull/969)
+- [Fix CSV importer compatibility with migrate_source_ui v1.3+ #993](https://github.com/farmOS/farmOS/pull/993)
 
 ## farmOS 3.x
 

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
         "drupal/inspire_tree": "^1.0.6",
         "drupal/jsonapi_schema": "^1.0",
         "drupal/log": "^2.3.1",
-        "drupal/migrate_plus": "6.0.5",
+        "drupal/migrate_plus": "^6.0.8",
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_source_ui": "^1.1",
-        "drupal/migrate_tools": "6.0.5",
+        "drupal/migrate_tools": "^6.1.2",
         "drupal/role_delegation": "^1.3",
         "drupal/simple_oauth": "^6.0",
         "drupal/simple_oauth_password_grant": "^2.1",
@@ -73,12 +73,6 @@
             },
             "drupal/gin": {
                 "Issue #3342164: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch"
-            },
-            "drupal/migrate_plus": {
-                "Issue #3508679: PHP 8.4 implicit nullable deprecation": "https://www.drupal.org/files/issues/2025-04-10/migrate_plus-3508679.patch"
-            },
-            "drupal/migrate_tools": {
-                "Issue #3411051: Fix PHPCS issues": "https://git.drupalcode.org/project/migrate_tools/-/commit/fe834c7295b3e028e755f1b399b1b9d2272b4c2b.patch"
             },
             "drupal/subrequests": {
                 "Issue #3524429: PHP 8.4 deprecation: Implicitly marking parameter as nullable": "https://git.drupalcode.org/issue/subrequests-3524429/-/commit/784ccfe8af7d803f392263d2dbf7dcd89f9566d5.patch"

--- a/modules/core/import/modules/csv/src/Form/CsvImportForm.php
+++ b/modules/core/import/modules/csv/src/Form/CsvImportForm.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\farm_import_csv\Form;
 
+use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+use Drupal\Core\StringTranslation\TranslationManager;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\file\FileRepositoryInterface;
 use Drupal\file\FileUsage\FileUsageInterface;
@@ -57,6 +60,12 @@ class CsvImportForm extends MigrateSourceUiForm {
    *   The config factory service.
    * @param \Drupal\Core\File\FileSystemInterface $file_system
    *   The File System service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value
+   *   The key value factory.
+   * @param \Drupal\Core\StringTranslation\TranslationManager $translation_manager
+   *   The translation manager service.
    * @param \Drupal\file\FileRepositoryInterface $file_repository
    *   The file repository service.
    * @param \Drupal\file\FileUsage\FileUsageInterface $file_usage
@@ -66,8 +75,8 @@ class CsvImportForm extends MigrateSourceUiForm {
    * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
    *   The tempstore service.
    */
-  public function __construct(MigrationPluginManager $plugin_manager_migration, ConfigFactoryInterface $config_factory, FileSystemInterface $file_system, FileRepositoryInterface $file_repository, FileUsageInterface $file_usage, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory) {
-    parent::__construct($plugin_manager_migration, $config_factory, $file_system);
+  public function __construct(MigrationPluginManager $plugin_manager_migration, ConfigFactoryInterface $config_factory, FileSystemInterface $file_system, TimeInterface $time, KeyValueFactoryInterface $key_value, TranslationManager $translation_manager, FileRepositoryInterface $file_repository, FileUsageInterface $file_usage, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory) {
+    parent::__construct($plugin_manager_migration, $config_factory, $file_system, $time, $key_value, $translation_manager);
     $this->fileRepository = $file_repository;
     $this->fileUsage = $file_usage;
     $this->entityTypeManager = $entity_type_manager;
@@ -77,11 +86,14 @@ class CsvImportForm extends MigrateSourceUiForm {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container) {
+  public static function create(ContainerInterface $container): static {
     return new static(
       $container->get('plugin.manager.migration'),
       $container->get('config.factory'),
       $container->get('file_system'),
+      $container->get('datetime.time'),
+      $container->get('keyvalue'),
+      $container->get('string_translation'),
       $container->get('file.repository'),
       $container->get('file.usage'),
       $container->get('entity_type.manager'),
@@ -92,14 +104,14 @@ class CsvImportForm extends MigrateSourceUiForm {
   /**
    * {@inheritdoc}
    */
-  public function getFormId() {
+  public function getFormId(): string {
     return 'farm_import_csv';
   }
 
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $migration_id = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $migration_id = NULL): array {
     $form = parent::buildForm($form, $form_state);
 
     // Hard-code and hide the dropdown of migrations.
@@ -120,7 +132,7 @@ class CsvImportForm extends MigrateSourceUiForm {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
+  public function validateForm(array &$form, FormStateInterface $form_state): void {
     parent::validateForm($form, $form_state);
 
     // If there is no uploaded file, bail.


### PR DESCRIPTION
The `migrate_source_ui` module introduced changes to their `MigrateSourceUiForm` class that broke backwards compatibility with our `CsvImportForm` class (which extends it).

@see https://www.drupal.org/project/migrate_source_ui/issues/3537749

This PR also unpins, unpatches, and updates `migrate_tools` and `migrate_plus` because the patches we were applying were merged upstream and included in new releases. The `migrate_source_ui` module then made its own changes in response to those updates, which broke our CSV importers.