### PR TITLE
Check that real path exists before loading exif data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Fix plan_record bundle field providers #969](https://github.com/farmOS/farmOS/pull/969)
 - [Fix logic for forcing entity revision creation #988](https://github.com/farmOS/farmOS/pull/969)
+- [Check that real path exists before loading exif data #1000](https://github.com/farmOS/farmOS/pull/1000)
 
 ## [3.4.5] 2025-04-28
 

--- a/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
+++ b/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
@@ -195,6 +195,11 @@ class AutoOrientImageEffect extends ImageEffectBase implements ContainerFactoryP
     // Get the image file path.
     $path = $this->fileSystem->realpath($uri);
 
+    // If there is no path for the image, return NULL.
+    if ($path === FALSE) {
+      return NULL;
+    }
+
     // Attempt to load EXIF data.
     $exif = @exif_read_data($path);
 


### PR DESCRIPTION
When the image file does not exist an error is thrown for an empty first argument to exif_read_data() and causes a page crash.

This can happen when working from a database dump and you do not have the same images/files from the production environment, as reported here: https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/843