### PR TITLE
Do not allow entity revisions to be reverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ requirements (inherited from Drupal 11):
 - [Fix logic for forcing entity revision creation #988](https://github.com/farmOS/farmOS/pull/969)
 - [Fix CSV importer compatibility with migrate_source_ui v1.3+ #993](https://github.com/farmOS/farmOS/pull/993)
 - [Check that real path exists before loading exif data #1000](https://github.com/farmOS/farmOS/pull/1000)
+- [Do not allow entity revisions to be reverted #1004](https://github.com/farmOS/farmOS/pull/1004)
 
 ## farmOS 3.x
 

--- a/modules/core/entity/farm_entity.module
+++ b/modules/core/entity/farm_entity.module
@@ -91,6 +91,27 @@ function farm_entity_entity_type_build(array &$entity_types) {
 }
 
 /**
+ * Implements hook_entity_type_alter().
+ */
+function farm_entity_entity_type_alter(array &$entity_types) {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
+
+  // Remove the form for reverting entity revisions.
+  // We do this because farmOS modules provide entity constraint validation
+  // logic that may depend on other entities in the database (not just the data
+  // in the entity being reverted), and Drupal does not validate entities when
+  // they are reverted. This could result in entities that no longer validate,
+  // leaving the database in a state that would normally be considered invalid.
+  foreach ($entity_types as $entity_type) {
+    if ($entity_type->hasLinkTemplate('revision-revert-form')) {
+      $links = $entity_type->getLinkTemplates();
+      unset($links['revision-revert-form']);
+      $entity_type->set('links', $links);
+    }
+  }
+}
+
+/**
  * Implements hook_entity_field_storage_info_alter().
  *
  * @todo https://www.drupal.org/project/farm/issues/3194206

--- a/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_entity\Functional;
+
+use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+
+/**
+ * Tests that entity revisions cannot be reverted.
+ *
+ * @group farm
+ */
+class FarmEntityRevisionsTest extends FarmBrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_entity',
+    'farm_entity_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create and login a user with access to entity revisions.
+    $user = $this->createuser([
+      'view any asset',
+      'view any log',
+      'view any plan',
+      'view all asset revisions',
+      'view all log revisions',
+      'view all plan revisions',
+      'revert all asset revisions',
+      'revert all log revisions',
+      'revert all plan revisions',
+    ]);
+    $this->drupalLogin($user);
+  }
+
+  /**
+   * Test that entity revisions cannot be reverted.
+   */
+  public function testFarmEntityRevisions() {
+    $entity_types = [
+      'asset',
+      'log',
+      'plan',
+    ];
+    foreach ($entity_types as $entity_type) {
+      $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+      /** @var \Drupal\Core\Entity\RevisionableInterface $entity */
+      $entity = $storage->create([
+        'name' => $this->randomMachineName(),
+        'type' => 'test',
+      ]);
+      $entity->save();
+      $first_revision_id = $entity->getRevisionId();
+      $entity->setNewRevision();
+      $entity->save();
+      $second_revision_id = $entity->getRevisionId();
+      $this->assertNotEquals($first_revision_id, $second_revision_id);
+      $this->drupalGet($entity_type . '/' . $entity->id() . '/revisions');
+      $this->assertSession()->statusCodeEquals(200);
+      $this->assertSession()->responseNotContains('Revert');
+      $this->drupalGet($entity_type . '/' . $entity->id() . '/revisions/' . $first_revision_id . '/revert');
+      $this->assertSession()->statusCodeEquals(404);
+    }
+  }
+
+}

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -235,7 +235,7 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
         // Entity types with EntityOwnerTrait and RevisionLogEntityTrait have
         // additional permissions for view, update and delete operations:
         // Owner adds "operation any bundle" or "operation own bundle".
-        // Revision adds "operation all bundle revisions".
+        // Revision adds "view all bundle revisions".
         case 'asset':
         case 'log':
         case 'organization':
@@ -258,7 +258,6 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
 
           // Update.
           if (!empty($entity_settings['update all'])) {
-            $perms[] = 'revert all ' . $entity_type . ' revisions';
             $permission_rules[$entity_type]['update any'] = ['all'];
             $permission_rules[$entity_type]['update own'] = ['all'];
           }


### PR DESCRIPTION
As discovered in https://github.com/farmOS/farmOS/pull/849#issuecomment-3408126282, Drupal does not run entity constraint validation when entities are reverted to previous revisions. farmOS modules provide entity constraint validation logic that may depend on other entities in the database (not just the data in the entity being reverted). This can lead to data that is in an invalid state.

This PR takes a very simple approach to solving this by preventing entities from being reverted to previous revisions.