### PR TITLE
Title improvements to entity forms, buttons, and Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ requirements (inherited from Drupal 11):
 - [Rename primary tab in edit forms to General #985](https://github.com/farmOS/farmOS/pull/985)
 - [Inject entity_type.manager and current_user service dependencies into QuickFormBase class #989](https://github.com/farmOS/farmOS/pull/989)
 - [Allow the "type" base field view display to be configured #990](https://github.com/farmOS/farmOS/pull/990)
+- [Title improvements to entity forms, buttons, and Views #996](https://github.com/farmOS/farmOS/pull/996)
 
 ### Deprecated
 

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -17,7 +17,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\entity\EntityAccessControlHandler;
 use Drupal\entity\EntityPermissionProvider;
 use Drupal\farm_entity\BundlePlugin\FarmEntityBundlePluginHandler;
-use Drupal\farm_entity\Routing\DefaultHtmlRouteProvider;
+use Drupal\farm_entity\Routing\BundleEntityTypeRouteProvider;
 
 /**
  * Implements hook_modules_installed().
@@ -78,7 +78,7 @@ function farm_entity_entity_type_build(array &$entity_types) {
       // See https://www.drupal.org/project/farm/issues/3196423
       $bundle_entity_type = $entity_types[$entity_type]->getBundleEntityType();
       $route_providers = $entity_types[$bundle_entity_type]->getRouteProviderClasses();
-      $route_providers['default'] = DefaultHtmlRouteProvider::class;
+      $route_providers['default'] = BundleEntityTypeRouteProvider::class;
       $entity_types[$bundle_entity_type]->setHandlerClass('route_provider', $route_providers);
     }
   }

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -18,6 +18,7 @@ use Drupal\entity\EntityAccessControlHandler;
 use Drupal\entity\EntityPermissionProvider;
 use Drupal\farm_entity\BundlePlugin\FarmEntityBundlePluginHandler;
 use Drupal\farm_entity\Routing\BundleEntityTypeRouteProvider;
+use Drupal\farm_entity\Routing\EntityRouteProvider;
 
 /**
  * Implements hook_modules_installed().
@@ -72,6 +73,11 @@ function farm_entity_entity_type_build(array &$entity_types) {
     if (!empty($entity_types[$entity_type])) {
       $entity_types[$entity_type]->set('bundle_plugin_type', $entity_type . '_type');
       $entity_types[$entity_type]->setHandlerClass('bundle_plugin', FarmEntityBundlePluginHandler::class);
+
+      // Override default entity route provider class.
+      $route_providers = $entity_types[$entity_type]->getRouteProviderClasses();
+      $route_providers['default'] = EntityRouteProvider::class;
+      $entity_types[$entity_type]->setHandlerClass('route_provider', $route_providers);
 
       // Deny access to the entity type add form. New entity types of entities
       // with bundle plugins cannot be created in the UI.

--- a/modules/core/entity/src/Controller/EntityController.php
+++ b/modules/core/entity/src/Controller/EntityController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Controller;
+
+use Drupal\Core\Entity\Controller\EntityController as CoreEntityController;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Provides the title callbacks for entities.
+ *
+ * It provides:
+ * - An add title callback for entity types with bundles.
+ * - An edit title callback.
+ */
+class EntityController extends CoreEntityController {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addBundleTitle(RouteMatchInterface $route_match, $entity_type_id, $bundle_parameter) {
+
+    // Always use the bundle label in the add entity form title.
+    // This overrides Drupal core's default behavior, which varies based on the
+    // number of available bundles. If there is a single bundle, Drupal core
+    // does not show the bundle label, and only shows the entity type label.
+    $bundles = $this->entityTypeBundleInfo->getBundleInfo($entity_type_id);
+    $bundle = $route_match->getRawParameter($bundle_parameter);
+    if (isset($bundles[$bundle])) {
+      // PHPStan throws the following error on the next line:
+      // Method Drupal\farm_entity\Controller\EntityController::addBundleTitle()
+      // should return string but returns
+      // Drupal\Core\StringTranslation\TranslatableMarkup.
+      // We ignore this because we are following Drupal core's pattern.
+      // @phpstan-ignore return.type
+      return $this->t('Add @bundle', ['@bundle' => $bundles[$bundle]['label']]);
+    }
+    return parent::addBundleTitle($route_match, $entity_type_id, $bundle_parameter);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function editTitle(RouteMatchInterface $route_match, ?EntityInterface $_entity = NULL) {
+
+    // Include bundle label in entity edit title.
+    $entity = $this->doGetEntity($route_match, $_entity);
+    if ($entity && method_exists($entity, 'getBundleLabel')) {
+      // PHPStan throws the following error on the next line:
+      // Method Drupal\farm_entity\Controller\EntityController::editTitle()
+      // should return string|null but returns
+      // Drupal\Core\StringTranslation\TranslatableMarkup.
+      // We ignore this because we are following Drupal core's pattern.
+      // @phpstan-ignore return.type
+      return $this->t('Edit @bundle: %label', ['@bundle' => $entity->getBundleLabel(), '%label' => $entity->label()]);
+    }
+    return parent::editTitle($route_match, $_entity);
+  }
+
+}

--- a/modules/core/entity/src/Routing/BundleEntityTypeRouteProvider.php
+++ b/modules/core/entity/src/Routing/BundleEntityTypeRouteProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_entity\Routing;
 
 use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\entity\Routing\DefaultHtmlRouteProvider as EntityDefaultHtmlRouteProvider;
+use Drupal\entity\Routing\DefaultHtmlRouteProvider;
 
 /**
  * Deny access to the entity type add form.
@@ -14,7 +14,7 @@ use Drupal\entity\Routing\DefaultHtmlRouteProvider as EntityDefaultHtmlRouteProv
  *
  * @See https://www.drupal.org/project/farm/issues/3196423
  */
-class DefaultHtmlRouteProvider extends EntityDefaultHtmlRouteProvider {
+class BundleEntityTypeRouteProvider extends DefaultHtmlRouteProvider {
 
   /**
    * {@inheritdoc}

--- a/modules/core/entity/src/Routing/EntityRouteProvider.php
+++ b/modules/core/entity/src/Routing/EntityRouteProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Routing;
+
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\entity\Routing\DefaultHtmlRouteProvider;
+
+/**
+ * Override entity route provider methods.
+ */
+class EntityRouteProvider extends DefaultHtmlRouteProvider {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAddFormRoute(EntityTypeInterface $entity_type) {
+
+    // Override the add form title callback.
+    $route = parent::getAddFormRoute($entity_type);
+    if (!is_null($route)) {
+      $route->setDefault('_title_callback', '\Drupal\farm_entity\Controller\EntityController::addBundleTitle');
+      return $route;
+    }
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditFormRoute(EntityTypeInterface $entity_type) {
+
+    // Override the edit form title callback.
+    $route = parent::getEditFormRoute($entity_type);
+    if (!is_null($route)) {
+      $route->setDefault('_title_callback', '\Drupal\farm_entity\Controller\EntityController::editTitle');
+      return $route;
+    }
+    return NULL;
+  }
+
+}

--- a/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -82,7 +82,7 @@ class AddEntity extends LocalActionDefault {
     $bundle_label = $this->entityTypeManager->getStorage($entity_type->getBundleEntityType())->load($bundle)->label();
 
     // Build the link title.
-    return $this->t('Add @bundle @entity_type', ['@bundle' => $bundle_label, '@entity_type' => $entity_type_label])->render();
+    return $this->t('Add @entity_type: @bundle', ['@entity_type' => $entity_type_label, '@bundle' => $bundle_label])->render();
   }
 
   /**

--- a/modules/core/ui/views/farm_ui_views.views_execution.inc
+++ b/modules/core/ui/views/farm_ui_views.views_execution.inc
@@ -125,12 +125,12 @@ function farm_ui_views_views_pre_render(ViewExecutable $view) {
   }
 
   // If this is a "By type" display and a bundle argument is specified, load
-  // the bundle label and set the title.
+  // the bundle label and add it to the title.
   $bundle = farm_ui_views_get_bundle_argument($view, $view->current_display, $view->args);
   if (!empty($bundle)) {
     $bundles = \Drupal::service('entity_type.bundle.info')->getBundleInfo($view->getBaseEntityType()->id());
     if (!empty($bundles[$bundle])) {
-      $title = $bundles[$bundle]['label'] . ' ' . $view->getBaseEntityType()->getPluralLabel();
+      $title = $view->getTitle() . ': ' . $bundles[$bundle]['label'];
     }
   }
 


### PR DESCRIPTION
This PR makes a few improvements to the titles of entity forms, action buttons, and Views throughout the farmOS UI. I decided to bundle all of these proposed changes into a single PR because they are similar. They are motivated by a few different conversations we've had recently in development calls.

Summary of changes:

### Entity edit form page title

When editing an existing entity (eg: asset, log, plan), the entity edit form page title will now include the bundle label. For example, if you are editing an Activity log named "Spread compost", the edit page title will be "Edit Activity: *Spread compost*". Previously it was "Edit *Spread compost*". This is a follow-up to #985, which removed the bundle label from the primary tab in the edit form. See this comment for more context: https://github.com/farmOS/farmOS/pull/985#issuecomment-3164938642

**Before**:

<img width="1365" height="511" alt="Screenshot from 2025-08-29 13-42-24" src="https://github.com/user-attachments/assets/46b5815a-ebfc-4ab0-97ae-be0411cd6208" />

**After**:

<img width="1365" height="509" alt="Screenshot from 2025-08-29 13-50-29" src="https://github.com/user-attachments/assets/a723daee-f9da-4d2d-84c9-72b950748e48" />

### Entity add form page title

When adding a new entity, the entity add form page title will now always be "Add [bundle]". This fixes a minor annoyance in Drupal core's default logic, which only uses the bundle label if there is more than one bundle available for a given entity type, otherwise it uses the entity type label. For example, before this change, if you only have the Activity log type enabled, and you go to /add/log/activity, the title would be "Add log", but if you had another log type enabled it would be "Add Activity". Now it will always be "Add activity".

**Before**:

<img width="1365" height="439" alt="Screenshot from 2025-08-29 13-41-51" src="https://github.com/user-attachments/assets/1c24ea15-857a-48d2-87f9-27f37f7607c9" />

**After**:

<img width="1365" height="444" alt="Screenshot from 2025-08-29 13-43-10" src="https://github.com/user-attachments/assets/f3aecc32-0966-433f-b720-ad10413bb2c0" />

### Entity "By type" Views titles

In all entity Views with a "By type" display (eg: /logs/activity), the title of the page will now be "[view-title]: [bundle]" (eg: "Logs: Activity"). Previously it was "[bundle] [entity-type-plural]" (eg: "Activity logs").

(see before/after pics below, because they include both this change and the next one)

### Add entity action link button titles

The action link buttons for adding entities of a specific bundle are now titled "Add [entity-type]: [bundle]" (eg: "Add Log: Activity"). Previously they were "Add [bundle] [entity-type]" (eg: "Add Activity Log").

(the before/after pics below include both this change and the previous one)

**Before**:

<img width="1365" height="509" alt="Screenshot from 2025-08-29 13-56-36" src="https://github.com/user-attachments/assets/ed1a8f71-5df2-429f-ba38-5f77271f3788" />

<img width="1365" height="509" alt="Screenshot from 2025-08-29 13-56-32" src="https://github.com/user-attachments/assets/c7523946-80ee-40b0-824f-7fd64b55c9a6" />

**After**:

<img width="1365" height="509" alt="Screenshot from 2025-08-29 13-57-10" src="https://github.com/user-attachments/assets/0a9f3a73-ba2e-4853-a89a-40555df6feac" />

<img width="1365" height="509" alt="Screenshot from 2025-08-29 13-57-07" src="https://github.com/user-attachments/assets/22214b52-a9bc-44da-a3e3-7ac10d14465d" />

Worth noting: the last two ("Entity "By type" Views titles" and "Add entity action link button titles") address an issue that has become apparent with plan bundle names, specifically. Oftentimes, the name of a plan bundle will include the name "plan" in it (eg: "Crop plan"). This resulted in Views titled "Crop plan plans" and action buttons titled "Add Crop plan plan", so the workaround was to omit "plan" from the bundle name, which felt weird from a plan DX perspective. Now that is no longer necessary - this proposed change simply rearranges the title a bit to lessen the redundancy of it.