### PR TITLE
Use PHP 8 constructor property promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ requirements (inherited from Drupal 11):
 - [Inject entity_type.manager and current_user service dependencies into QuickFormBase class #989](https://github.com/farmOS/farmOS/pull/989)
 - [Allow the "type" base field view display to be configured #990](https://github.com/farmOS/farmOS/pull/990)
 - [Title improvements to entity forms, buttons, and Views #996](https://github.com/farmOS/farmOS/pull/996)
+- [Use PHP 8 constructor property promotion #1005](https://github.com/farmOS/farmOS/pull/1005)
 
 ### Deprecated
 

--- a/docker/dev/files/rector.php
+++ b/docker/dev/files/rector.php
@@ -13,6 +13,7 @@ use DrupalRector\Drupal10\Rector\ValueObject\AnnotationToAttributeConfiguration;
 use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
 use DrupalRector\Set\Drupal10SetList;
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 
 return static function (RectorConfig $rectorConfig): void {
 
@@ -78,5 +79,10 @@ return static function (RectorConfig $rectorConfig): void {
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'PlanRecordType', 'Drupal\farm_entity\Attribute\PlanRecordType'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'QuantityType', 'Drupal\farm_entity\Attribute\QuantityType'),
     new AnnotationToAttributeConfiguration('10.0.0', '10.0.0', 'QuickForm', 'Drupal\farm_quick\Attribute\QuickForm'),
+  ]);
+
+  // Use PHP 8 constructor property promotion.
+  $rectorConfig->ruleWithConfiguration(ClassPropertyAssignToConstructorPromotionRector::class, [
+    ClassPropertyAssignToConstructorPromotionRector::INLINE_PUBLIC => TRUE,
   ]);
 };

--- a/modules/asset/group/src/Access/FarmGroupMembersViewsAccessCheck.php
+++ b/modules/asset/group/src/Access/FarmGroupMembersViewsAccessCheck.php
@@ -21,12 +21,6 @@ class FarmGroupMembersViewsAccessCheck implements AccessInterface {
    */
   protected $assetStorage;
 
-  /**
-   * FarmGroupMembersViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->assetStorage = $entity_type_manager->getStorage('asset');
   }

--- a/modules/asset/group/src/Access/FarmGroupMembersViewsAccessCheck.php
+++ b/modules/asset/group/src/Access/FarmGroupMembersViewsAccessCheck.php
@@ -15,14 +15,14 @@ use Drupal\Core\Routing\RouteMatchInterface;
 class FarmGroupMembersViewsAccessCheck implements AccessInterface {
 
   /**
-   * The asset storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetStorage;
+  protected $entityTypeManager;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->assetStorage = $entity_type_manager->getStorage('asset');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -39,9 +39,12 @@ class FarmGroupMembersViewsAccessCheck implements AccessInterface {
       return AccessResult::allowed();
     }
 
-    // Allow access if the asset is a group.
+    // Load the asset.
+    $asset_storage = $this->entityTypeManager->getStorage('asset');
     /** @var \Drupal\asset\Entity\AssetInterface $asset */
-    $asset = $this->assetStorage->load($asset_id);
+    $asset = $asset_storage->load($asset_id);
+
+    // Allow access if the asset is a group.
     $access = AccessResult::allowedIf($asset->bundle() == 'group');
 
     // Invalidate the access result when assets are changed.

--- a/modules/asset/group/src/Access/FarmGroupMembersViewsAccessCheck.php
+++ b/modules/asset/group/src/Access/FarmGroupMembersViewsAccessCheck.php
@@ -14,16 +14,9 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 class FarmGroupMembersViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
@@ -39,16 +39,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   protected $groupMembership;
 
-  /**
-   * LogEventSubscriber Constructor.
-   *
-   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
-   *   Cache tag invalidator service.
-   * @param \Drupal\Component\Datetime\TimeInterface $date_time
-   *   Datetime time service.
-   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
-   *   Group membership service.
-   */
   public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator, TimeInterface $date_time, GroupMembershipInterface $group_membership) {
     $this->time = $date_time;
     $this->cacheTagsInvalidator = $cache_tags_invalidator;

--- a/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/asset/group/src/EventSubscriber/LogEventSubscriber.php
@@ -18,32 +18,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class LogEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * Cache tag invalidator service.
-   *
-   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
-   */
-  protected CacheTagsInvalidatorInterface $cacheTagsInvalidator;
-
-  /**
-   * Datetime time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  /**
-   * Group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface
-   */
-  protected $groupMembership;
-
-  public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator, TimeInterface $date_time, GroupMembershipInterface $group_membership) {
-    $this->time = $date_time;
-    $this->cacheTagsInvalidator = $cache_tags_invalidator;
-    $this->groupMembership = $group_membership;
-  }
+  public function __construct(
+    protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+    protected TimeInterface $time,
+    protected GroupMembershipInterface $groupMembership,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/asset/group/src/GroupAssetLocation.php
+++ b/modules/asset/group/src/GroupAssetLocation.php
@@ -27,22 +27,6 @@ class GroupAssetLocation extends AssetLocation implements AssetLocationInterface
    */
   protected GroupMembershipInterface $groupMembership;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\farm_location\LogLocationInterface $log_location
-   *   Log location service.
-   * @param \Drupal\farm_log\LogQueryFactoryInterface $log_query_factory
-   *   Log query factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database service.
-   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
-   *   The group membership service.
-   */
   public function __construct(LogLocationInterface $log_location, LogQueryFactoryInterface $log_query_factory, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time, Connection $database, GroupMembershipInterface $group_membership) {
     parent::__construct($log_location, $log_query_factory, $entity_type_manager, $time, $database);
     $this->groupMembership = $group_membership;

--- a/modules/asset/group/src/GroupAssetLocation.php
+++ b/modules/asset/group/src/GroupAssetLocation.php
@@ -20,16 +20,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class GroupAssetLocation extends AssetLocation implements AssetLocationInterface {
 
-  /**
-   * Group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface
-   */
-  protected GroupMembershipInterface $groupMembership;
-
-  public function __construct(LogLocationInterface $log_location, LogQueryFactoryInterface $log_query_factory, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time, Connection $database, GroupMembershipInterface $group_membership) {
-    parent::__construct($log_location, $log_query_factory, $entity_type_manager, $time, $database);
-    $this->groupMembership = $group_membership;
+  public function __construct(
+    protected LogLocationInterface $logLocation,
+    protected LogQueryFactoryInterface $logQueryFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+    protected Connection $database,
+    protected GroupMembershipInterface $groupMembership,
+  ) {
+    parent::__construct($logLocation, $logQueryFactory, $entityTypeManager, $time, $database);
   }
 
   /**

--- a/modules/asset/group/src/GroupMembership.php
+++ b/modules/asset/group/src/GroupMembership.php
@@ -23,40 +23,12 @@ class GroupMembership implements GroupMembershipInterface {
    */
   const LOG_FIELD_GROUP = 'group';
 
-  /**
-   * Log query factory.
-   *
-   * @var \Drupal\farm_log\LogQueryFactoryInterface
-   */
-  protected LogQueryFactoryInterface $logQueryFactory;
-
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  /**
-   * The database service.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected $database;
-
-  public function __construct(LogQueryFactoryInterface $log_query_factory, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time, Connection $database) {
-    $this->logQueryFactory = $log_query_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->time = $time;
-    $this->database = $database;
-  }
+  public function __construct(
+    protected LogQueryFactoryInterface $logQueryFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+    protected Connection $database,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/asset/group/src/GroupMembership.php
+++ b/modules/asset/group/src/GroupMembership.php
@@ -51,18 +51,6 @@ class GroupMembership implements GroupMembershipInterface {
    */
   protected $database;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\farm_log\LogQueryFactoryInterface $log_query_factory
-   *   Log query factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database service.
-   */
   public function __construct(LogQueryFactoryInterface $log_query_factory, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time, Connection $database) {
     $this->logQueryFactory = $log_query_factory;
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
@@ -16,16 +16,9 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class CircularGroupMembershipConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
-  /**
-   * Group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface
-   */
-  protected $groupMembership;
-
-  public function __construct(GroupMembershipInterface $group_membership) {
-    $this->groupMembership = $group_membership;
-  }
+  public function __construct(
+    protected GroupMembershipInterface $groupMembership,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
@@ -23,12 +23,6 @@ class CircularGroupMembershipConstraintValidator extends ConstraintValidator imp
    */
   protected $groupMembership;
 
-  /**
-   * CircularGroupMembershipConstraintValidator constructor.
-   *
-   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
-   *   Group membership service.
-   */
   public function __construct(GroupMembershipInterface $group_membership) {
     $this->groupMembership = $group_membership;
   }

--- a/modules/asset/group/src/Plugin/views/argument/AssetGroup.php
+++ b/modules/asset/group/src/Plugin/views/argument/AssetGroup.php
@@ -33,20 +33,6 @@ class AssetGroup extends ArgumentPluginBase {
    */
   protected $groupMembership;
 
-  /**
-   * Constructs an AssetGroup object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
-   *   The group membership service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, GroupMembershipInterface $group_membership) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/asset/group/src/Plugin/views/argument/AssetGroup.php
+++ b/modules/asset/group/src/Plugin/views/argument/AssetGroup.php
@@ -19,24 +19,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[ViewsArgument("asset_group")]
 class AssetGroup extends ArgumentPluginBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface
-   */
-  protected $groupMembership;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, GroupMembershipInterface $group_membership) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected GroupMembershipInterface $groupMembership,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->groupMembership = $group_membership;
   }
 
   /**

--- a/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -32,14 +32,6 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   protected $layerStyleLoader;
 
-  /**
-   * MapRenderEventSubscriber Constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_map\LayerStyleLoaderInterface $layer_style_loader
-   *   The layer style loader service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
     $this->landAssetType = $entity_type_manager->getStorage('asset_type')->load('land');
     $this->layerStyleLoader = $layer_style_loader;

--- a/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -18,24 +18,10 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The layer style loader service.
-   *
-   * @var \Drupal\farm_map\LayerStyleLoaderInterface
-   */
-  protected $layerStyleLoader;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->layerStyleLoader = $layer_style_loader;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected LayerStyleLoaderInterface $layerStyleLoader,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/land/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -19,11 +19,11 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   use StringTranslationTrait;
 
   /**
-   * Land asset type.
+   * The entity type manager.
    *
-   * @var \Drupal\asset\Entity\AssetTypeInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $landAssetType;
+  protected $entityTypeManager;
 
   /**
    * The layer style loader service.
@@ -33,7 +33,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   protected $layerStyleLoader;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
-    $this->landAssetType = $entity_type_manager->getStorage('asset_type')->load('land');
+    $this->entityTypeManager = $entity_type_manager;
     $this->layerStyleLoader = $layer_style_loader;
   }
 
@@ -65,10 +65,13 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
       // Define the parent group.
       $group = $this->t('Locations');
 
+      // Load the land asset type.
+      $land_asset_type = $this->entityTypeManager->getStorage('asset_type')->load('land');
+
       // Create a layer group for the asset type.
       $layers['land'] = [
         'group' => $group,
-        'label' => $this->landAssetType->label(),
+        'label' => $land_asset_type->label(),
         'is_group' => TRUE,
       ];
 
@@ -87,7 +90,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
           $color = $layer_style->get('color');
         }
         $layers['land_' . $land_type->id()] = [
-          'group' => $this->landAssetType->label(),
+          'group' => $land_asset_type->label(),
           'label' => $land_type->label(),
           'asset_type' => 'land',
           'filters' => $filters + ['land_type_value[]' => $land_type->id()],

--- a/modules/asset/sensor/src/Controller/SensorDataController.php
+++ b/modules/asset/sensor/src/Controller/SensorDataController.php
@@ -30,12 +30,6 @@ class SensorDataController extends ControllerBase {
    */
   protected $basicDataStream;
 
-  /**
-   * SensorDataController constructor.
-   *
-   * @param \Drupal\data_stream\DataStreamTypeManager $data_stream_type_manager
-   *   The data stream type manager.
-   */
   public function __construct(DataStreamTypeManager $data_stream_type_manager) {
     $this->basicDataStream = $data_stream_type_manager->createInstance('basic');
   }

--- a/modules/asset/sensor/src/Controller/SensorDataController.php
+++ b/modules/asset/sensor/src/Controller/SensorDataController.php
@@ -23,16 +23,9 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class SensorDataController extends ControllerBase {
 
-  /**
-   * Data stream type manager.
-   *
-   * @var \Drupal\data_stream\DataStreamTypeManager
-   */
-  protected $dataStreamTypeManager;
-
-  public function __construct(DataStreamTypeManager $data_stream_type_manager) {
-    $this->dataStreamTypeManager = $data_stream_type_manager;
-  }
+  public function __construct(
+    protected DataStreamTypeManager $dataStreamTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/asset/sensor/src/Controller/SensorDataController.php
+++ b/modules/asset/sensor/src/Controller/SensorDataController.php
@@ -24,14 +24,14 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class SensorDataController extends ControllerBase {
 
   /**
-   * The basic data stream plugin.
+   * Data stream type manager.
    *
-   * @var \Drupal\data_stream\Plugin\DataStream\DataStreamType\Basic
+   * @var \Drupal\data_stream\DataStreamTypeManager
    */
-  protected $basicDataStream;
+  protected $dataStreamTypeManager;
 
   public function __construct(DataStreamTypeManager $data_stream_type_manager) {
-    $this->basicDataStream = $data_stream_type_manager->createInstance('basic');
+    $this->dataStreamTypeManager = $data_stream_type_manager;
   }
 
   /**
@@ -93,6 +93,9 @@ class SensorDataController extends ControllerBase {
       return $data_stream->bundle() === 'basic';
     });
 
+    // Create an instance of the basic data stream plugin.
+    $basic_data_stream = $this->dataStreamTypeManager->createInstance('basic');
+
     // Get request method.
     $method = $request->getMethod();
     switch ($method) {
@@ -118,7 +121,7 @@ class SensorDataController extends ControllerBase {
         }
         $params['limit'] = $limit;
 
-        $data = $this->basicDataStream->storageGetMultiple($basic_data_streams, $params);
+        $data = $basic_data_stream->storageGetMultiple($basic_data_streams, $params);
         return new JsonResponse($data);
 
       case Request::METHOD_POST:
@@ -146,13 +149,13 @@ class SensorDataController extends ControllerBase {
 
         // Allow each data stream to process the data.
         foreach ($basic_data_streams as $data_stream) {
-          $this->basicDataStream->storageSave($data_stream, $data);
+          $basic_data_stream->storageSave($data_stream, $data);
         }
         return new Response('', Response::HTTP_CREATED);
     }
 
     // Else raise error.
-    throw new MethodNotAllowedHttpException($this->basicDataStream->apiAllowedMethods());
+    throw new MethodNotAllowedHttpException($basic_data_stream->apiAllowedMethods());
   }
 
   /**

--- a/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -18,24 +18,10 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The layer style loader service.
-   *
-   * @var \Drupal\farm_map\LayerStyleLoaderInterface
-   */
-  protected $layerStyleLoader;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->layerStyleLoader = $layer_style_loader;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected LayerStyleLoaderInterface $layerStyleLoader,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -19,11 +19,11 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   use StringTranslationTrait;
 
   /**
-   * Structure asset type.
+   * The entity type manager.
    *
-   * @var \Drupal\asset\Entity\AssetTypeInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $structureAssetType;
+  protected $entityTypeManager;
 
   /**
    * The layer style loader service.
@@ -33,7 +33,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   protected $layerStyleLoader;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
-    $this->structureAssetType = $entity_type_manager->getStorage('asset_type')->load('structure');
+    $this->entityTypeManager = $entity_type_manager;
     $this->layerStyleLoader = $layer_style_loader;
   }
 
@@ -65,10 +65,13 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
       // Define the parent group.
       $group = $this->t('Locations');
 
+      // Load the structure asset type.
+      $structure_asset_type = $this->entityTypeManager->getStorage('asset_type')->load('structure');
+
       // Create a layer group for the asset type.
       $layers['structure'] = [
         'group' => $group,
-        'label' => $this->structureAssetType->label(),
+        'label' => $structure_asset_type->label(),
         'is_group' => TRUE,
       ];
 
@@ -87,7 +90,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
           $color = $layer_style->get('color');
         }
         $layers['structure_' . $structure_type->id()] = [
-          'group' => $this->structureAssetType->label(),
+          'group' => $structure_asset_type->label(),
           'label' => $structure_type->label(),
           'asset_type' => 'structure',
           'filters' => $filters + ['structure_type_value[]' => $structure_type->id()],

--- a/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/asset/structure/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -32,14 +32,6 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   protected $layerStyleLoader;
 
-  /**
-   * MapRenderEventSubscriber Constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_map\LayerStyleLoaderInterface $layer_style_loader
-   *   The layer style loader service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
     $this->structureAssetType = $entity_type_manager->getStorage('asset_type')->load('structure');
     $this->layerStyleLoader = $layer_style_loader;

--- a/modules/core/api/modules/farm_api_oauth/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/modules/core/api/modules/farm_api_oauth/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -24,12 +24,6 @@ class CorsResponseEventSubscriber implements EventSubscriberInterface {
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a new CorsResponseEventSubscriber.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/core/api/modules/farm_api_oauth/src/EventSubscriber/CorsResponseEventSubscriber.php
+++ b/modules/core/api/modules/farm_api_oauth/src/EventSubscriber/CorsResponseEventSubscriber.php
@@ -17,16 +17,9 @@ use Symfony\Component\HttpKernel\KernelEvents;
  */
 class CorsResponseEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * Entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/api/src/Controller/FarmEntryPoint.php
+++ b/modules/core/api/src/Controller/FarmEntryPoint.php
@@ -46,18 +46,6 @@ class FarmEntryPoint extends EntryPoint {
    */
   protected $moduleHandler;
 
-  /**
-   * EntryPoint constructor.
-   *
-   * @param \Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface $resource_type_repository
-   *   The resource type repository.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   * @param \Drupal\Core\Extension\ProfileExtensionList $profile_extension_list
-   *   The profile extension list service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(ResourceTypeRepositoryInterface $resource_type_repository, AccountInterface $user, ProfileExtensionList $profile_extension_list, ModuleHandlerInterface $module_handler) {
     parent::__construct($resource_type_repository, $user);
     $this->farmProfileInfo = $profile_extension_list->getExtensionInfo('farm');

--- a/modules/core/api/src/Controller/FarmEntryPoint.php
+++ b/modules/core/api/src/Controller/FarmEntryPoint.php
@@ -32,15 +32,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class FarmEntryPoint extends EntryPoint {
 
   /**
-   * Farm profile info.
+   * The profile extension list.
    *
-   * @var mixed[]
+   * @var \Drupal\Core\Extension\ExtensionList
    */
-  protected $farmProfileInfo;
+  protected $profileExtensionList;
 
   public function __construct(ResourceTypeRepositoryInterface $resource_type_repository, AccountInterface $user, ProfileExtensionList $profile_extension_list) {
     parent::__construct($resource_type_repository, $user);
-    $this->farmProfileInfo = $profile_extension_list->getExtensionInfo('farm');
+    $this->profileExtensionList = $profile_extension_list;
   }
 
   /**
@@ -72,11 +72,14 @@ class FarmEntryPoint extends EntryPoint {
     $urls = $data->getLinks();
     $meta = $data->getMeta();
 
+    // Get the farmOS profile info.
+    $farm_profile_info = $this->profileExtensionList->getExtensionInfo('farm');
+
     // Add a "farm" object to meta.
     $meta['farm'] = [
       'name' => $this->config('system.site')->get('name'),
       'url' => $base_url,
-      'version' => $this->farmProfileInfo['version'],
+      'version' => $farm_profile_info['version'],
     ];
 
     // Allow modules to add additional meta information.

--- a/modules/core/api/src/Controller/FarmEntryPoint.php
+++ b/modules/core/api/src/Controller/FarmEntryPoint.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_api\Controller;
 
-use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Extension\ProfileExtensionList;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\jsonapi\CacheableResourceResponse;
@@ -39,17 +38,9 @@ class FarmEntryPoint extends EntryPoint {
    */
   protected $farmProfileInfo;
 
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  public function __construct(ResourceTypeRepositoryInterface $resource_type_repository, AccountInterface $user, ProfileExtensionList $profile_extension_list, ModuleHandlerInterface $module_handler) {
+  public function __construct(ResourceTypeRepositoryInterface $resource_type_repository, AccountInterface $user, ProfileExtensionList $profile_extension_list) {
     parent::__construct($resource_type_repository, $user);
     $this->farmProfileInfo = $profile_extension_list->getExtensionInfo('farm');
-    $this->moduleHandler = $module_handler;
   }
 
   /**
@@ -60,7 +51,6 @@ class FarmEntryPoint extends EntryPoint {
       $container->get('jsonapi.resource_type.repository'),
       $container->get('current_user'),
       $container->get('extension.list.profile'),
-      $container->get('module_handler'),
     );
   }
 
@@ -90,7 +80,7 @@ class FarmEntryPoint extends EntryPoint {
     ];
 
     // Allow modules to add additional meta information.
-    $this->moduleHandler->alter('farm_api_meta', $meta['farm']);
+    $this->moduleHandler()->alter('farm_api_meta', $meta['farm']);
 
     // Build a new response.
     $new_response = new CacheableResourceResponse(new JsonApiDocumentTopLevel(new ResourceObjectData([]), new NullIncludedData(), $urls, $meta));

--- a/modules/core/api/src/Controller/FarmEntryPoint.php
+++ b/modules/core/api/src/Controller/FarmEntryPoint.php
@@ -31,16 +31,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FarmEntryPoint extends EntryPoint {
 
-  /**
-   * The profile extension list.
-   *
-   * @var \Drupal\Core\Extension\ExtensionList
-   */
-  protected $profileExtensionList;
-
-  public function __construct(ResourceTypeRepositoryInterface $resource_type_repository, AccountInterface $user, ProfileExtensionList $profile_extension_list) {
-    parent::__construct($resource_type_repository, $user);
-    $this->profileExtensionList = $profile_extension_list;
+  public function __construct(
+    ResourceTypeRepositoryInterface $resourceTypeRepository,
+    AccountInterface $user,
+    protected ProfileExtensionList $profileExtensionList,
+  ) {
+    parent::__construct($resourceTypeRepository, $user);
   }
 
   /**

--- a/modules/core/api/src/EventSubscriber/JsonApiBuildSubscriber.php
+++ b/modules/core/api/src/EventSubscriber/JsonApiBuildSubscriber.php
@@ -14,16 +14,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class JsonApiBuildSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  public function __construct(ModuleHandlerInterface $module_handler) {
-    $this->moduleHandler = $module_handler;
-  }
+  public function __construct(
+    protected ModuleHandlerInterface $moduleHandler,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/api/src/EventSubscriber/JsonApiBuildSubscriber.php
+++ b/modules/core/api/src/EventSubscriber/JsonApiBuildSubscriber.php
@@ -21,12 +21,6 @@ class JsonApiBuildSubscriber implements EventSubscriberInterface {
    */
   protected $moduleHandler;
 
-  /**
-   * Constructor.
-   *
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(ModuleHandlerInterface $module_handler) {
     $this->moduleHandler = $module_handler;
   }

--- a/modules/core/asset/src/AssetStorage.php
+++ b/modules/core/asset/src/AssetStorage.php
@@ -32,28 +32,6 @@ class AssetStorage extends SqlContentEntityStorage {
    */
   protected $time;
 
-  /**
-   * Constructs an AssetStorage object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type definition.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database connection to be used.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache
-   *   The cache backend to be used.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The language manager.
-   * @param \Drupal\Core\Cache\MemoryCache\MemoryCacheInterface $memory_cache
-   *   The memory cache backend to be used.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle info.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   */
   public function __construct(EntityTypeInterface $entity_type, Connection $database, EntityFieldManagerInterface $entity_field_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, MemoryCacheInterface $memory_cache, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
     parent::__construct($entity_type, $database, $entity_field_manager, $cache, $language_manager, $memory_cache, $entity_type_bundle_info, $entity_type_manager);
     $this->time = $time;

--- a/modules/core/asset/src/AssetStorage.php
+++ b/modules/core/asset/src/AssetStorage.php
@@ -25,16 +25,18 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class AssetStorage extends SqlContentEntityStorage {
 
-  /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  public function __construct(EntityTypeInterface $entity_type, Connection $database, EntityFieldManagerInterface $entity_field_manager, CacheBackendInterface $cache, LanguageManagerInterface $language_manager, MemoryCacheInterface $memory_cache, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    Connection $database,
+    EntityFieldManagerInterface $entity_field_manager,
+    CacheBackendInterface $cache,
+    LanguageManagerInterface $language_manager,
+    MemoryCacheInterface $memory_cache,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected TimeInterface $time,
+  ) {
     parent::__construct($entity_type, $database, $entity_field_manager, $cache, $language_manager, $memory_cache, $entity_type_bundle_info, $entity_type_manager);
-    $this->time = $time;
   }
 
   /**

--- a/modules/core/asset/src/Event/AssetEvent.php
+++ b/modules/core/asset/src/Event/AssetEvent.php
@@ -24,12 +24,6 @@ class AssetEvent extends Event {
    */
   public AssetInterface $asset;
 
-  /**
-   * Constructs the object.
-   *
-   * @param \Drupal\asset\Entity\AssetInterface $asset
-   *   The Asset entity.
-   */
   public function __construct(AssetInterface $asset) {
     $this->asset = $asset;
   }

--- a/modules/core/asset/src/Event/AssetEvent.php
+++ b/modules/core/asset/src/Event/AssetEvent.php
@@ -17,15 +17,8 @@ class AssetEvent extends Event {
   const UPDATE = 'asset_update';
   const DELETE = 'asset_delete';
 
-  /**
-   * The Asset entity.
-   *
-   * @var \Drupal\asset\Entity\AssetInterface
-   */
-  public AssetInterface $asset;
-
-  public function __construct(AssetInterface $asset) {
-    $this->asset = $asset;
-  }
+  public function __construct(
+    public AssetInterface $asset,
+  ) {}
 
 }

--- a/modules/core/asset/src/Plugin/Action/AssetClone.php
+++ b/modules/core/asset/src/Plugin/Action/AssetClone.php
@@ -22,16 +22,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class AssetClone extends EntityActionBase {
 
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->currentUser = $current_user;
   }
 
   /**

--- a/modules/core/asset/src/Plugin/Action/AssetClone.php
+++ b/modules/core/asset/src/Plugin/Action/AssetClone.php
@@ -29,20 +29,6 @@ class AssetClone extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs an AssetClone object.
-   *
-   * @param mixed[] $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   The current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $this->currentUser = $current_user;

--- a/modules/core/csv/src/Encoder/CsvEncoder.php
+++ b/modules/core/csv/src/Encoder/CsvEncoder.php
@@ -18,22 +18,6 @@ class CsvEncoder extends ContribCsvEncoder {
    */
   protected $sanitize = TRUE;
 
-  /**
-   * Constructs the class.
-   *
-   * @param string $delimiter
-   *   Indicates the character used to delimit fields. Defaults to ",".
-   * @param string $enclosure
-   *   Indicates the character used for field enclosure. Defaults to '"'.
-   * @param string $escape_char
-   *   Indicates the character used for escaping. Defaults to "\".
-   * @param bool $strip_tags
-   *   Whether to strip tags from values or not. Defaults to TRUE.
-   * @param bool $trim_values
-   *   Whether to trim values or not. Defaults to TRUE.
-   * @param bool $sanitize
-   *   Whether to sanitize values against formula injection. Defaults to TRUE.
-   */
   public function __construct($delimiter = ",", $enclosure = '"', $escape_char = "\\", $strip_tags = TRUE, $trim_values = TRUE, $sanitize = TRUE) {
     parent::__construct($delimiter, $enclosure, $escape_char, $strip_tags, $trim_values);
     $this->sanitize = $sanitize;

--- a/modules/core/csv/src/Encoder/CsvEncoder.php
+++ b/modules/core/csv/src/Encoder/CsvEncoder.php
@@ -11,16 +11,15 @@ use Drupal\csv_serialization\Encoder\CsvEncoder as ContribCsvEncoder;
  */
 class CsvEncoder extends ContribCsvEncoder {
 
-  /**
-   * Whether to sanitize cell values.
-   *
-   * @var bool
-   */
-  protected $sanitize = TRUE;
-
-  public function __construct($delimiter = ",", $enclosure = '"', $escape_char = "\\", $strip_tags = TRUE, $trim_values = TRUE, $sanitize = TRUE) {
+  public function __construct(
+    $delimiter = ",",
+    $enclosure = '"',
+    $escape_char = "\\",
+    $strip_tags = TRUE,
+    $trim_values = TRUE,
+    protected bool $sanitize = TRUE,
+  ) {
     parent::__construct($delimiter, $enclosure, $escape_char, $strip_tags, $trim_values);
-    $this->sanitize = $sanitize;
   }
 
   /**

--- a/modules/core/data_stream/modules/notification/src/Attribute/NotificationCondition.php
+++ b/modules/core/data_stream/modules/notification/src/Attribute/NotificationCondition.php
@@ -13,17 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class NotificationCondition extends Plugin {
 
-  /**
-   * Constructs a notification condition attribute.
-   *
-   * @param string $id
-   *   The notification condition ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The notification condition label.
-   * @param \Drupal\Core\Plugin\Context\ContextDefinitionInterface[] $context_definitions
-   *   (optional) An array of context definitions describing the context used by
-   *   the plugin. The array is keyed by context names.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/data_stream/modules/notification/src/Attribute/NotificationDelivery.php
+++ b/modules/core/data_stream/modules/notification/src/Attribute/NotificationDelivery.php
@@ -13,17 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class NotificationDelivery extends Plugin {
 
-  /**
-   * Constructs a notification delivery attribute.
-   *
-   * @param string $id
-   *   The notification delivery ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The notification delivery label.
-   * @param \Drupal\Core\Plugin\Context\ContextDefinitionInterface[] $context_definitions
-   *   (optional) An array of context definitions describing the context used by
-   *   the plugin. The array is keyed by context names.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
+++ b/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
@@ -16,14 +16,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class DataStreamEventSubscriber implements EventSubscriberInterface {
 
   /**
-   * The data stream notification entity storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $notificationStorage;
+  protected $entityTypeManager;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->notificationStorage = $entity_type_manager->getStorage('data_stream_notification');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -45,7 +45,7 @@ class DataStreamEventSubscriber implements EventSubscriberInterface {
 
     // Load any notifications configured for the data stream.
     /** @var \Drupal\data_stream_notification\Entity\DataStreamNotificationInterface[] $notifications */
-    $notifications = $this->notificationStorage->loadByProperties([
+    $notifications = $this->entityTypeManager->getStorage('data_stream_notification')->loadByProperties([
       'status' => TRUE,
       'data_stream' => $event->dataStream->id(),
     ]);

--- a/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
+++ b/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
@@ -22,12 +22,6 @@ class DataStreamEventSubscriber implements EventSubscriberInterface {
    */
   protected $notificationStorage;
 
-  /**
-   * Constructs a DataStreamEventSubscriber object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->notificationStorage = $entity_type_manager->getStorage('data_stream_notification');
   }

--- a/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
+++ b/modules/core/data_stream/modules/notification/src/EventSubscriber/DataStreamEventSubscriber.php
@@ -15,16 +15,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class DataStreamEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/data_stream/modules/notification/src/Form/DataStreamNotificationForm.php
+++ b/modules/core/data_stream/modules/notification/src/Form/DataStreamNotificationForm.php
@@ -24,24 +24,10 @@ class DataStreamNotificationForm extends EntityForm {
    */
   protected $entity;
 
-  /**
-   * The notification condition manager service.
-   *
-   * @var \Drupal\data_stream_notification\NotificationConditionManagerInterface
-   */
-  protected $conditionManager;
-
-  /**
-   * The notification delivery manager service.
-   *
-   * @var \Drupal\data_stream_notification\NotificationDeliveryManagerInterface
-   */
-  protected $deliveryManager;
-
-  public function __construct(NotificationConditionManagerInterface $condition_manager, NotificationDeliveryManagerInterface $delivery_manager) {
-    $this->conditionManager = $condition_manager;
-    $this->deliveryManager = $delivery_manager;
-  }
+  public function __construct(
+    protected NotificationConditionManagerInterface $conditionManager,
+    protected NotificationDeliveryManagerInterface $deliveryManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/data_stream/modules/notification/src/Form/DataStreamNotificationForm.php
+++ b/modules/core/data_stream/modules/notification/src/Form/DataStreamNotificationForm.php
@@ -38,14 +38,6 @@ class DataStreamNotificationForm extends EntityForm {
    */
   protected $deliveryManager;
 
-  /**
-   * Constructs a new DataStreamNotificationForm object.
-   *
-   * @param \Drupal\data_stream_notification\NotificationConditionManagerInterface $condition_manager
-   *   The notification condition manager service.
-   * @param \Drupal\data_stream_notification\NotificationDeliveryManagerInterface $delivery_manager
-   *   The notification delivery manager service.
-   */
   public function __construct(NotificationConditionManagerInterface $condition_manager, NotificationDeliveryManagerInterface $delivery_manager) {
     $this->conditionManager = $condition_manager;
     $this->deliveryManager = $delivery_manager;

--- a/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
@@ -17,7 +17,11 @@ use Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition\Noti
  */
 class NotificationConditionManager extends DefaultPluginManager implements NotificationConditionManagerInterface {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/DataStream/NotificationCondition',
       $namespaces,

--- a/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationConditionManager.php
@@ -17,17 +17,6 @@ use Drupal\data_stream_notification\Plugin\DataStream\NotificationCondition\Noti
  */
 class NotificationConditionManager extends DefaultPluginManager implements NotificationConditionManagerInterface {
 
-  /**
-   * Constructs a NotificationConditionManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   Cache backend instance to use.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler to invoke the alter hook with.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/DataStream/NotificationCondition',

--- a/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
@@ -15,7 +15,11 @@ use Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\Notif
  */
 class NotificationDeliveryManager extends DefaultPluginManager implements NotificationDeliveryManagerInterface {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/DataStream/NotificationDelivery',
       $namespaces,

--- a/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
+++ b/modules/core/data_stream/modules/notification/src/NotificationDeliveryManager.php
@@ -15,17 +15,6 @@ use Drupal\data_stream_notification\Plugin\DataStream\NotificationDelivery\Notif
  */
 class NotificationDeliveryManager extends DefaultPluginManager implements NotificationDeliveryManagerInterface {
 
-  /**
-   * Constructs a NotificationDeliveryManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   Cache backend instance to use.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler to invoke the alter hook with.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/DataStream/NotificationDelivery',

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
@@ -43,20 +43,6 @@ class Email extends NotificationDeliveryBase implements ContainerFactoryPluginIn
    */
   protected $mailManager;
 
-  /**
-   * Constructs an Email object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Component\Utility\EmailValidatorInterface $email_validator
-   *   The email validator service.
-   * @param \Drupal\Core\Mail\MailManagerInterface $mail_manager
-   *   The mail manager service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EmailValidatorInterface $email_validator, MailManagerInterface $mail_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->emailValidator = $email_validator;

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
@@ -29,24 +29,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class Email extends NotificationDeliveryBase implements ContainerFactoryPluginInterface {
 
-  /**
-   * The email validator service.
-   *
-   * @var \Drupal\Component\Utility\EmailValidatorInterface
-   */
-  protected $emailValidator;
-
-  /**
-   * The mail manager service.
-   *
-   * @var \Drupal\Core\Mail\MailManagerInterface
-   */
-  protected $mailManager;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EmailValidatorInterface $email_validator, MailManagerInterface $mail_manager) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EmailValidatorInterface $emailValidator,
+    protected MailManagerInterface $mailManager,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->emailValidator = $email_validator;
-    $this->mailManager = $mail_manager;
   }
 
   /**

--- a/modules/core/data_stream/src/Attribute/DataStreamType.php
+++ b/modules/core/data_stream/src/Attribute/DataStreamType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class DataStreamType extends Plugin {
 
-  /**
-   * Constructs a data stream type attribute.
-   *
-   * @param string $id
-   *   The data stream type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The data stream type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/data_stream/src/DataStreamTypeManager.php
+++ b/modules/core/data_stream/src/DataStreamTypeManager.php
@@ -16,17 +16,6 @@ use Drupal\data_stream\Plugin\DataStream\DataStreamType\DataStreamTypeInterface;
  */
 class DataStreamTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new DataStreamTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/DataStream/DataStreamType',

--- a/modules/core/data_stream/src/DataStreamTypeManager.php
+++ b/modules/core/data_stream/src/DataStreamTypeManager.php
@@ -16,7 +16,11 @@ use Drupal\data_stream\Plugin\DataStream\DataStreamType\DataStreamTypeInterface;
  */
 class DataStreamTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/DataStream/DataStreamType',
       $namespaces,

--- a/modules/core/data_stream/src/Event/DataStreamEvent.php
+++ b/modules/core/data_stream/src/Event/DataStreamEvent.php
@@ -14,23 +14,11 @@ class DataStreamEvent extends Event {
 
   const DATA_RECEIVE = 'data_stream_data_receive';
 
-  /**
-   * The data steam entity.
-   *
-   * @var \Drupal\data_stream\Entity\DataStreamInterface
-   */
-  public DataStreamInterface $dataStream;
-
-  /**
-   * The context associated with the event.
-   *
-   * @var array
-   */
-  public array $context;
-
-  public function __construct(DataStreamInterface $data_stream, array $context = []) {
-    $this->dataStream = $data_stream;
-    $this->context = $context + ['data_stream' => $data_stream];
+  public function __construct(
+    public DataStreamInterface $dataStream,
+    public array $context = [],
+  ) {
+    $this->context = $context + ['data_stream' => $dataStream];
   }
 
 }

--- a/modules/core/data_stream/src/Event/DataStreamEvent.php
+++ b/modules/core/data_stream/src/Event/DataStreamEvent.php
@@ -28,14 +28,6 @@ class DataStreamEvent extends Event {
    */
   public array $context;
 
-  /**
-   * Constructs the DataStreamEvent object.
-   *
-   * @param \Drupal\data_stream\Entity\DataStreamInterface $data_stream
-   *   The data stream entity.
-   * @param array $context
-   *   The event context.
-   */
   public function __construct(DataStreamInterface $data_stream, array $context = []) {
     $this->dataStream = $data_stream;
     $this->context = $context + ['data_stream' => $data_stream];

--- a/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
+++ b/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
@@ -69,22 +69,6 @@ class Basic extends DataStreamTypeBase implements DataStreamStorageInterface, Da
    */
   protected $tableName = 'data_stream_basic';
 
-  /**
-   * Constructs a \Drupal\Component\Plugin\PluginBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Database\Connection $connection
-   *   The database connection.
-   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
-   *   The event dispatcher service.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   */
   public function __construct(array $configuration, string $plugin_id, $plugin_definition, Connection $connection, EventDispatcherInterface $event_dispatcher, TimeInterface $time) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->connection = $connection;

--- a/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
+++ b/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
@@ -38,29 +38,6 @@ class Basic extends DataStreamTypeBase implements DataStreamStorageInterface, Da
   use DataStreamPrivateKeyAccess;
 
   /**
-   * A database connection.
-   *
-   * @var \Drupal\Core\Database\Connection
-   *
-   * @see DataStreamSqlStorage
-   */
-  protected $connection;
-
-  /**
-   * The event dispatcher service.
-   *
-   * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
-   */
-  protected $eventDispatcher;
-
-  /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  /**
    * Database table.
    *
    * @var string
@@ -69,11 +46,15 @@ class Basic extends DataStreamTypeBase implements DataStreamStorageInterface, Da
    */
   protected $tableName = 'data_stream_basic';
 
-  public function __construct(array $configuration, string $plugin_id, $plugin_definition, Connection $connection, EventDispatcherInterface $event_dispatcher, TimeInterface $time) {
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    $plugin_definition,
+    protected Connection $connection,
+    protected EventDispatcherInterface $eventDispatcher,
+    protected TimeInterface $time,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->connection = $connection;
-    $this->eventDispatcher = $event_dispatcher;
-    $this->time = $time;
   }
 
   /**

--- a/modules/core/entity/src/AssetTypeManager.php
+++ b/modules/core/entity/src/AssetTypeManager.php
@@ -16,17 +16,6 @@ use Drupal\farm_entity\Plugin\Asset\AssetType\AssetTypeInterface;
  */
 class AssetTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new AssetTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/Asset/AssetType',

--- a/modules/core/entity/src/AssetTypeManager.php
+++ b/modules/core/entity/src/AssetTypeManager.php
@@ -16,7 +16,11 @@ use Drupal\farm_entity\Plugin\Asset\AssetType\AssetTypeInterface;
  */
 class AssetTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/Asset/AssetType',
       $namespaces,

--- a/modules/core/entity/src/Attribute/AssetType.php
+++ b/modules/core/entity/src/Attribute/AssetType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AssetType extends Plugin {
 
-  /**
-   * Constructs an asset type attribute.
-   *
-   * @param string $id
-   *   The asset type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The asset type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/entity/src/Attribute/LogType.php
+++ b/modules/core/entity/src/Attribute/LogType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class LogType extends Plugin {
 
-  /**
-   * Constructs a log type attribute.
-   *
-   * @param string $id
-   *   The log type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The log type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/entity/src/Attribute/OrganizationType.php
+++ b/modules/core/entity/src/Attribute/OrganizationType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class OrganizationType extends Plugin {
 
-  /**
-   * Constructs an organization type attribute.
-   *
-   * @param string $id
-   *   The organization type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The organization type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/entity/src/Attribute/PlanRecordType.php
+++ b/modules/core/entity/src/Attribute/PlanRecordType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class PlanRecordType extends Plugin {
 
-  /**
-   * Constructs a plan record type attribute.
-   *
-   * @param string $id
-   *   The plan record type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The plan record type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/entity/src/Attribute/PlanType.php
+++ b/modules/core/entity/src/Attribute/PlanType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class PlanType extends Plugin {
 
-  /**
-   * Constructs a plan type attribute.
-   *
-   * @param string $id
-   *   The plan type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The plan type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/entity/src/Attribute/QuantityType.php
+++ b/modules/core/entity/src/Attribute/QuantityType.php
@@ -13,14 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class QuantityType extends Plugin {
 
-  /**
-   * Constructs a quantity type attribute.
-   *
-   * @param string $id
-   *   The quantity type ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The quantity type label.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/entity/src/BundlePlugin/FarmEntityBundlePluginHandler.php
+++ b/modules/core/entity/src/BundlePlugin/FarmEntityBundlePluginHandler.php
@@ -17,16 +17,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FarmEntityBundlePluginHandler extends BundlePluginHandler {
 
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  public function __construct(EntityTypeInterface $entity_type, PluginManagerInterface $plugin_manager, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    PluginManagerInterface $plugin_manager,
+    protected ModuleHandlerInterface $moduleHandler,
+  ) {
     parent::__construct($entity_type, $plugin_manager);
-    $this->moduleHandler = $module_handler;
   }
 
   /**

--- a/modules/core/entity/src/BundlePlugin/FarmEntityBundlePluginHandler.php
+++ b/modules/core/entity/src/BundlePlugin/FarmEntityBundlePluginHandler.php
@@ -24,16 +24,6 @@ class FarmEntityBundlePluginHandler extends BundlePluginHandler {
    */
   protected $moduleHandler;
 
-  /**
-   * Constructs a new FarmEntityBundlePluginHandler object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   * @param \Drupal\Component\Plugin\PluginManagerInterface $plugin_manager
-   *   The bundle plugin manager.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(EntityTypeInterface $entity_type, PluginManagerInterface $plugin_manager, ModuleHandlerInterface $module_handler) {
     parent::__construct($entity_type, $plugin_manager);
     $this->moduleHandler = $module_handler;

--- a/modules/core/entity/src/FarmEntityTypeBase.php
+++ b/modules/core/entity/src/FarmEntityTypeBase.php
@@ -21,9 +21,6 @@ abstract class FarmEntityTypeBase extends PluginBase implements ContainerFactory
    */
   protected $farmFieldFactory;
 
-  /**
-   * {@inheritdoc}
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, FarmFieldFactoryInterface $farm_field_factory) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->farmFieldFactory = $farm_field_factory;

--- a/modules/core/entity/src/FarmEntityTypeBase.php
+++ b/modules/core/entity/src/FarmEntityTypeBase.php
@@ -14,16 +14,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class FarmEntityTypeBase extends PluginBase implements ContainerFactoryPluginInterface {
 
-  /**
-   * The farm_field.factory service.
-   *
-   * @var \Drupal\farm_field\FarmFieldFactoryInterface
-   */
-  protected $farmFieldFactory;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, FarmFieldFactoryInterface $farm_field_factory) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected FarmFieldFactoryInterface $farmFieldFactory,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->farmFieldFactory = $farm_field_factory;
   }
 
   /**

--- a/modules/core/entity/src/LogTypeManager.php
+++ b/modules/core/entity/src/LogTypeManager.php
@@ -16,17 +16,6 @@ use Drupal\farm_entity\Plugin\Log\LogType\LogTypeInterface;
  */
 class LogTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new LogTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/Log/LogType',

--- a/modules/core/entity/src/LogTypeManager.php
+++ b/modules/core/entity/src/LogTypeManager.php
@@ -16,7 +16,11 @@ use Drupal\farm_entity\Plugin\Log\LogType\LogTypeInterface;
  */
 class LogTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/Log/LogType',
       $namespaces,

--- a/modules/core/entity/src/OrganizationTypeManager.php
+++ b/modules/core/entity/src/OrganizationTypeManager.php
@@ -19,17 +19,6 @@ use Drupal\farm_entity\Plugin\Organization\OrganizationType\OrganizationTypeInte
  */
 class OrganizationTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new OrganizationTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/Organization/OrganizationType',

--- a/modules/core/entity/src/OrganizationTypeManager.php
+++ b/modules/core/entity/src/OrganizationTypeManager.php
@@ -19,7 +19,11 @@ use Drupal\farm_entity\Plugin\Organization\OrganizationType\OrganizationTypeInte
  */
 class OrganizationTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/Organization/OrganizationType',
       $namespaces,

--- a/modules/core/entity/src/PlanRecordTypeManager.php
+++ b/modules/core/entity/src/PlanRecordTypeManager.php
@@ -16,7 +16,11 @@ use Drupal\farm_entity\Plugin\PlanRecord\PlanRecordType\PlanRecordTypeInterface;
  */
 class PlanRecordTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/PlanRecord/PlanRecordType',
       $namespaces,

--- a/modules/core/entity/src/PlanRecordTypeManager.php
+++ b/modules/core/entity/src/PlanRecordTypeManager.php
@@ -16,17 +16,6 @@ use Drupal\farm_entity\Plugin\PlanRecord\PlanRecordType\PlanRecordTypeInterface;
  */
 class PlanRecordTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new PlanRecordTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/PlanRecord/PlanRecordType',

--- a/modules/core/entity/src/PlanTypeManager.php
+++ b/modules/core/entity/src/PlanTypeManager.php
@@ -16,7 +16,11 @@ use Drupal\farm_entity\Plugin\Plan\PlanType\PlanTypeInterface;
  */
 class PlanTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/Plan/PlanType',
       $namespaces,

--- a/modules/core/entity/src/PlanTypeManager.php
+++ b/modules/core/entity/src/PlanTypeManager.php
@@ -16,17 +16,6 @@ use Drupal\farm_entity\Plugin\Plan\PlanType\PlanTypeInterface;
  */
 class PlanTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new PlanTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/Plan/PlanType',

--- a/modules/core/entity/src/QuantityTypeManager.php
+++ b/modules/core/entity/src/QuantityTypeManager.php
@@ -16,17 +16,6 @@ use Drupal\farm_entity\Plugin\Quantity\QuantityType\QuantityTypeInterface;
  */
 class QuantityTypeManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a new QuantityTypeManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   The cache backend.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/Quantity/QuantityType',

--- a/modules/core/entity/src/QuantityTypeManager.php
+++ b/modules/core/entity/src/QuantityTypeManager.php
@@ -16,7 +16,11 @@ use Drupal\farm_entity\Plugin\Quantity\QuantityType\QuantityTypeInterface;
  */
 class QuantityTypeManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/Quantity/QuantityType',
       $namespaces,

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_export_csv\Form;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -64,13 +63,6 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
   protected $fileSystem;
 
   /**
-   * The default file scheme.
-   *
-   * @var string
-   */
-  protected $defaultFileScheme;
-
-  /**
    * The file repository service.
    *
    * @var \Drupal\file\FileRepositoryInterface
@@ -105,13 +97,12 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
    */
   protected $entities;
 
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, SerializerInterface $serializer, FileSystemInterface $file_system, ConfigFactoryInterface $config_factory, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator, AccountInterface $user) {
+  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, SerializerInterface $serializer, FileSystemInterface $file_system, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator, AccountInterface $user) {
     $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
     $this->serializer = $serializer;
     $this->fileSystem = $file_system;
-    $this->defaultFileScheme = $config_factory->get('system.file')->get('default_scheme') ?? 'public';
     $this->fileRepository = $file_repository;
     $this->fileUrlGenerator = $file_url_generator;
     $this->user = $user;
@@ -127,7 +118,6 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       $container->get('entity_field.manager'),
       $container->get('serializer'),
       $container->get('file_system'),
-      $container->get('config.factory'),
       $container->get('file.repository'),
       $container->get('file_url_generator'),
       $container->get('current_user'),
@@ -315,7 +305,8 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
     $output = $this->serializer->serialize($accessible_entities, 'csv', $context);
 
     // Prepare the file directory.
-    $directory = $this->defaultFileScheme . '://csv';
+    $default_file_scheme = $this->config('system.file')->get('default_scheme') ?? 'public';
+    $directory = $default_file_scheme . '://csv';
     $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
 
     // Create the file.

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -29,11 +29,11 @@ use Symfony\Component\Serializer\SerializerInterface;
 class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -106,7 +106,7 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
   protected $entities;
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, SerializerInterface $serializer, FileSystemInterface $file_system, ConfigFactoryInterface $config_factory, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator, AccountInterface $user) {
-    $this->tempStore = $temp_store_factory->get('entity_csv_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
     $this->serializer = $serializer;
@@ -187,7 +187,7 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
 
     // If we don't have an entity type or list of entities, redirect.
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type_id);
-    $this->entities = $this->tempStore->get($this->user->id() . ':' . $entity_type_id);
+    $this->entities = $this->tempStoreFactory->get('entity_csv_confirm')->get($this->user->id() . ':' . $entity_type_id);
     if (empty($entity_type_id) || empty($this->entities)) {
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
@@ -359,7 +359,7 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
       '%filename' => $file->label(),
     ]));
 
-    $this->tempStore->delete($this->currentUser()->id() . ':' . $this->entityType->id());
+    $this->tempStoreFactory->get('entity_csv_confirm')->delete($this->currentUser()->id() . ':' . $this->entityType->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -28,62 +28,6 @@ use Symfony\Component\Serializer\SerializerInterface;
 class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity field manager.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
-  /**
-   * The serializer service.
-   *
-   * @var \Symfony\Component\Serializer\SerializerInterface
-   */
-  protected $serializer;
-
-  /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  /**
-   * The file repository service.
-   *
-   * @var \Drupal\file\FileRepositoryInterface
-   */
-  protected $fileRepository;
-
-  /**
-   * The file URL generator.
-   *
-   * @var \Drupal\Core\File\FileUrlGeneratorInterface
-   */
-  protected $fileUrlGenerator;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface
@@ -97,16 +41,16 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
    */
   protected $entities;
 
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, SerializerInterface $serializer, FileSystemInterface $file_system, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator, AccountInterface $user) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityFieldManager = $entity_field_manager;
-    $this->serializer = $serializer;
-    $this->fileSystem = $file_system;
-    $this->fileRepository = $file_repository;
-    $this->fileUrlGenerator = $file_url_generator;
-    $this->user = $user;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected SerializerInterface $serializer,
+    protected FileSystemInterface $fileSystem,
+    protected FileRepositoryInterface $fileRepository,
+    protected FileUrlGeneratorInterface $fileUrlGenerator,
+    protected AccountInterface $user,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -298,7 +242,7 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
 
       // CSV encoder settings.
       'csv_settings' => [
-        'sanitize' => $form_state->getValue('sanitize'),
+        'sanitize' => (bool) $form_state->getValue('sanitize'),
         'strip_tags' => FALSE,
       ],
     ];

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -105,28 +105,6 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
    */
   protected $entities;
 
-  /**
-   * Constructs an EntityCsvActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager.
-   * @param \Symfony\Component\Serializer\SerializerInterface $serializer
-   *   The serializer service.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The file system service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   * @param \Drupal\file\FileRepositoryInterface $file_repository
-   *   The file repository service.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
-   *   The file URL generator.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, SerializerInterface $serializer, FileSystemInterface $file_system, ConfigFactoryInterface $config_factory, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator, AccountInterface $user) {
     $this->tempStore = $temp_store_factory->get('entity_csv_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityCsv extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class EntityCsv extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->tempStore = $temp_store_factory->get('entity_csv_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->currentUser = $current_user;
   }
 
@@ -62,7 +62,7 @@ class EntityCsv extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id() . ':' . $this->getPluginDefinition()['type'], $entities);
+    $this->tempStoreFactory->get('entity_csv_confirm')->set($this->currentUser->id() . ':' . $this->getPluginDefinition()['type'], $entities);
   }
 
   /**

--- a/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
@@ -23,24 +23,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class EntityCsv extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->currentUser = $current_user;
   }
 
   /**

--- a/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
@@ -37,22 +37,6 @@ class EntityCsv extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new EntityCsv object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $this->tempStore = $temp_store_factory->get('entity_csv_confirm');

--- a/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
@@ -23,24 +23,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class LogQuantityCsv extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->currentUser = $current_user;
   }
 
   /**

--- a/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
@@ -37,22 +37,6 @@ class LogQuantityCsv extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new LogQuantityCsv object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $this->tempStore = $temp_store_factory->get('entity_csv_confirm');

--- a/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LogQuantityCsv extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class LogQuantityCsv extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->tempStore = $temp_store_factory->get('entity_csv_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->currentUser = $current_user;
   }
 
@@ -66,7 +66,7 @@ class LogQuantityCsv extends EntityActionBase {
       return $carry;
     }, []);
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id() . ':quantity', $quantities);
+    $this->tempStoreFactory->get('entity_csv_confirm')->set($this->currentUser->id() . ':quantity', $quantities);
   }
 
   /**

--- a/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
+++ b/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
@@ -62,28 +62,6 @@ class EntityKml extends EntityActionBase {
    */
   protected $fileUrlGenerator;
 
-  /**
-   * Constructs a new EntityKml object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Symfony\Component\Serializer\SerializerInterface $serializer
-   *   The serializer service.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The file system service.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   * @param \Drupal\file\FileRepositoryInterface $file_repository
-   *   The file repository service.
-   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
-   *   The file URL generator.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, SerializerInterface $serializer, FileSystemInterface $file_system, ConfigFactoryInterface $config_factory, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $this->serializer = $serializer;

--- a/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
+++ b/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
@@ -42,11 +42,11 @@ class EntityKml extends EntityActionBase {
   protected $fileSystem;
 
   /**
-   * The default file scheme.
+   * The config factory.
    *
-   * @var string
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
    */
-  protected $defaultFileScheme;
+  protected $configFactory;
 
   /**
    * The file repository service.
@@ -66,7 +66,7 @@ class EntityKml extends EntityActionBase {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $this->serializer = $serializer;
     $this->fileSystem = $file_system;
-    $this->defaultFileScheme = $config_factory->get('system.file')->get('default_scheme') ?? 'public';
+    $this->configFactory = $config_factory;
     $this->fileRepository = $file_repository;
     $this->fileUrlGenerator = $file_url_generator;
   }
@@ -110,7 +110,8 @@ class EntityKml extends EntityActionBase {
     }
 
     // Prepare the file directory.
-    $directory = $this->defaultFileScheme . '://kml';
+    $default_file_scheme = $this->configFactory->get('system.file')->get('default_scheme') ?? 'public';
+    $directory = $default_file_scheme . '://kml';
     $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
 
     // Create the file.

--- a/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
+++ b/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
@@ -27,48 +27,18 @@ use Symfony\Component\Serializer\SerializerInterface;
 )]
 class EntityKml extends EntityActionBase {
 
-  /**
-   * The serializer service.
-   *
-   * @var \Symfony\Component\Serializer\SerializerInterface
-   */
-  protected $serializer;
-
-  /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  /**
-   * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
-   * The file repository service.
-   *
-   * @var \Drupal\file\FileRepositoryInterface
-   */
-  protected $fileRepository;
-
-  /**
-   * The file URL generator.
-   *
-   * @var \Drupal\Core\File\FileUrlGeneratorInterface
-   */
-  protected $fileUrlGenerator;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, SerializerInterface $serializer, FileSystemInterface $file_system, ConfigFactoryInterface $config_factory, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected SerializerInterface $serializer,
+    protected FileSystemInterface $fileSystem,
+    protected ConfigFactoryInterface $configFactory,
+    protected FileRepositoryInterface $fileRepository,
+    protected FileUrlGeneratorInterface $fileUrlGenerator,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->serializer = $serializer;
-    $this->fileSystem = $file_system;
-    $this->configFactory = $config_factory;
-    $this->fileRepository = $file_repository;
-    $this->fileUrlGenerator = $file_url_generator;
   }
 
   /**

--- a/modules/core/fieldkit/src/Controller/FieldModuleController.php
+++ b/modules/core/fieldkit/src/Controller/FieldModuleController.php
@@ -16,16 +16,9 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
  */
 class FieldModuleController extends ControllerBase {
 
-  /**
-   * The library discovery service.
-   *
-   * @var \Drupal\Core\Asset\LibraryDiscoveryInterface
-   */
-  protected $libraryDiscovery;
-
-  public function __construct(LibraryDiscoveryInterface $library_discovery) {
-    $this->libraryDiscovery = $library_discovery;
-  }
+  public function __construct(
+    protected LibraryDiscoveryInterface $libraryDiscovery,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/fieldkit/src/Controller/FieldModuleController.php
+++ b/modules/core/fieldkit/src/Controller/FieldModuleController.php
@@ -23,12 +23,6 @@ class FieldModuleController extends ControllerBase {
    */
   protected $libraryDiscovery;
 
-  /**
-   * FieldModuleController constructor.
-   *
-   * @param \Drupal\Core\Asset\LibraryDiscoveryInterface $library_discovery
-   *   The library discovery service.
-   */
   public function __construct(LibraryDiscoveryInterface $library_discovery) {
     $this->libraryDiscovery = $library_discovery;
   }

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -23,34 +23,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class EntityFlagActionForm extends ConfirmFormBase {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity field manager.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface
@@ -71,12 +43,12 @@ class EntityFlagActionForm extends ConfirmFormBase {
    */
   protected $flagFieldName = 'flag';
 
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, AccountInterface $user) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityFieldManager = $entity_field_manager;
-    $this->user = $user;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected AccountInterface $user,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -71,18 +71,6 @@ class EntityFlagActionForm extends ConfirmFormBase {
    */
   protected $flagFieldName = 'flag';
 
-  /**
-   * Constructs an EntityFlagActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, AccountInterface $user) {
     $this->tempStore = $temp_store_factory->get('entity_flag_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -23,11 +23,11 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class EntityFlagActionForm extends ConfirmFormBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -72,7 +72,7 @@ class EntityFlagActionForm extends ConfirmFormBase {
   protected $flagFieldName = 'flag';
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, AccountInterface $user) {
-    $this->tempStore = $temp_store_factory->get('entity_flag_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;
     $this->user = $user;
@@ -134,7 +134,7 @@ class EntityFlagActionForm extends ConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL): array|RedirectResponse {
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type_id);
-    $this->entities = $this->tempStore->get($this->user->id() . ':' . $entity_type_id);
+    $this->entities = $this->tempStoreFactory->get('entity_flag_confirm')->get($this->user->id() . ':' . $entity_type_id);
     if (empty($entity_type_id) || empty($this->entities)) {
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
@@ -248,7 +248,7 @@ class EntityFlagActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete($this->currentUser()->id() . ':' . $this->entityType->id());
+    $this->tempStoreFactory->get('entity_flag_confirm')->delete($this->currentUser()->id() . ':' . $this->entityType->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/core/flag/src/Plugin/Action/EntityFlag.php
+++ b/modules/core/flag/src/Plugin/Action/EntityFlag.php
@@ -37,22 +37,6 @@ class EntityFlag extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new EntityFlag object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
     $this->tempStore = $temp_store_factory->get('entity_flag_confirm');

--- a/modules/core/flag/src/Plugin/Action/EntityFlag.php
+++ b/modules/core/flag/src/Plugin/Action/EntityFlag.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityFlag extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class EntityFlag extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('entity_flag_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
 
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
@@ -63,7 +63,7 @@ class EntityFlag extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id() . ':' . $this->getPluginDefinition()['type'], $entities);
+    $this->tempStoreFactory->get('entity_flag_confirm')->set($this->currentUser->id() . ':' . $this->getPluginDefinition()['type'], $entities);
   }
 
   /**

--- a/modules/core/flag/src/Plugin/Action/EntityFlag.php
+++ b/modules/core/flag/src/Plugin/Action/EntityFlag.php
@@ -23,24 +23,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class EntityFlag extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
-
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 

--- a/modules/core/geo/src/GeometryWrapper.php
+++ b/modules/core/geo/src/GeometryWrapper.php
@@ -14,25 +14,9 @@ namespace Drupal\farm_geo;
  */
 class GeometryWrapper {
 
-  /**
-   * The geometry to wrap.
-   *
-   * @var \Geometry
-   *   The GeoPHP Geometry object.
-   */
-  public \Geometry $geometry;
-
-  /**
-   * Properties associated with the geometry.
-   *
-   * @var array
-   *   Associative array of property values.
-   */
-  public array $properties;
-
-  public function __construct(\Geometry $geometry, array $properties = []) {
-    $this->geometry = $geometry;
-    $this->properties = $properties;
-  }
+  public function __construct(
+    public \Geometry $geometry,
+    public array $properties = [],
+  ) {}
 
 }

--- a/modules/core/geo/src/GeometryWrapper.php
+++ b/modules/core/geo/src/GeometryWrapper.php
@@ -30,14 +30,6 @@ class GeometryWrapper {
    */
   public array $properties;
 
-  /**
-   * GeometryWrapper constructor.
-   *
-   * @param \Geometry $geometry
-   *   The GeoPHP geometry object.
-   * @param array $properties
-   *   Associative array of property values.
-   */
   public function __construct(\Geometry $geometry, array $properties = []) {
     $this->geometry = $geometry;
     $this->properties = $properties;

--- a/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
+++ b/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
@@ -24,16 +24,9 @@ class ContentEntityGeometryNormalizer implements NormalizerInterface, Serializer
 
   use SerializerAwareTrait;
 
-  /**
-   * The GeoPHP service.
-   *
-   * @var \Drupal\geofield\GeoPHP\GeoPHPInterface
-   */
-  protected $geoPHP;
-
-  public function __construct(GeoPHPInterface $geo_PHP) {
-    $this->geoPHP = $geo_PHP;
-  }
+  public function __construct(
+    protected GeoPHPInterface $geoPHP,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
+++ b/modules/core/geo/src/Normalizer/ContentEntityGeometryNormalizer.php
@@ -31,12 +31,6 @@ class ContentEntityGeometryNormalizer implements NormalizerInterface, Serializer
    */
   protected $geoPHP;
 
-  /**
-   * ContentEntityGeometryNormalizer constructor.
-   *
-   * @param \Drupal\geofield\GeoPHP\GeoPHPInterface $geo_PHP
-   *   The GeoPHP service.
-   */
   public function __construct(GeoPHPInterface $geo_PHP) {
     $this->geoPHP = $geo_PHP;
   }

--- a/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
@@ -22,16 +22,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class IdTagFormatter extends FormatterBase {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    $label,
+    $view_mode,
+    array $third_party_settings,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
@@ -29,26 +29,6 @@ class IdTagFormatter extends FormatterBase {
    */
   protected $tagTypeStorage;
 
-  /**
-   * Constructs an IdTagFormatter object.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The formatter settings.
-   * @param string $label
-   *   The formatter label display setting.
-   * @param string $view_mode
-   *   The view mode.
-   * @param array $third_party_settings
-   *   Any third party settings.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
     $this->tagTypeStorage = $entity_type_manager->getStorage('tag_type');

--- a/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
@@ -23,15 +23,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class IdTagFormatter extends FormatterBase {
 
   /**
-   * The tag_type entity storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $tagTypeStorage;
+  protected $entityTypeManager;
 
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-    $this->tagTypeStorage = $entity_type_manager->getStorage('tag_type');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -66,7 +66,8 @@ class IdTagFormatter extends FormatterBase {
       }
 
       // Render the type if it exists. Use the tag_type label.
-      if (!empty($item->type) && $tag_type = $this->tagTypeStorage->load($item->type)) {
+      $tag_type_storage = $this->entityTypeManager->getStorage('tag_type');
+      if (!empty($item->type) && $tag_type = $tag_type_storage->load($item->type)) {
         $elements[$delta]['type'] = [
           '#markup' => $this->t('Type: @value', ['@value' => $tag_type->label()]),
         ];

--- a/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
+++ b/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
@@ -30,20 +30,6 @@ class AutoOrientImageEffect extends ImageEffectBase implements ContainerFactoryP
    */
   protected $fileSystem;
 
-  /**
-   * AutoOrientImageEffect constructor.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param array $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Psr\Log\LoggerInterface $logger
-   *   A logger instance.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The file system service.
-   */
   public function __construct(array $configuration, string $plugin_id, array $plugin_definition, LoggerInterface $logger, FileSystemInterface $file_system) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $logger);
     $this->fileSystem = $file_system;

--- a/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
+++ b/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
@@ -23,16 +23,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class AutoOrientImageEffect extends ImageEffectBase implements ContainerFactoryPluginInterface {
 
-  /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, LoggerInterface $logger, FileSystemInterface $file_system) {
+  public function __construct(
+    array $configuration,
+    string $plugin_id,
+    array $plugin_definition,
+    LoggerInterface $logger,
+    protected FileSystemInterface $fileSystem,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $logger);
-    $this->fileSystem = $file_system;
   }
 
   /**

--- a/modules/core/import/modules/csv/src/Access/CsvImportMigrationAccess.php
+++ b/modules/core/import/modules/csv/src/Access/CsvImportMigrationAccess.php
@@ -7,23 +7,16 @@ namespace Drupal\farm_import_csv\Access;
 use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\migrate\Plugin\MigrationPluginManager;
+use Drupal\migrate\Plugin\MigrationPluginManagerInterface;
 
 /**
  * Access checking logic for CSV importers.
  */
 class CsvImportMigrationAccess {
 
-  /**
-   * The migration plugin manager.
-   *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManager
-   */
-  protected $pluginManagerMigration;
-
-  public function __construct(MigrationPluginManager $plugin_manager_migration) {
-    $this->pluginManagerMigration = $plugin_manager_migration;
-  }
+  public function __construct(
+    protected MigrationPluginManagerInterface $pluginManagerMigration,
+  ) {}
 
   /**
    * Checks access to a migration.

--- a/modules/core/import/modules/csv/src/Access/CsvImportMigrationAccess.php
+++ b/modules/core/import/modules/csv/src/Access/CsvImportMigrationAccess.php
@@ -21,12 +21,6 @@ class CsvImportMigrationAccess {
    */
   protected $pluginManagerMigration;
 
-  /**
-   * MigrateSourceUiForm constructor.
-   *
-   * @param \Drupal\migrate\Plugin\MigrationPluginManager $plugin_manager_migration
-   *   The migration plugin manager.
-   */
   public function __construct(MigrationPluginManager $plugin_manager_migration) {
     $this->pluginManagerMigration = $plugin_manager_migration;
   }

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -63,20 +63,6 @@ class CsvImportController extends ControllerBase {
    */
   protected $database;
 
-  /**
-   * Constructs a new CsvImportController.
-   *
-   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_link_tree
-   *   The menu link tree service.
-   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
-   *   The form builder.
-   * @param \Drupal\migrate\Plugin\MigrationPluginManager $plugin_manager_migration
-   *   The migration plugin manager.
-   * @param \Drupal\farm_import_csv\Access\CsvImportMigrationAccess $migration_access
-   *   The CSV import migration access service.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database connection.
-   */
   public function __construct(MenuLinkTreeInterface $menu_link_tree, FormBuilderInterface $form_builder, MigrationPluginManager $plugin_manager_migration, CsvImportMigrationAccess $migration_access, Connection $database) {
     $this->menuLinkTree = $menu_link_tree;
     $this->formBuilder = $form_builder;

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -8,7 +8,6 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
-use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
@@ -50,22 +49,14 @@ class CsvImportController extends ControllerBase {
   protected $migrationAccess;
 
   /**
-   * The form builder.
-   *
-   * @var \Drupal\Core\Form\FormBuilderInterface
-   */
-  protected $formBuilder;
-
-  /**
    * The database connection.
    *
    * @var \Drupal\Core\Database\Connection
    */
   protected $database;
 
-  public function __construct(MenuLinkTreeInterface $menu_link_tree, FormBuilderInterface $form_builder, MigrationPluginManager $plugin_manager_migration, CsvImportMigrationAccess $migration_access, Connection $database) {
+  public function __construct(MenuLinkTreeInterface $menu_link_tree, MigrationPluginManager $plugin_manager_migration, CsvImportMigrationAccess $migration_access, Connection $database) {
     $this->menuLinkTree = $menu_link_tree;
-    $this->formBuilder = $form_builder;
     $this->pluginManagerMigration = $plugin_manager_migration;
     $this->migrationAccess = $migration_access;
     $this->database = $database;
@@ -77,7 +68,6 @@ class CsvImportController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('menu.link_tree'),
-      $container->get('form_builder'),
       $container->get('plugin.manager.migration'),
       $container->get('farm_import_csv.access'),
       $container->get('database'),
@@ -218,7 +208,7 @@ class CsvImportController extends ControllerBase {
     }
 
     // Add the importer form.
-    $build['form'] = $this->formBuilder->getForm('Drupal\farm_import_csv\Form\CsvImportForm', $migration_id);
+    $build['form'] = $this->formBuilder()->getForm('Drupal\farm_import_csv\Form\CsvImportForm', $migration_id);
 
     // If entities have been created by this importer, display a View of them.
     if ($this->database->select('farm_import_csv_entity', 'e')->condition('e.migration', $migration_id)->countQuery()->execute()->fetchField()) {

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -27,40 +27,12 @@ class CsvImportController extends ControllerBase {
 
   use StringTranslationTrait;
 
-  /**
-   * The menu link tree service.
-   *
-   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
-   */
-  protected $menuLinkTree;
-
-  /**
-   * The migration plugin manager.
-   *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManager
-   */
-  protected $pluginManagerMigration;
-
-  /**
-   * The CSV import migration access service.
-   *
-   * @var \Drupal\farm_import_csv\Access\CsvImportMigrationAccess
-   */
-  protected $migrationAccess;
-
-  /**
-   * The database connection.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected $database;
-
-  public function __construct(MenuLinkTreeInterface $menu_link_tree, MigrationPluginManager $plugin_manager_migration, CsvImportMigrationAccess $migration_access, Connection $database) {
-    $this->menuLinkTree = $menu_link_tree;
-    $this->pluginManagerMigration = $plugin_manager_migration;
-    $this->migrationAccess = $migration_access;
-    $this->database = $database;
-  }
+  public function __construct(
+    protected MenuLinkTreeInterface $menuLinkTree,
+    protected MigrationPluginManager $pluginManagerMigration,
+    protected CsvImportMigrationAccess $migrationAccess,
+    protected Connection $database,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationConfigSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationConfigSubscriber.php
@@ -21,12 +21,6 @@ class CsvMigrationConfigSubscriber implements EventSubscriberInterface {
    */
   protected $routerBuilder;
 
-  /**
-   * Constructs the CsvMigrationConfigSubscriber.
-   *
-   * @param \Drupal\Core\Routing\RouteBuilderInterface $router_builder
-   *   The router builder service.
-   */
   public function __construct(RouteBuilderInterface $router_builder) {
     $this->routerBuilder = $router_builder;
   }

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationConfigSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationConfigSubscriber.php
@@ -14,16 +14,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class CsvMigrationConfigSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The router builder.
-   *
-   * @var \Drupal\Core\Routing\RouteBuilderInterface
-   */
-  protected $routerBuilder;
-
-  public function __construct(RouteBuilderInterface $router_builder) {
-    $this->routerBuilder = $router_builder;
-  }
+  public function __construct(
+    protected RouteBuilderInterface $routeBuilder,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -43,7 +36,7 @@ class CsvMigrationConfigSubscriber implements EventSubscriberInterface {
   public function rebuildRouter(ConfigCrudEvent $event) {
     $config = $event->getConfig();
     if (str_starts_with($config->getName(), 'migrate_plus.migration.')) {
-      $this->routerBuilder->setRebuildNeeded();
+      $this->routeBuilder->setRebuildNeeded();
     }
   }
 

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
@@ -49,18 +49,6 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
    */
   protected $messenger;
 
-  /**
-   * CsvMigrationSubscriber constructor.
-   *
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database connection.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   The current user.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore service.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger.
-   */
   public function __construct(Connection $database, AccountInterface $current_user, PrivateTempStoreFactory $temp_store_factory, MessengerInterface $messenger) {
     $this->database = $database;
     $this->currentUser = $current_user;

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
@@ -36,11 +36,11 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
   protected $currentUser;
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The messenger.
@@ -52,7 +52,7 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
   public function __construct(Connection $database, AccountInterface $current_user, PrivateTempStoreFactory $temp_store_factory, MessengerInterface $messenger) {
     $this->database = $database;
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('farm_import_csv');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->messenger = $messenger;
   }
 
@@ -117,7 +117,7 @@ class CsvMigrationSubscriber implements EventSubscriberInterface {
     // Load the file ID from temporary storage (set during CSV upload form
     // submit), and show any messages associated with it.
     $tempstore_key = $this->currentUser->id() . ':' . $event->getMigration()->id();
-    $file_id = $this->tempStore->get($tempstore_key);
+    $file_id = $this->tempStoreFactory->get('farm_import_csv')->get($tempstore_key);
     if (!is_null($file_id)) {
 
       // Query the migrate_map_* table, if it exists.

--- a/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
+++ b/modules/core/import/modules/csv/src/EventSubscriber/CsvMigrationSubscriber.php
@@ -19,42 +19,15 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * Subscribe to migration events.
  */
 class CsvMigrationSubscriber implements EventSubscriberInterface {
+
   use StringTranslationTrait;
 
-  /**
-   * The database connection.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected $database;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The messenger.
-   *
-   * @var \Drupal\Core\Messenger\MessengerInterface
-   */
-  protected $messenger;
-
-  public function __construct(Connection $database, AccountInterface $current_user, PrivateTempStoreFactory $temp_store_factory, MessengerInterface $messenger) {
-    $this->database = $database;
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->messenger = $messenger;
-  }
+  public function __construct(
+    protected Connection $database,
+    protected AccountInterface $currentUser,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected MessengerInterface $messenger,
+  ) {}
 
   /**
    * Get subscribed events.

--- a/modules/core/import/modules/csv/src/Form/CsvImportForm.php
+++ b/modules/core/import/modules/csv/src/Form/CsvImportForm.php
@@ -24,64 +24,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class CsvImportForm extends FormBase {
 
-  /**
-   * The migration plugin manager.
-   *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManager
-   */
-  protected MigrationPluginManager $migrationPluginManager;
-
-  /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected FileSystemInterface $fileSystem;
-
-  /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected TimeInterface $time;
-
-  /**
-   * The key-value factory.
-   *
-   * @var \Drupal\Core\KeyValueStore\KeyValueFactoryInterface
-   */
-  protected KeyValueFactoryInterface $keyValueFactory;
-
-  /**
-   * The translation manager.
-   *
-   * @var \Drupal\Core\StringTranslation\TranslationManager
-   */
-  protected TranslationManager $translationManager;
-
-  /**
-   * The file usage service.
-   *
-   * @var \Drupal\file\FileUsage\FileUsageInterface
-   */
-  protected $fileUsage;
-
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  public function __construct(MigrationPluginManager $plugin_manager_migration, FileSystemInterface $file_system, TimeInterface $time, KeyValueFactoryInterface $key_value, TranslationManager $translation_manager, FileUsageInterface $file_usage, PrivateTempStoreFactory $temp_store_factory) {
-    $this->migrationPluginManager = $plugin_manager_migration;
-    $this->fileSystem = $file_system;
-    $this->time = $time;
-    $this->keyValueFactory = $key_value;
-    $this->translationManager = $translation_manager;
-    $this->fileUsage = $file_usage;
-    $this->tempStoreFactory = $temp_store_factory;
-  }
+  public function __construct(
+    protected MigrationPluginManager $migrationPluginManager,
+    protected FileSystemInterface $fileSystem,
+    protected TimeInterface $time,
+    protected KeyValueFactoryInterface $keyValueFactory,
+    protected TranslationManager $translationManager,
+    protected FileUsageInterface $fileUsage,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/modules/csv/src/Form/CsvImportForm.php
+++ b/modules/core/import/modules/csv/src/Form/CsvImportForm.php
@@ -73,24 +73,6 @@ class CsvImportForm extends FormBase {
    */
   protected $tempStore;
 
-  /**
-   * CsvImportForm constructor.
-   *
-   * @param \Drupal\migrate\Plugin\MigrationPluginManager $plugin_manager_migration
-   *   The migration plugin manager.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The File System service.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value
-   *   The key value factory.
-   * @param \Drupal\Core\StringTranslation\TranslationManager $translation_manager
-   *   The translation manager service.
-   * @param \Drupal\file\FileUsage\FileUsageInterface $file_usage
-   *   The file usage service.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore service.
-   */
   public function __construct(MigrationPluginManager $plugin_manager_migration, FileSystemInterface $file_system, TimeInterface $time, KeyValueFactoryInterface $key_value, TranslationManager $translation_manager, FileUsageInterface $file_usage, PrivateTempStoreFactory $temp_store_factory) {
     $this->migrationPluginManager = $plugin_manager_migration;
     $this->fileSystem = $file_system;

--- a/modules/core/import/modules/csv/src/Form/CsvImportForm.php
+++ b/modules/core/import/modules/csv/src/Form/CsvImportForm.php
@@ -67,11 +67,11 @@ class CsvImportForm extends FormBase {
   protected $fileUsage;
 
   /**
-   * The farm_import_csv temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   public function __construct(MigrationPluginManager $plugin_manager_migration, FileSystemInterface $file_system, TimeInterface $time, KeyValueFactoryInterface $key_value, TranslationManager $translation_manager, FileUsageInterface $file_usage, PrivateTempStoreFactory $temp_store_factory) {
     $this->migrationPluginManager = $plugin_manager_migration;
@@ -80,7 +80,7 @@ class CsvImportForm extends FormBase {
     $this->keyValueFactory = $key_value;
     $this->translationManager = $translation_manager;
     $this->fileUsage = $file_usage;
-    $this->tempStore = $temp_store_factory->get('farm_import_csv');
+    $this->tempStoreFactory = $temp_store_factory;
   }
 
   /**
@@ -176,7 +176,7 @@ class CsvImportForm extends FormBase {
     $this->fileUsage->add($file, 'farm_import_csv', 'migration', $form_state->getValue('migration_id'));
 
     // Save the file ID to the private tempstore.
-    $this->tempStore->set($this->currentUser()->id() . ':' . $form_state->getValue('migration_id'), $file->id());
+    $this->tempStoreFactory->get('farm_import_csv')->set($this->currentUser()->id() . ':' . $form_state->getValue('migration_id'), $file->id());
   }
 
   /**

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMenuLink.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMenuLink.php
@@ -21,12 +21,6 @@ class CsvImportMenuLink extends DeriverBase implements ContainerDeriverInterface
    */
   protected MigrationPluginManagerInterface $migrationPluginManager;
 
-  /**
-   * CsvImportMenuLink constructor.
-   *
-   * @param \Drupal\migrate\Plugin\MigrationPluginManagerInterface $migration_plugin_manager
-   *   The migration plugin manager.
-   */
   public function __construct(MigrationPluginManagerInterface $migration_plugin_manager) {
     $this->migrationPluginManager = $migration_plugin_manager;
   }

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMenuLink.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMenuLink.php
@@ -14,16 +14,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class CsvImportMenuLink extends DeriverBase implements ContainerDeriverInterface {
 
-  /**
-   * The migration plugin manager.
-   *
-   * @var \Drupal\migrate\Plugin\MigrationPluginManagerInterface
-   */
-  protected MigrationPluginManagerInterface $migrationPluginManager;
-
-  public function __construct(MigrationPluginManagerInterface $migration_plugin_manager) {
-    $this->migrationPluginManager = $migration_plugin_manager;
-  }
+  public function __construct(
+    protected MigrationPluginManagerInterface $migrationPluginManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @internal
  */
 abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDeriverInterface {
+
   use StringTranslationTrait;
 
   /**
@@ -29,32 +30,11 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
    */
   protected string $entityType;
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity field manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, ModuleHandlerInterface $module_handler) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityFieldManager = $entity_field_manager;
-    $this->moduleHandler = $module_handler;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityFieldManagerInterface $entityFieldManager,
+    protected ModuleHandlerInterface $moduleHandler,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -50,16 +50,6 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
    */
   protected $moduleHandler;
 
-  /**
-   * CsvImportMigration constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager, ModuleHandlerInterface $module_handler) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityFieldManager = $entity_field_manager;

--- a/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
@@ -31,9 +31,6 @@ class CSVFile extends CSV implements ContainerFactoryPluginInterface {
    */
   protected $fileStorage;
 
-  /**
-   * {@inheritdoc}
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, EntityTypeManagerInterface $entity_type_manager) {
 
     // Uniqueness of rows will be determined by file ID + row number, so we

--- a/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
@@ -31,7 +31,13 @@ class CSVFile extends CSV implements ContainerFactoryPluginInterface {
    */
   protected $fileStorage;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    MigrationInterface $migration,
+    EntityTypeManagerInterface $entity_type_manager,
+  ) {
 
     // Uniqueness of rows will be determined by file ID + row number, so we
     // explicitly set create_record_number and ids in the source configuration

--- a/modules/core/import/modules/kml/src/Form/KmlImporter.php
+++ b/modules/core/import/modules/kml/src/Form/KmlImporter.php
@@ -44,16 +44,6 @@ class KmlImporter extends FormBase {
    */
   protected $fileSystem;
 
-  /**
-   * Constructs a new KmlImporter object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Symfony\Component\Serializer\SerializerInterface $serializer
-   *   The serializer service.
-   * @param \Drupal\Core\File\FileSystemInterface $file_system
-   *   The file system service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, SerializerInterface $serializer, FileSystemInterface $file_system) {
     $this->entityTypeManager = $entity_type_manager;
     $this->serializer = $serializer;

--- a/modules/core/import/modules/kml/src/Form/KmlImporter.php
+++ b/modules/core/import/modules/kml/src/Form/KmlImporter.php
@@ -23,32 +23,11 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class KmlImporter extends FormBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The serializer service.
-   *
-   * @var \Symfony\Component\Serializer\SerializerInterface
-   */
-  protected $serializer;
-
-  /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, SerializerInterface $serializer, FileSystemInterface $file_system) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->serializer = $serializer;
-    $this->fileSystem = $file_system;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected SerializerInterface $serializer,
+    protected FileSystemInterface $fileSystem,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/src/Controller/ImportController.php
+++ b/modules/core/import/src/Controller/ImportController.php
@@ -18,16 +18,9 @@ class ImportController extends ControllerBase {
 
   use StringTranslationTrait;
 
-  /**
-   * The menu link tree service.
-   *
-   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
-   */
-  protected $menuLinkTree;
-
-  public function __construct(MenuLinkTreeInterface $menu_link_tree) {
-    $this->menuLinkTree = $menu_link_tree;
-  }
+  public function __construct(
+    protected MenuLinkTreeInterface $menuLinkTree,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/src/Controller/ImportController.php
+++ b/modules/core/import/src/Controller/ImportController.php
@@ -25,12 +25,6 @@ class ImportController extends ControllerBase {
    */
   protected $menuLinkTree;
 
-  /**
-   * Constructs a new ImportController.
-   *
-   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_link_tree
-   *   The menu link tree service.
-   */
   public function __construct(MenuLinkTreeInterface $menu_link_tree) {
     $this->menuLinkTree = $menu_link_tree;
   }

--- a/modules/core/inventory/farm_inventory.services.yml
+++ b/modules/core/inventory/farm_inventory.services.yml
@@ -2,7 +2,7 @@ services:
   asset.inventory:
     class: Drupal\farm_inventory\AssetInventory
     arguments:
-      [ '@entity_type.manager', '@datetime.time' ]
+      [ '@database', '@entity_type.manager', '@datetime.time' ]
   farm_inventory.log_event_subscriber:
     class: Drupal\farm_inventory\EventSubscriber\LogEventSubscriber
     arguments:

--- a/modules/core/inventory/src/AssetInventory.php
+++ b/modules/core/inventory/src/AssetInventory.php
@@ -15,32 +15,11 @@ use Drupal\fraction\Fraction;
  */
 class AssetInventory implements AssetInventoryInterface {
 
-  /**
-   * The database object.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected $database;
-
-  /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  public function __construct(Connection $database, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
-    $this->database = $database;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->time = $time;
-  }
+  public function __construct(
+    protected Connection $database,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/inventory/src/AssetInventory.php
+++ b/modules/core/inventory/src/AssetInventory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_inventory;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Core\Database\Database;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\fraction\Fraction;
@@ -36,8 +36,8 @@ class AssetInventory implements AssetInventoryInterface {
    */
   protected EntityTypeManagerInterface $entityTypeManager;
 
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
-    $this->database = Database::getConnection();
+  public function __construct(Connection $database, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
+    $this->database = $database;
     $this->entityTypeManager = $entity_type_manager;
     $this->time = $time;
   }

--- a/modules/core/inventory/src/AssetInventory.php
+++ b/modules/core/inventory/src/AssetInventory.php
@@ -36,14 +36,6 @@ class AssetInventory implements AssetInventoryInterface {
    */
   protected EntityTypeManagerInterface $entityTypeManager;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, TimeInterface $time) {
     $this->database = Database::getConnection();
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
@@ -17,24 +17,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class LogEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * Cache tag invalidator service.
-   *
-   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
-   */
-  protected CacheTagsInvalidatorInterface $cacheTagsInvalidator;
-
-  /**
-   * Datetime time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator, TimeInterface $date_time) {
-    $this->time = $date_time;
-    $this->cacheTagsInvalidator = $cache_tags_invalidator;
-  }
+  public function __construct(
+    protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+    protected TimeInterface $time,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/inventory/src/EventSubscriber/LogEventSubscriber.php
@@ -31,14 +31,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   protected $time;
 
-  /**
-   * LogEventSubscriber Constructor.
-   *
-   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
-   *   Cache tag invalidator service.
-   * @param \Drupal\Component\Datetime\TimeInterface $date_time
-   *   Datetime time service.
-   */
   public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator, TimeInterface $date_time) {
     $this->time = $date_time;
     $this->cacheTagsInvalidator = $cache_tags_invalidator;

--- a/modules/core/kml/src/Normalizer/KmlNormalizer.php
+++ b/modules/core/kml/src/Normalizer/KmlNormalizer.php
@@ -26,16 +26,9 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
    */
   const TYPE = GeometryWrapper::class;
 
-  /**
-   * The GeoPHP service.
-   *
-   * @var \Drupal\geofield\GeoPHP\GeoPHPInterface
-   */
-  protected $geoPHP;
-
-  public function __construct(GeoPHPInterface $geo_PHP) {
-    $this->geoPHP = $geo_PHP;
-  }
+  public function __construct(
+    protected GeoPHPInterface $geoPHP,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/kml/src/Normalizer/KmlNormalizer.php
+++ b/modules/core/kml/src/Normalizer/KmlNormalizer.php
@@ -33,12 +33,6 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
    */
   protected $geoPHP;
 
-  /**
-   * KMLNormalizer constructor.
-   *
-   * @param \Drupal\geofield\GeoPHP\GeoPHPInterface $geo_PHP
-   *   The GeoPHP service.
-   */
   public function __construct(GeoPHPInterface $geo_PHP) {
     $this->geoPHP = $geo_PHP;
   }

--- a/modules/core/l10n/src/Form/L10nSettingsForm.php
+++ b/modules/core/l10n/src/Form/L10nSettingsForm.php
@@ -26,16 +26,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class L10nSettingsForm extends NegotiationSelectedForm {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(ConfigFactoryInterface $config_factory, protected TypedConfigManagerInterface $typedConfigManager, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    protected TypedConfigManagerInterface $typedConfigManager,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($config_factory, $typedConfigManager);
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/l10n/src/Form/L10nSettingsForm.php
+++ b/modules/core/l10n/src/Form/L10nSettingsForm.php
@@ -33,16 +33,6 @@ class L10nSettingsForm extends NegotiationSelectedForm {
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructor for L10nSettingsForm.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typedConfigManager
-   *   The typed config manager.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(ConfigFactoryInterface $config_factory, protected TypedConfigManagerInterface $typedConfigManager, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($config_factory, $typedConfigManager);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/location/src/AssetLocation.php
+++ b/modules/core/location/src/AssetLocation.php
@@ -72,20 +72,6 @@ class AssetLocation implements AssetLocationInterface {
    */
   protected $database;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\farm_location\LogLocationInterface $log_location
-   *   Log location service.
-   * @param \Drupal\farm_log\LogQueryFactoryInterface $log_query_factory
-   *   Log query factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   * @param \Drupal\Core\Database\Connection $database
-   *   The database service.
-   */
   public function __construct(LogLocationInterface $log_location, LogQueryFactoryInterface $log_query_factory, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time, Connection $database) {
     $this->logLocation = $log_location;
     $this->logQueryFactory = $log_query_factory;

--- a/modules/core/location/src/AssetLocation.php
+++ b/modules/core/location/src/AssetLocation.php
@@ -37,48 +37,13 @@ class AssetLocation implements AssetLocationInterface {
    */
   const ASSET_FIELD_FIXED = 'is_fixed';
 
-  /**
-   * Log location service.
-   *
-   * @var \Drupal\farm_location\LogLocationInterface
-   */
-  protected LogLocationInterface $logLocation;
-
-  /**
-   * Log query factory.
-   *
-   * @var \Drupal\farm_log\LogQueryFactoryInterface
-   */
-  protected LogQueryFactoryInterface $logQueryFactory;
-
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * The time service.
-   *
-   * @var \Drupal\Component\Datetime\TimeInterface
-   */
-  protected $time;
-
-  /**
-   * The database service.
-   *
-   * @var \Drupal\Core\Database\Connection
-   */
-  protected $database;
-
-  public function __construct(LogLocationInterface $log_location, LogQueryFactoryInterface $log_query_factory, EntityTypeManagerInterface $entity_type_manager, TimeInterface $time, Connection $database) {
-    $this->logLocation = $log_location;
-    $this->logQueryFactory = $log_query_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->time = $time;
-    $this->database = $database;
-  }
+  public function __construct(
+    protected LogLocationInterface $logLocation,
+    protected LogQueryFactoryInterface $logQueryFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected TimeInterface $time,
+    protected Connection $database,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
@@ -26,32 +26,11 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   const LOG_FIELD_ASSET = 'asset';
 
-  /**
-   * Log location service.
-   *
-   * @var \Drupal\farm_location\LogLocationInterface
-   */
-  protected LogLocationInterface $logLocation;
-
-  /**
-   * Asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected AssetLocationInterface $assetLocation;
-
-  /**
-   * Cache tag invalidator service.
-   *
-   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
-   */
-  protected CacheTagsInvalidatorInterface $cacheTagsInvalidator;
-
-  public function __construct(LogLocationInterface $log_location, AssetLocationInterface $asset_locaiton, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
-    $this->logLocation = $log_location;
-    $this->assetLocation = $asset_locaiton;
-    $this->cacheTagsInvalidator = $cache_tags_invalidator;
-  }
+  public function __construct(
+    protected LogLocationInterface $logLocation,
+    protected AssetLocationInterface $assetLocation,
+    protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/location/src/EventSubscriber/LogEventSubscriber.php
@@ -47,16 +47,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   protected CacheTagsInvalidatorInterface $cacheTagsInvalidator;
 
-  /**
-   * LogEventSubscriber Constructor.
-   *
-   * @param \Drupal\farm_location\LogLocationInterface $log_location
-   *   Log location service.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_locaiton
-   *   Asset location service.
-   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
-   *   Cache tag invalidator service.
-   */
   public function __construct(LogLocationInterface $log_location, AssetLocationInterface $asset_locaiton, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
     $this->logLocation = $log_location;
     $this->assetLocation = $asset_locaiton;

--- a/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
+++ b/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
@@ -23,12 +23,6 @@ class CircularAssetLocationConstraintValidator extends ConstraintValidator imple
    */
   protected $assetLocation;
 
-  /**
-   * CircularAssetLocationConstraintValidator constructor.
-   *
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   Asset location service.
-   */
   public function __construct(AssetLocationInterface $asset_location) {
     $this->assetLocation = $asset_location;
   }

--- a/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
+++ b/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
@@ -16,16 +16,9 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class CircularAssetLocationConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
-  /**
-   * Asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(AssetLocationInterface $asset_location) {
-    $this->assetLocation = $asset_location;
-  }
+  public function __construct(
+    protected AssetLocationInterface $assetLocation,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/location/src/Plugin/views/argument/AssetLocation.php
+++ b/modules/core/location/src/Plugin/views/argument/AssetLocation.php
@@ -19,24 +19,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[ViewsArgument("asset_location")]
 class AssetLocation extends ArgumentPluginBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AssetLocationInterface $assetLocation,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->assetLocation = $asset_location;
   }
 
   /**

--- a/modules/core/location/src/Plugin/views/argument/AssetLocation.php
+++ b/modules/core/location/src/Plugin/views/argument/AssetLocation.php
@@ -33,20 +33,6 @@ class AssetLocation extends ArgumentPluginBase {
    */
   protected $assetLocation;
 
-  /**
-   * Constructs an AssetLocation object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   The asset location service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
+++ b/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
@@ -17,16 +17,9 @@ class LogQuantityEventSubscriber implements EventSubscriberInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
+++ b/modules/core/log/modules/quantity/src/EventSubscriber/LogQuantityEventSubscriber.php
@@ -24,9 +24,6 @@ class LogQuantityEventSubscriber implements EventSubscriberInterface {
    */
   protected EntityTypeManagerInterface $entityTypeManager;
 
-  /**
-   * {@inheritdoc}
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/core/log/src/AssetLogs.php
+++ b/modules/core/log/src/AssetLogs.php
@@ -26,14 +26,6 @@ class AssetLogs implements AssetLogsInterface {
    */
   protected LogQueryFactoryInterface $logQueryFactory;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   * @param \Drupal\farm_log\LogQueryFactoryInterface $log_query_factory
-   *   Log query factory.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LogQueryFactoryInterface $log_query_factory) {
     $this->entityTypeManager = $entity_type_manager;
     $this->logQueryFactory = $log_query_factory;

--- a/modules/core/log/src/AssetLogs.php
+++ b/modules/core/log/src/AssetLogs.php
@@ -12,24 +12,10 @@ use Drupal\asset\Entity\AssetInterface;
  */
 class AssetLogs implements AssetLogsInterface {
 
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  /**
-   * Log query factory.
-   *
-   * @var \Drupal\farm_log\LogQueryFactoryInterface
-   */
-  protected LogQueryFactoryInterface $logQueryFactory;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LogQueryFactoryInterface $log_query_factory) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->logQueryFactory = $log_query_factory;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected LogQueryFactoryInterface $logQueryFactory,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -19,11 +19,11 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class AssetAddLogActionForm extends ConfirmFormBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -54,7 +54,7 @@ class AssetAddLogActionForm extends ConfirmFormBase {
   protected $entities;
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user) {
-    $this->tempStore = $temp_store_factory->get('asset_add_log_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->user = $user;
   }
@@ -111,7 +111,7 @@ class AssetAddLogActionForm extends ConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
     $this->entityType = $this->entityTypeManager->getDefinition('asset', FALSE);
-    $this->entities = $this->tempStore->get((string) $this->user->id());
+    $this->entities = $this->tempStoreFactory->get('asset_add_log_confirm')->get((string) $this->user->id());
     if (!$this->entityType || empty($this->entities)) {
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
@@ -190,7 +190,7 @@ class AssetAddLogActionForm extends ConfirmFormBase {
       }
     }
 
-    $this->tempStore->delete((string) $this->currentUser()->id());
+    $this->tempStoreFactory->get('asset_add_log_confirm')->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($redirect_url);
   }
 

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -19,27 +19,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class AssetAddLogActionForm extends ConfirmFormBase {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface|null
@@ -53,11 +32,11 @@ class AssetAddLogActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->user = $user;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountInterface $user,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -53,16 +53,6 @@ class AssetAddLogActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  /**
-   * Constructs an AssetAddLogActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user) {
     $this->tempStore = $temp_store_factory->get('asset_add_log_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/log/src/LogQueryFactory.php
+++ b/modules/core/log/src/LogQueryFactory.php
@@ -21,12 +21,6 @@ class LogQueryFactory implements LogQueryFactoryInterface {
    */
   protected EntityTypeManagerInterface $entityTypeManager;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   Entity type manager.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/core/log/src/LogQueryFactory.php
+++ b/modules/core/log/src/LogQueryFactory.php
@@ -14,16 +14,9 @@ use Drupal\Core\Entity\Query\QueryInterface;
  */
 class LogQueryFactory implements LogQueryFactoryInterface {
 
-  /**
-   * Entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected EntityTypeManagerInterface $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -37,22 +37,6 @@ class AssetAddLog extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new AssetAddLog object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
     $this->tempStore = $temp_store_factory->get('asset_add_log_confirm');

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -23,24 +23,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class AssetAddLog extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
-
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AssetAddLog extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class AssetAddLog extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('asset_add_log_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
 
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
@@ -63,7 +63,7 @@ class AssetAddLog extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set((string) $this->currentUser->id(), $entities);
+    $this->tempStoreFactory->get('asset_add_log_confirm')->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/core/map/modules/mapbox/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/modules/mapbox/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -15,16 +15,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class MapRenderEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The config factory service.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  private $configFactory;
-
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->configFactory = $config_factory;
-  }
+  public function __construct(
+    private ConfigFactoryInterface $configFactory,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/map/modules/mapbox/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/modules/mapbox/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -22,12 +22,6 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   private $configFactory;
 
-  /**
-   * Constructor.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   */
   public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;
   }

--- a/modules/core/map/src/Element/FarmMap.php
+++ b/modules/core/map/src/Element/FarmMap.php
@@ -40,8 +40,8 @@ class FarmMap extends RenderElementBase {
    *   appended to 'farm-map-' as the map element ID if one has not already
    *   been provided.
    *
-   * @return \Drupal\farm_map\Element\FarmMap
-   *   The farm map render element.
+   * @return array
+   *   The farm map render element build array.
    *
    * @see \Drupal\farm_map\Event\MapRenderEvent
    */

--- a/modules/core/map/src/Event/MapRenderEvent.php
+++ b/modules/core/map/src/Event/MapRenderEvent.php
@@ -17,32 +17,11 @@ class MapRenderEvent extends Event {
 
   const EVENT_NAME = 'map_render_event';
 
-  /**
-   * The farm_map render element or render array.
-   *
-   * @var \Drupal\farm_map\Element\FarmMap|array
-   */
-  public $element;
-
-  /**
-   * The map type config entity.
-   *
-   * @var \Drupal\farm_map\Entity\MapTypeInterface
-   */
-  private $mapType;
-
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(MapTypeInterface $map_type, array $element, EntityTypeManagerInterface $entity_type_manager) {
-    $this->element = $element;
-    $this->mapType = $map_type;
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    private MapTypeInterface $mapType,
+    public array $element,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * Getter method to get the map target ID.

--- a/modules/core/map/src/Event/MapRenderEvent.php
+++ b/modules/core/map/src/Event/MapRenderEvent.php
@@ -38,16 +38,6 @@ class MapRenderEvent extends Event {
    */
   protected $entityTypeManager;
 
-  /**
-   * MapRenderEvent constructor.
-   *
-   * @param \Drupal\farm_map\Entity\MapTypeInterface $map_type
-   *   The farm_map render element.
-   * @param array $element
-   *   The farm_map render array.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(MapTypeInterface $map_type, array $element, EntityTypeManagerInterface $entity_type_manager) {
     $this->element = $element;
     $this->mapType = $map_type;

--- a/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -15,16 +15,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class MapRenderEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The config factory service.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  private $configFactory;
-
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->configFactory = $config_factory;
-  }
+  public function __construct(
+    private ConfigFactoryInterface $configFactory,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -22,12 +22,6 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   private $configFactory;
 
-  /**
-   * Constructor.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   */
   public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;
   }

--- a/modules/core/map/src/Plugin/Block/MapBlock.php
+++ b/modules/core/map/src/Plugin/Block/MapBlock.php
@@ -24,16 +24,13 @@ class MapBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   use PluginDependencyTrait;
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/map/src/Plugin/Block/MapBlock.php
+++ b/modules/core/map/src/Plugin/Block/MapBlock.php
@@ -31,18 +31,6 @@ class MapBlock extends BlockBase implements ContainerFactoryPluginInterface {
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a MapBlock object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
+++ b/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
@@ -22,17 +22,17 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class GeofieldFormatter extends FormatterBase {
 
-  /**
-   * The geofield.geophp service.
-   *
-   * @var \Drupal\geofield\GeoPHP\GeoPHPInterface
-   */
-  protected $geoPhp;
-
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, GeoPHPInterface $geo_php) {
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    $label,
+    $view_mode,
+    array $third_party_settings,
+    protected GeoPHPInterface $geoPhp,
+  ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-
-    $this->geoPhp = $geo_php;
   }
 
   /**

--- a/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
+++ b/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
@@ -29,26 +29,6 @@ class GeofieldFormatter extends FormatterBase {
    */
   protected $geoPhp;
 
-  /**
-   * Constructs a FormatterBase object.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The formatter settings.
-   * @param string $label
-   *   The formatter label display setting.
-   * @param string $view_mode
-   *   The view mode.
-   * @param array $third_party_settings
-   *   Any third party settings.
-   * @param \Drupal\geofield\GeoPHP\GeoPHPInterface $geo_php
-   *   The geofield geophp service.
-   */
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, GeoPHPInterface $geo_php) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
 

--- a/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
+++ b/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
@@ -35,20 +35,6 @@ class GeofieldWidget extends GeofieldBaseWidget {
   use WktTrait;
 
   /**
-   * The file system service.
-   *
-   * @var \Drupal\Core\File\FileSystemInterface
-   */
-  protected $fileSystem;
-
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * Supported GeoPHP file types.
    *
    * @var string[]
@@ -63,10 +49,19 @@ class GeofieldWidget extends GeofieldBaseWidget {
     'wkt' => 'wkt',
   ];
 
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, GeoPHPInterface $geophp_wrapper, WktGeneratorInterface $wkt_generator, GeofieldBackendManager $geofield_backend_manager, FileSystem $file_system, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    $plugin_id,
+    $plugin_definition,
+    FieldDefinitionInterface $field_definition,
+    array $settings,
+    array $third_party_settings,
+    GeoPHPInterface $geophp_wrapper,
+    WktGeneratorInterface $wkt_generator,
+    GeofieldBackendManager $geofield_backend_manager,
+    protected FileSystem $fileSystem,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings, $geophp_wrapper, $wkt_generator, $geofield_backend_manager);
-    $this->fileSystem = $file_system;
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
+++ b/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
@@ -63,30 +63,6 @@ class GeofieldWidget extends GeofieldBaseWidget {
     'wkt' => 'wkt',
   ];
 
-  /**
-   * GeofieldWidget constructor.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The formatter settings.
-   * @param array $third_party_settings
-   *   Any third party settings settings.
-   * @param \Drupal\geofield\GeoPHP\GeoPHPInterface $geophp_wrapper
-   *   The geoPhpWrapper.
-   * @param \Drupal\geofield\WktGeneratorInterface $wkt_generator
-   *   The WKT format Generator service.
-   * @param \Drupal\geofield\Plugin\GeofieldBackendManager $geofield_backend_manager
-   *   The geofieldBackendManager.
-   * @param \Drupal\Core\File\FileSystem $file_system
-   *   The file system service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, array $third_party_settings, GeoPHPInterface $geophp_wrapper, WktGeneratorInterface $wkt_generator, GeofieldBackendManager $geofield_backend_manager, FileSystem $file_system, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $third_party_settings, $geophp_wrapper, $wkt_generator, $geofield_backend_manager);
     $this->fileSystem = $file_system;

--- a/modules/core/organization/src/Event/OrganizationEvent.php
+++ b/modules/core/organization/src/Event/OrganizationEvent.php
@@ -24,12 +24,6 @@ class OrganizationEvent extends Event {
    */
   public OrganizationInterface $organization;
 
-  /**
-   * Constructs the object.
-   *
-   * @param \Drupal\organization\Entity\OrganizationInterface $organization
-   *   The Organization entity.
-   */
   public function __construct(OrganizationInterface $organization) {
     $this->organization = $organization;
   }

--- a/modules/core/organization/src/Event/OrganizationEvent.php
+++ b/modules/core/organization/src/Event/OrganizationEvent.php
@@ -17,15 +17,8 @@ class OrganizationEvent extends Event {
   const UPDATE = 'organization_update';
   const DELETE = 'organization_delete';
 
-  /**
-   * The Organization entity.
-   *
-   * @var \Drupal\organization\Entity\OrganizationInterface
-   */
-  public OrganizationInterface $organization;
-
-  public function __construct(OrganizationInterface $organization) {
-    $this->organization = $organization;
-  }
+  public function __construct(
+    protected OrganizationInterface $organization,
+  ) {}
 
 }

--- a/modules/core/organization/src/Plugin/Action/OrganizationClone.php
+++ b/modules/core/organization/src/Plugin/Action/OrganizationClone.php
@@ -29,20 +29,6 @@ class OrganizationClone extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs an OrganizationClone object.
-   *
-   * @param mixed[] $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   The current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $this->currentUser = $current_user;

--- a/modules/core/organization/src/Plugin/Action/OrganizationClone.php
+++ b/modules/core/organization/src/Plugin/Action/OrganizationClone.php
@@ -22,16 +22,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class OrganizationClone extends EntityActionBase {
 
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $this->currentUser = $current_user;
   }
 
   /**

--- a/modules/core/owner/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/owner/src/EventSubscriber/LogEventSubscriber.php
@@ -13,16 +13,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class LogEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-  }
+  public function __construct(
+    protected AccountInterface $currentUser,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/owner/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/core/owner/src/EventSubscriber/LogEventSubscriber.php
@@ -20,12 +20,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   protected $currentUser;
 
-  /**
-   * LogEventSubscriber constructor.
-   *
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   The current user.
-   */
   public function __construct(AccountInterface $current_user) {
     $this->currentUser = $current_user;
   }

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -21,11 +21,11 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class AssignActionForm extends ConfirmFormBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -63,7 +63,7 @@ class AssignActionForm extends ConfirmFormBase {
   protected $entities;
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager, AccountInterface $user) {
-    $this->tempStore = $temp_store_factory->get('entity_assign_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->managedRolePermissionsManager = $managed_role_permissions_manager;
     $this->user = $user;
@@ -131,7 +131,7 @@ class AssignActionForm extends ConfirmFormBase {
     $this->entityType = $this->entityTypeManager->getDefinition($entity_type, FALSE);
 
     // Load saved entities.
-    $this->entities = $this->tempStore->get((string) $this->user->id());
+    $this->entities = $this->tempStoreFactory->get('entity_assign_confirm')->get((string) $this->user->id());
 
     // If there are no entities, or if the entity type definition didn't load,
     // redirect the user to the cancel URL.
@@ -252,7 +252,7 @@ class AssignActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete((string) $this->currentUser()->id());
+    $this->tempStoreFactory->get('entity_assign_confirm')->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -21,34 +21,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class AssignActionForm extends ConfirmFormBase {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The managed role permissions manager.
-   *
-   * @var \Drupal\farm_role\ManagedRolePermissionsManagerInterface
-   */
-  protected $managedRolePermissionsManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface|null
@@ -62,12 +34,12 @@ class AssignActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager, AccountInterface $user) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->managedRolePermissionsManager = $managed_role_permissions_manager;
-    $this->user = $user;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
+    protected AccountInterface $user,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -62,18 +62,6 @@ class AssignActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  /**
-   * Constructs an AssignActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_permissions_manager
-   *   The managed role permissions manager.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager, AccountInterface $user) {
     $this->tempStore = $temp_store_factory->get('entity_assign_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/owner/src/Plugin/Action/AssignBase.php
+++ b/modules/core/owner/src/Plugin/Action/AssignBase.php
@@ -29,22 +29,6 @@ abstract class AssignBase extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new AssignBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
     $this->tempStore = $temp_store_factory->get('entity_assign_confirm');

--- a/modules/core/owner/src/Plugin/Action/AssignBase.php
+++ b/modules/core/owner/src/Plugin/Action/AssignBase.php
@@ -16,11 +16,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class AssignBase extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -31,7 +31,7 @@ abstract class AssignBase extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('entity_assign_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
 
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
@@ -55,7 +55,7 @@ abstract class AssignBase extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set((string) $this->currentUser->id(), $entities);
+    $this->tempStoreFactory->get('entity_assign_confirm')->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/core/owner/src/Plugin/Action/AssignBase.php
+++ b/modules/core/owner/src/Plugin/Action/AssignBase.php
@@ -15,24 +15,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class AssignBase extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
-
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -62,18 +62,6 @@ class AssetParentActionForm extends ConfirmFormBase {
    */
   protected $request;
 
-  /**
-   * Constructs an AssetParentActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The current Request object.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
     $this->tempStore = $temp_store_factory->get('asset_parent_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -21,27 +21,6 @@ use Symfony\Component\HttpFoundation\Request;
 class AssetParentActionForm extends ConfirmFormBase {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface|null
@@ -55,19 +34,12 @@ class AssetParentActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  /**
-   * The current Request object.
-   *
-   * @var \Symfony\Component\HttpFoundation\Request
-   */
-  protected $request;
-
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->user = $user;
-    $this->request = $request;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountInterface $user,
+    protected Request $request,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -21,11 +21,11 @@ use Symfony\Component\HttpFoundation\Request;
 class AssetParentActionForm extends ConfirmFormBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -63,7 +63,7 @@ class AssetParentActionForm extends ConfirmFormBase {
   protected $request;
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
-    $this->tempStore = $temp_store_factory->get('asset_parent_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->user = $user;
     $this->request = $request;
@@ -137,7 +137,7 @@ class AssetParentActionForm extends ConfirmFormBase {
     }
     // Else load entities from the tempStore state.
     else {
-      $this->entities = $this->tempStore->get((string) $this->user->id());
+      $this->entities = $this->tempStoreFactory->get('asset_parent_confirm')->get((string) $this->user->id());
     }
 
     $this->entityType = $this->entityTypeManager->getDefinition('asset', FALSE);
@@ -262,7 +262,7 @@ class AssetParentActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete((string) $this->currentUser()->id());
+    $this->tempStoreFactory->get('asset_parent_confirm')->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -23,24 +23,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class AssetParent extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
-
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -37,22 +37,6 @@ class AssetParent extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new AssetParent object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
     $this->tempStore = $temp_store_factory->get('asset_parent_confirm');

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AssetParent extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class AssetParent extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('asset_parent_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
 
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
@@ -63,7 +63,7 @@ class AssetParent extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set((string) $this->currentUser->id(), $entities);
+    $this->tempStoreFactory->get('asset_parent_confirm')->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/core/plan/src/Form/PlanTypeForm.php
+++ b/modules/core/plan/src/Form/PlanTypeForm.php
@@ -23,16 +23,9 @@ class PlanTypeForm extends EntityForm {
    */
   protected $entity;
 
-  /**
-   * The workflow manager.
-   *
-   * @var \Drupal\state_machine\WorkflowManagerInterface
-   */
-  protected $workflowManager;
-
-  public function __construct(WorkflowManagerInterface $workflow_manager) {
-    $this->workflowManager = $workflow_manager;
-  }
+  public function __construct(
+    protected WorkflowManagerInterface $workflowManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/plan/src/Form/PlanTypeForm.php
+++ b/modules/core/plan/src/Form/PlanTypeForm.php
@@ -30,12 +30,6 @@ class PlanTypeForm extends EntityForm {
    */
   protected $workflowManager;
 
-  /**
-   * Constructs a new PlanTypeForm object.
-   *
-   * @param \Drupal\state_machine\WorkflowManagerInterface $workflow_manager
-   *   The workflow manager.
-   */
   public function __construct(WorkflowManagerInterface $workflow_manager) {
     $this->workflowManager = $workflow_manager;
   }

--- a/modules/core/quantity/src/Event/QuantityEvent.php
+++ b/modules/core/quantity/src/Event/QuantityEvent.php
@@ -22,12 +22,6 @@ class QuantityEvent extends Event {
    */
   public QuantityInterface $quantity;
 
-  /**
-   * Constructs the object.
-   *
-   * @param \Drupal\quantity\Entity\QuantityInterface $quantity
-   *   The Quantity entity.
-   */
   public function __construct(QuantityInterface $quantity) {
     $this->quantity = $quantity;
   }

--- a/modules/core/quantity/src/Event/QuantityEvent.php
+++ b/modules/core/quantity/src/Event/QuantityEvent.php
@@ -15,15 +15,8 @@ class QuantityEvent extends Event {
   const PRESAVE = 'quantity_presave';
   const DELETE = 'quantity_delete';
 
-  /**
-   * The Quantity entity.
-   *
-   * @var \Drupal\quantity\Entity\QuantityInterface
-   */
-  public QuantityInterface $quantity;
-
-  public function __construct(QuantityInterface $quantity) {
-    $this->quantity = $quantity;
-  }
+  public function __construct(
+    public QuantityInterface $quantity,
+  ) {}
 
 }

--- a/modules/core/quantity/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/quantity/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -22,12 +22,6 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   private $configFactory;
 
-  /**
-   * Constructor.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   */
   public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;
   }

--- a/modules/core/quantity/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/quantity/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -15,16 +15,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class MapRenderEventSubscriber implements EventSubscriberInterface {
 
-  /**
-   * The config factory service.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  private $configFactory;
-
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->configFactory = $config_factory;
-  }
+  public function __construct(
+    protected ConfigFactoryInterface $configFactory,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Attribute/QuickForm.php
+++ b/modules/core/quick/src/Attribute/QuickForm.php
@@ -13,22 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class QuickForm extends Plugin {
 
-  /**
-   * Constructs a quick form attribute.
-   *
-   * @param string $id
-   *   The quick form ID.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup $label
-   *   The quick form label.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $description
-   *   The quick form description.
-   * @param \Drupal\Core\StringTranslation\TranslatableMarkup|null $helpText
-   *   The quick form help text.
-   * @param string[] $permissions
-   *   An array of access permissions for the quick form.
-   * @param bool $requiresEntity
-   *   Require a quick form instance entity to instantiate.
-   */
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $label,

--- a/modules/core/quick/src/Controller/QuickFormAddPage.php
+++ b/modules/core/quick/src/Controller/QuickFormAddPage.php
@@ -16,16 +16,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class QuickFormAddPage extends ControllerBase {
 
-  /**
-   * The quick form plugin manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormPluginManager
-   */
-  protected $quickFormPluginManager;
-
-  public function __construct(QuickFormPluginManager $quick_form_plugin_manager) {
-    $this->quickFormPluginManager = $quick_form_plugin_manager;
-  }
+  public function __construct(
+    protected QuickFormPluginManager $quickFormPluginManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Controller/QuickFormAddPage.php
+++ b/modules/core/quick/src/Controller/QuickFormAddPage.php
@@ -23,9 +23,6 @@ class QuickFormAddPage extends ControllerBase {
    */
   protected $quickFormPluginManager;
 
-  /**
-   * Constructs a new QuickFormAddPage object.
-   */
   public function __construct(QuickFormPluginManager $quick_form_plugin_manager) {
     $this->quickFormPluginManager = $quick_form_plugin_manager;
   }

--- a/modules/core/quick/src/Controller/QuickFormController.php
+++ b/modules/core/quick/src/Controller/QuickFormController.php
@@ -20,16 +20,9 @@ class QuickFormController extends ControllerBase {
 
   use StringTranslationTrait;
 
-  /**
-   * The quick form instance manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
-   */
-  protected $quickFormInstanceManager;
-
-  public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
-    $this->quickFormInstanceManager = $quick_form_instance_manager;
-  }
+  public function __construct(
+    protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Controller/QuickFormController.php
+++ b/modules/core/quick/src/Controller/QuickFormController.php
@@ -27,12 +27,6 @@ class QuickFormController extends ControllerBase {
    */
   protected $quickFormInstanceManager;
 
-  /**
-   * Quick form controller constructor.
-   *
-   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
-   *   The quick form instance manager.
-   */
   public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
     $this->quickFormInstanceManager = $quick_form_instance_manager;
   }

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -34,12 +34,6 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
    */
   protected $quickFormId;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
-   *   The quick form instance manager.
-   */
   public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
     $this->quickFormInstanceManager = $quick_form_instance_manager;
   }

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -21,22 +21,15 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 class QuickForm extends FormBase implements BaseFormIdInterface {
 
   /**
-   * The quick form instance manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
-   */
-  protected $quickFormInstanceManager;
-
-  /**
    * The quick form ID.
    *
    * @var string
    */
   protected $quickFormId;
 
-  public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
-    $this->quickFormInstanceManager = $quick_form_instance_manager;
-  }
+  public function __construct(
+    protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Form/QuickFormEntityForm.php
+++ b/modules/core/quick/src/Form/QuickFormEntityForm.php
@@ -27,16 +27,9 @@ class QuickFormEntityForm extends EntityForm {
    */
   protected $entity;
 
-  /**
-   * The quick form plugin manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormPluginManager
-   */
-  protected $quickFormPluginManager;
-
-  public function __construct(QuickFormPluginManager $quick_form_plugin_manager) {
-    $this->quickFormPluginManager = $quick_form_plugin_manager;
-  }
+  public function __construct(
+    protected QuickFormPluginManager $quickFormPluginManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Form/QuickFormEntityForm.php
+++ b/modules/core/quick/src/Form/QuickFormEntityForm.php
@@ -34,12 +34,6 @@ class QuickFormEntityForm extends EntityForm {
    */
   protected $quickFormPluginManager;
 
-  /**
-   * Constructs a new QuickFormEntityForm object.
-   *
-   * @param \Drupal\farm_quick\QuickFormPluginManager $quick_form_plugin_manager
-   *   The quick form plugin manager.
-   */
   public function __construct(QuickFormPluginManager $quick_form_plugin_manager) {
     $this->quickFormPluginManager = $quick_form_plugin_manager;
   }

--- a/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
+++ b/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
@@ -15,25 +15,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class QuickFormActionBase extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
-    $quick_form_id = $this->getQuickFormId();
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->currentUser = $current_user;
   }
 
   /**

--- a/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
+++ b/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
@@ -16,11 +16,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class QuickFormActionBase extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -32,7 +32,7 @@ abstract class QuickFormActionBase extends EntityActionBase {
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $quick_form_id = $this->getQuickFormId();
-    $this->tempStore = $temp_store_factory->get("farm_quick.$quick_form_id");
+    $this->tempStoreFactory = $temp_store_factory;
     $this->currentUser = $current_user;
   }
 
@@ -63,7 +63,7 @@ abstract class QuickFormActionBase extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set($this->currentUser->id() . ':' . $this->getPluginDefinition()['type'], $entities);
+    $this->tempStoreFactory->get('farm_quick.' . $this->getQuickFormId())->set($this->currentUser->id() . ':' . $this->getPluginDefinition()['type'], $entities);
   }
 
   /**

--- a/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
+++ b/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
@@ -29,22 +29,6 @@ abstract class QuickFormActionBase extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new EntityFlag object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
     $quick_form_id = $this->getQuickFormId();

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
@@ -15,16 +15,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class QuickFormMenuLink extends DeriverBase implements ContainerDeriverInterface {
 
-  /**
-   * The quick form instance manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
-   */
-  protected $quickFormInstanceManager;
-
-  public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
-    $this->quickFormInstanceManager = $quick_form_instance_manager;
-  }
+  public function __construct(
+    protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
@@ -22,12 +22,6 @@ class QuickFormMenuLink extends DeriverBase implements ContainerDeriverInterface
    */
   protected $quickFormInstanceManager;
 
-  /**
-   * FarmQuickMenuLink constructor.
-   *
-   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
-   *   The quick form instance manager.
-   */
   public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
     $this->quickFormInstanceManager = $quick_form_instance_manager;
   }

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormTaskLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormTaskLink.php
@@ -17,16 +17,9 @@ class QuickFormTaskLink extends DeriverBase implements ContainerDeriverInterface
 
   use StringTranslationTrait;
 
-  /**
-   * The quick form instance manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
-   */
-  protected $quickFormInstanceManager;
-
-  public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
-    $this->quickFormInstanceManager = $quick_form_instance_manager;
-  }
+  public function __construct(
+    protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormTaskLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormTaskLink.php
@@ -24,12 +24,6 @@ class QuickFormTaskLink extends DeriverBase implements ContainerDeriverInterface
    */
   protected $quickFormInstanceManager;
 
-  /**
-   * QuickFormTaskLink constructor.
-   *
-   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
-   *   The quick form plugin manager.
-   */
   public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
     $this->quickFormInstanceManager = $quick_form_instance_manager;
   }

--- a/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
+++ b/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
@@ -44,22 +44,6 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
    */
   protected $currentUser;
 
-  /**
-   * Constructs a QuickFormBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
+++ b/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_quick\Plugin\QuickForm;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
@@ -44,11 +43,10 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
    */
   protected $currentUser;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->currentUser = $current_user;
-    $this->messenger = $messenger;
   }
 
   /**
@@ -61,7 +59,6 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('messenger'),
     );
   }
 

--- a/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
+++ b/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
@@ -29,24 +29,14 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
    */
   protected string $quickId;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * Current user object.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->currentUser = $current_user;
   }
 
   /**

--- a/modules/core/quick/src/QuickFormInstanceManager.php
+++ b/modules/core/quick/src/QuickFormInstanceManager.php
@@ -13,24 +13,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class QuickFormInstanceManager implements QuickFormInstanceManagerInterface {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The quick form plugin manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormPluginManager
-   */
-  protected $quickFormPluginManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, QuickFormPluginManager $quick_form_plugin_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->quickFormPluginManager = $quick_form_plugin_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected QuickFormPluginManager $quickFormPluginManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/QuickFormInstanceManager.php
+++ b/modules/core/quick/src/QuickFormInstanceManager.php
@@ -27,14 +27,6 @@ class QuickFormInstanceManager implements QuickFormInstanceManagerInterface {
    */
   protected $quickFormPluginManager;
 
-  /**
-   * Constructs a QuickFormInstanceManager object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_quick\QuickFormPluginManager $quick_form_plugin_manager
-   *   The quick form plugin manager.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, QuickFormPluginManager $quick_form_plugin_manager) {
     $this->entityTypeManager = $entity_type_manager;
     $this->quickFormPluginManager = $quick_form_plugin_manager;

--- a/modules/core/quick/src/QuickFormListBuilder.php
+++ b/modules/core/quick/src/QuickFormListBuilder.php
@@ -23,16 +23,6 @@ class QuickFormListBuilder extends ConfigEntityListBuilder {
    */
   protected $quickFormInstanceManager;
 
-  /**
-   * Constructs a new QuickFormListBuilder object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type definition.
-   * @param \Drupal\Core\Entity\EntityStorageInterface $storage
-   *   The entity storage class.
-   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
-   *   The quick form instance manager.
-   */
   public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, QuickFormInstanceManagerInterface $quick_form_instance_manager) {
     parent::__construct($entity_type, $storage);
     $this->quickFormInstanceManager = $quick_form_instance_manager;

--- a/modules/core/quick/src/QuickFormListBuilder.php
+++ b/modules/core/quick/src/QuickFormListBuilder.php
@@ -16,16 +16,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class QuickFormListBuilder extends ConfigEntityListBuilder {
 
-  /**
-   * The quick form instance manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
-   */
-  protected $quickFormInstanceManager;
-
-  public function __construct(EntityTypeInterface $entity_type, EntityStorageInterface $storage, QuickFormInstanceManagerInterface $quick_form_instance_manager) {
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    EntityStorageInterface $storage,
+    protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
+  ) {
     parent::__construct($entity_type, $storage);
-    $this->quickFormInstanceManager = $quick_form_instance_manager;
   }
 
   /**

--- a/modules/core/quick/src/QuickFormPluginCollection.php
+++ b/modules/core/quick/src/QuickFormPluginCollection.php
@@ -20,18 +20,6 @@ class QuickFormPluginCollection extends DefaultSingleLazyPluginCollection {
    */
   protected $quickFormId;
 
-  /**
-   * Constructs a new QuickFormPluginCollection.
-   *
-   * @param \Drupal\Component\Plugin\PluginManagerInterface $manager
-   *   The manager to be used for instantiating plugins.
-   * @param string $instance_id
-   *   The ID of the plugin instance.
-   * @param array $configuration
-   *   An array of configuration.
-   * @param string $quick_form_id
-   *   The unique ID of the quick form entity using this plugin.
-   */
   public function __construct(PluginManagerInterface $manager, $instance_id, array $configuration, $quick_form_id) {
     parent::__construct($manager, $instance_id, $configuration);
     $this->quickFormId = $quick_form_id;

--- a/modules/core/quick/src/QuickFormPluginCollection.php
+++ b/modules/core/quick/src/QuickFormPluginCollection.php
@@ -13,16 +13,13 @@ use Drupal\Core\Plugin\DefaultSingleLazyPluginCollection;
  */
 class QuickFormPluginCollection extends DefaultSingleLazyPluginCollection {
 
-  /**
-   * The quick form ID this plugin collection belongs to.
-   *
-   * @var string
-   */
-  protected $quickFormId;
-
-  public function __construct(PluginManagerInterface $manager, $instance_id, array $configuration, $quick_form_id) {
+  public function __construct(
+    PluginManagerInterface $manager,
+    $instance_id,
+    array $configuration,
+    protected ?string $quickFormId = NULL,
+  ) {
     parent::__construct($manager, $instance_id, $configuration);
-    $this->quickFormId = $quick_form_id;
   }
 
   /**

--- a/modules/core/quick/src/QuickFormPluginManager.php
+++ b/modules/core/quick/src/QuickFormPluginManager.php
@@ -15,7 +15,11 @@ use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
  */
 class QuickFormPluginManager extends DefaultPluginManager {
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct(
       'Plugin/QuickForm',
       $namespaces,

--- a/modules/core/quick/src/QuickFormPluginManager.php
+++ b/modules/core/quick/src/QuickFormPluginManager.php
@@ -15,17 +15,6 @@ use Drupal\farm_quick\Plugin\QuickForm\QuickFormInterface;
  */
 class QuickFormPluginManager extends DefaultPluginManager {
 
-  /**
-   * Constructs a QuickFormPluginManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   Cache backend instance to use.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler to invoke the alter hook with.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
     parent::__construct(
       'Plugin/QuickForm',

--- a/modules/core/quick/src/Routing/QuickFormRoutes.php
+++ b/modules/core/quick/src/Routing/QuickFormRoutes.php
@@ -23,12 +23,6 @@ class QuickFormRoutes implements ContainerInjectionInterface {
    */
   protected $quickFormInstanceManager;
 
-  /**
-   * Constructs a QuickFormRoutes object.
-   *
-   * @param \Drupal\farm_quick\QuickFormInstanceManagerInterface $quick_form_instance_manager
-   *   The quick form instance manager.
-   */
   public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
     $this->quickFormInstanceManager = $quick_form_instance_manager;
   }

--- a/modules/core/quick/src/Routing/QuickFormRoutes.php
+++ b/modules/core/quick/src/Routing/QuickFormRoutes.php
@@ -16,16 +16,9 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class QuickFormRoutes implements ContainerInjectionInterface {
 
-  /**
-   * The quick form instance manager.
-   *
-   * @var \Drupal\farm_quick\QuickFormInstanceManagerInterface
-   */
-  protected $quickFormInstanceManager;
-
-  public function __construct(QuickFormInstanceManagerInterface $quick_form_instance_manager) {
-    $this->quickFormInstanceManager = $quick_form_instance_manager;
-  }
+  public function __construct(
+    protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Traits/ConfigurableQuickFormTrait.php
+++ b/modules/core/quick/src/Traits/ConfigurableQuickFormTrait.php
@@ -53,7 +53,7 @@ trait ConfigurableQuickFormTrait {
     // @todo Save configuration entity.
 
     // Add a status message.
-    $this->messenger->addStatus($this->t('Configuration saved.'));
+    $this->messenger()->addStatus($this->t('Configuration saved.'));
   }
 
 }

--- a/modules/core/quick/src/Traits/QuickAssetTrait.php
+++ b/modules/core/quick/src/Traits/QuickAssetTrait.php
@@ -67,7 +67,7 @@ trait QuickAssetTrait {
 
     // Display a message with a link to the asset.
     $message = $this->t('Asset created: <a href=":url">@name</a>', [':url' => $asset->toUrl()->toString(), '@name' => $asset->label()]);
-    $this->messenger->addStatus($message);
+    $this->messenger()->addStatus($message);
 
     // Return the asset entity.
     return $asset;

--- a/modules/core/quick/src/Traits/QuickLogTrait.php
+++ b/modules/core/quick/src/Traits/QuickLogTrait.php
@@ -89,7 +89,7 @@ trait QuickLogTrait {
 
     // Display a message with a link to the log.
     $message = $this->t('Log created: <a href=":url">@name</a>', [':url' => $log->toUrl()->toString(), '@name' => $log->label()]);
-    $this->messenger->addStatus($message);
+    $this->messenger()->addStatus($message);
 
     // Return the log entity.
     return $log;

--- a/modules/core/report/src/Controller/ReportController.php
+++ b/modules/core/report/src/Controller/ReportController.php
@@ -25,12 +25,6 @@ class ReportController extends ControllerBase {
    */
   protected $menuLinkTree;
 
-  /**
-   * Constructs a new ReportController.
-   *
-   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_link_tree
-   *   The menu link tree service.
-   */
   public function __construct(MenuLinkTreeInterface $menu_link_tree) {
     $this->menuLinkTree = $menu_link_tree;
   }

--- a/modules/core/report/src/Controller/ReportController.php
+++ b/modules/core/report/src/Controller/ReportController.php
@@ -18,16 +18,9 @@ class ReportController extends ControllerBase {
 
   use StringTranslationTrait;
 
-  /**
-   * The menu link tree service.
-   *
-   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
-   */
-  protected $menuLinkTree;
-
-  public function __construct(MenuLinkTreeInterface $menu_link_tree) {
-    $this->menuLinkTree = $menu_link_tree;
-  }
+  public function __construct(
+    protected MenuLinkTreeInterface $menuLinkTree,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/role/src/FarmRoleStorage.php
+++ b/modules/core/role/src/FarmRoleStorage.php
@@ -22,16 +22,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FarmRoleStorage extends RoleStorage {
 
-  /**
-   * The managed role permissions manager interface.
-   *
-   * @var \Drupal\farm_role\ManagedRolePermissionsManagerInterface
-   */
-  protected $managedRolePermissionsManager;
-
-  public function __construct(EntityTypeInterface $entity_type, ConfigFactoryInterface $config_factory, UuidInterface $uuid_service, LanguageManagerInterface $language_manager, MemoryCacheInterface $memory_cache, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager) {
+  public function __construct(
+    EntityTypeInterface $entity_type,
+    ConfigFactoryInterface $config_factory,
+    UuidInterface $uuid_service,
+    LanguageManagerInterface $language_manager,
+    MemoryCacheInterface $memory_cache,
+    protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
+  ) {
     parent::__construct($entity_type, $config_factory, $uuid_service, $language_manager, $memory_cache);
-    $this->managedRolePermissionsManager = $managed_role_permissions_manager;
   }
 
   /**

--- a/modules/core/role/src/FarmRoleStorage.php
+++ b/modules/core/role/src/FarmRoleStorage.php
@@ -29,22 +29,6 @@ class FarmRoleStorage extends RoleStorage {
    */
   protected $managedRolePermissionsManager;
 
-  /**
-   * Constructs a ConfigEntityStorage object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type definition.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   * @param \Drupal\Component\Uuid\UuidInterface $uuid_service
-   *   The UUID service.
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
-   *   The language manager.
-   * @param \Drupal\Core\Cache\MemoryCache\MemoryCacheInterface $memory_cache
-   *   The memory cache backend.
-   * @param \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_permissions_manager
-   *   The managed role permissions manager.
-   */
   public function __construct(EntityTypeInterface $entity_type, ConfigFactoryInterface $config_factory, UuidInterface $uuid_service, LanguageManagerInterface $language_manager, MemoryCacheInterface $memory_cache, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager) {
     parent::__construct($entity_type, $config_factory, $uuid_service, $language_manager, $memory_cache);
     $this->managedRolePermissionsManager = $managed_role_permissions_manager;

--- a/modules/core/role/src/ManagedRolePermissionChecker.php
+++ b/modules/core/role/src/ManagedRolePermissionChecker.php
@@ -28,16 +28,6 @@ class ManagedRolePermissionChecker extends PermissionChecker {
    */
   protected $managedRolePermissionsManager;
 
-  /**
-   * Class constructor.
-   *
-   * @param \Drupal\Core\Session\AccessPolicyProcessorInterface $processor
-   *   The access policy processor.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_permissions_manager
-   *   The managed role permissions manager.
-   */
   public function __construct(protected AccessPolicyProcessorInterface $processor, EntityTypeManagerInterface $entity_type_manager, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager) {
     parent::__construct($processor);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/role/src/ManagedRolePermissionChecker.php
+++ b/modules/core/role/src/ManagedRolePermissionChecker.php
@@ -14,24 +14,12 @@ use Drupal\Core\Session\PermissionChecker;
  */
 class ManagedRolePermissionChecker extends PermissionChecker {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The managed role permissions manager.
-   *
-   * @var \Drupal\farm_role\ManagedRolePermissionsManagerInterface
-   */
-  protected $managedRolePermissionsManager;
-
-  public function __construct(protected AccessPolicyProcessorInterface $processor, EntityTypeManagerInterface $entity_type_manager, ManagedRolePermissionsManagerInterface $managed_role_permissions_manager) {
+  public function __construct(
+    protected AccessPolicyProcessorInterface $processor,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
+  ) {
     parent::__construct($processor);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->managedRolePermissionsManager = $managed_role_permissions_manager;
   }
 
   /**

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -24,27 +24,6 @@ use Drupal\user\RoleInterface;
 class ManagedRolePermissionsManager extends DefaultPluginManager implements ManagedRolePermissionsManagerInterface {
 
   /**
-   * Controller resolver service.
-   *
-   * @var \Drupal\Core\Controller\ControllerResolverInterface
-   */
-  protected $controllerResolver;
-
-  /**
-   * Entity type bundle info service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
    * Default values for each FarmRolePermissions plugin.
    *
    * @var array
@@ -61,18 +40,21 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
    *
    * @var array
    */
-  protected $rolePermissions;
+  protected $rolePermissions = [];
 
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler, ControllerResolverInterface $controller_resolver, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+    protected ControllerResolverInterface $controllerResolver,
+    protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct(
       'Plugin/ManagedRolePermissions',
       $namespaces,
       $module_handler
     );
-    $this->controllerResolver = $controller_resolver;
-    $this->entityTypeBundleInfo = $entity_type_bundle_info;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->rolePermissions = [];
     $this->alterInfo('managed_role_permissions_info');
     $this->setCacheBackend($cache_backend, 'managed_role_permissions_plugins');
   }

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -63,23 +63,6 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
    */
   protected $rolePermissions;
 
-  /**
-   * Constructs a ManagedRolePermissionsManager object.
-   *
-   * @param \Traversable $namespaces
-   *   An object that implements \Traversable which contains the root paths
-   *   keyed by the corresponding namespace to look for plugin implementations.
-   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
-   *   Cache backend instance to use.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler to invoke the alter hook with.
-   * @param \Drupal\Core\Controller\ControllerResolverInterface $controller_resolver
-   *   The controller resolver service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle info service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler, ControllerResolverInterface $controller_resolver, EntityTypeBundleInfoInterface $entity_type_bundle_info, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct(
       'Plugin/ManagedRolePermissions',

--- a/modules/core/settings/src/Form/FarmSettingsModulesForm.php
+++ b/modules/core/settings/src/Form/FarmSettingsModulesForm.php
@@ -31,22 +31,15 @@ class FarmSettingsModulesForm extends FormBase {
   const FARM_QUICK_PACKAGE = 'farmOS Quick Forms';
 
   /**
-   * The module extension list.
-   *
-   * @var \Drupal\Core\Extension\ModuleExtensionList
-   */
-  protected $moduleExtensionList;
-
-  /**
    * {@inheritdoc}
    */
   public function getFormId() {
     return 'farm_settings_modules_form';
   }
 
-  public function __construct(ModuleExtensionList $module_extension_list) {
-    $this->moduleExtensionList = $module_extension_list;
-  }
+  public function __construct(
+    protected ModuleExtensionList $moduleExtensionList,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/settings/src/Form/FarmSettingsModulesForm.php
+++ b/modules/core/settings/src/Form/FarmSettingsModulesForm.php
@@ -44,12 +44,6 @@ class FarmSettingsModulesForm extends FormBase {
     return 'farm_settings_modules_form';
   }
 
-  /**
-   * Constructs a new FarmSettingsModulesForm.
-   *
-   * @param \Drupal\Core\Extension\ModuleExtensionList $module_extension_list
-   *   The module extension list.
-   */
   public function __construct(ModuleExtensionList $module_extension_list) {
     $this->moduleExtensionList = $module_extension_list;
   }

--- a/modules/core/setup/src/Controller/SetupController.php
+++ b/modules/core/setup/src/Controller/SetupController.php
@@ -25,12 +25,6 @@ class SetupController extends ControllerBase {
    */
   protected $menuLinkTree;
 
-  /**
-   * Constructs a new SetupController.
-   *
-   * @param \Drupal\Core\Menu\MenuLinkTreeInterface $menu_link_tree
-   *   The menu link tree service.
-   */
   public function __construct(MenuLinkTreeInterface $menu_link_tree) {
     $this->menuLinkTree = $menu_link_tree;
   }

--- a/modules/core/setup/src/Controller/SetupController.php
+++ b/modules/core/setup/src/Controller/SetupController.php
@@ -18,16 +18,9 @@ class SetupController extends ControllerBase {
 
   use StringTranslationTrait;
 
-  /**
-   * The menu link tree service.
-   *
-   * @var \Drupal\Core\Menu\MenuLinkTreeInterface
-   */
-  protected $menuLinkTree;
-
-  public function __construct(MenuLinkTreeInterface $menu_link_tree) {
-    $this->menuLinkTree = $menu_link_tree;
-  }
+  public function __construct(
+    protected MenuLinkTreeInterface $menuLinkTree,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -40,16 +40,6 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
    */
   protected $entityTypeBundleInfo;
 
-  /**
-   * Constructs a FarmActions object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle info.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
     $this->entityTypeManager = $entity_type_manager;
     $this->moduleHandler = $module_handler;

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -19,32 +19,11 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * The entity type bundle info.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, EntityTypeBundleInfoInterface $entity_type_bundle_info) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->moduleHandler = $module_handler;
-    $this->entityTypeBundleInfo = $entity_type_bundle_info;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -30,20 +30,6 @@ class AddEntity extends LocalActionDefault {
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs an AddEntity object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Routing\RouteProviderInterface $route_provider
-   *   The route provider to load routes by name.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteProviderInterface $route_provider, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $route_provider);
 

--- a/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -23,17 +23,14 @@ class AddEntity extends LocalActionDefault {
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteProviderInterface $route_provider, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    RouteProviderInterface $route_provider,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $route_provider);
-
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -39,9 +39,6 @@ class DashboardController extends ControllerBase {
    */
   protected $currentUser;
 
-  /**
-   * Class constructor.
-   */
   public function __construct(LayoutPluginManagerInterface $layout_plugin_manager, BlockManagerInterface $block_manager, AccountInterface $current_user) {
     $this->layoutPluginManager = $layout_plugin_manager;
     $this->blockManager = $block_manager;

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -17,24 +17,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class DashboardController extends ControllerBase {
 
-  /**
-   * The layout plugin manager.
-   *
-   * @var \Drupal\Core\Layout\LayoutPluginManagerInterface
-   */
-  protected $layoutPluginManager;
-
-  /**
-   * The block manager.
-   *
-   * @var \Drupal\Core\Block\BlockManagerInterface
-   */
-  protected $blockManager;
-
-  public function __construct(LayoutPluginManagerInterface $layout_plugin_manager, BlockManagerInterface $block_manager) {
-    $this->layoutPluginManager = $layout_plugin_manager;
-    $this->blockManager = $block_manager;
-  }
+  public function __construct(
+    protected LayoutPluginManagerInterface $layoutPluginManager,
+    protected BlockManagerInterface $blockManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_ui_dashboard\Controller;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Layout\LayoutPluginManagerInterface;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\views\Views;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -32,17 +31,9 @@ class DashboardController extends ControllerBase {
    */
   protected $blockManager;
 
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(LayoutPluginManagerInterface $layout_plugin_manager, BlockManagerInterface $block_manager, AccountInterface $current_user) {
+  public function __construct(LayoutPluginManagerInterface $layout_plugin_manager, BlockManagerInterface $block_manager) {
     $this->layoutPluginManager = $layout_plugin_manager;
     $this->blockManager = $block_manager;
-    $this->currentUser = $current_user;
   }
 
   /**
@@ -52,7 +43,6 @@ class DashboardController extends ControllerBase {
     return new static(
       $container->get('plugin.manager.core.layout'),
       $container->get('plugin.manager.block'),
-      $container->get('current_user'),
     );
   }
 
@@ -120,7 +110,7 @@ class DashboardController extends ControllerBase {
         $block = $this->blockManager->createInstance($pane['block'], $args);
 
         // Check block access.
-        $access_result = $block->access($this->currentUser);
+        $access_result = $block->access($this->currentUser());
 
         // Build renderable array of the block.
         if ($access_result == TRUE) {

--- a/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
@@ -21,24 +21,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class BaseLocationHierarchyForm extends FormBase {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->assetLocation = $asset_location;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AssetLocationInterface $assetLocation,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
@@ -35,14 +35,6 @@ abstract class BaseLocationHierarchyForm extends FormBase {
    */
   protected $assetLocation;
 
-  /**
-   * Constructs a new BaseLocationHierarchyForm.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   The asset location service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
     $this->entityTypeManager = $entity_type_manager;
     $this->assetLocation = $asset_location;

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -32,9 +32,6 @@ class LocationHierarchyForm extends BaseLocationHierarchyForm {
    */
   protected $assetLocation;
 
-  /**
-   * {@inheritdoc}
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
     parent::__construct($entity_type_manager, $asset_location);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/ui/location/src/Form/LocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/LocationHierarchyForm.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_location\Form;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\asset\Entity\AssetInterface;
-use Drupal\farm_location\AssetLocationInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for changing the hierarchy of all location assets.
@@ -17,36 +14,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ingroup farm
  */
 class LocationHierarchyForm extends BaseLocationHierarchyForm {
-
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
-    parent::__construct($entity_type_manager, $asset_location);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->assetLocation = $asset_location;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('asset.location'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/location/src/Form/OrganizationLocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/OrganizationLocationHierarchyForm.php
@@ -27,9 +27,6 @@ class OrganizationLocationHierarchyForm extends BaseLocationHierarchyForm {
    */
   protected $routeMatch;
 
-  /**
-   * {@inheritdoc}
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location, RouteMatchInterface $route_match) {
     parent::__construct($entity_type_manager, $asset_location);
     $this->routeMatch = $route_match;

--- a/modules/core/ui/location/src/Form/OrganizationLocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/OrganizationLocationHierarchyForm.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_location\Form;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\asset\Entity\AssetInterface;
-use Drupal\farm_location\AssetLocationInterface;
 use Drupal\organization\Entity\OrganizationInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for changing the hierarchy of location assets within an organization.
@@ -19,29 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ingroup farm
  */
 class OrganizationLocationHierarchyForm extends BaseLocationHierarchyForm {
-
-  /**
-   * The route match service.
-   *
-   * @var \Drupal\Core\Routing\RouteMatchInterface
-   */
-  protected $routeMatch;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location, RouteMatchInterface $route_match) {
-    parent::__construct($entity_type_manager, $asset_location);
-    $this->routeMatch = $route_match;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('asset.location'),
-      $container->get('current_route_match'),
-    );
-  }
 
   /**
    * {@inheritdoc}
@@ -98,7 +71,7 @@ class OrganizationLocationHierarchyForm extends BaseLocationHierarchyForm {
 
     // Add farm organization condition to query.
     $query = parent::getLocationQuery($parent);
-    if ($organization = $this->routeMatch->getParameter('organization')) {
+    if ($organization = $this->getRouteMatch()->getParameter('organization')) {
       $query->condition('farm', $organization->id());
     }
     return $query;

--- a/modules/core/ui/location/src/Plugin/Derivative/AddLocationAssetAction.php
+++ b/modules/core/ui/location/src/Plugin/Derivative/AddLocationAssetAction.php
@@ -17,16 +17,9 @@ class AddLocationAssetAction extends DeriverBase implements ContainerDeriverInte
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/location/src/Plugin/Derivative/AddLocationAssetAction.php
+++ b/modules/core/ui/location/src/Plugin/Derivative/AddLocationAssetAction.php
@@ -24,12 +24,6 @@ class AddLocationAssetAction extends DeriverBase implements ContainerDeriverInte
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a FarmActions object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -33,14 +33,6 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
    */
   protected $layerStyleLoader;
 
-  /**
-   * MapRenderEventSubscriber Constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_map\LayerStyleLoaderInterface $layer_style_loader
-   *   The layer style loader service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
     $this->assetTypes = $entity_type_manager->getStorage('asset_type')->loadMultiple();
     $this->layerStyleLoader = $layer_style_loader;

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -19,24 +19,10 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The layer style loader service.
-   *
-   * @var \Drupal\farm_map\LayerStyleLoaderInterface
-   */
-  protected $layerStyleLoader;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->layerStyleLoader = $layer_style_loader;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected LayerStyleLoaderInterface $layerStyleLoader,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
+++ b/modules/core/ui/map/src/EventSubscriber/MapRenderEventSubscriber.php
@@ -20,11 +20,11 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   use StringTranslationTrait;
 
   /**
-   * Asset types.
+   * The entity type manager.
    *
-   * @var \Drupal\asset\Entity\AssetTypeInterface[]
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetTypes;
+  protected $entityTypeManager;
 
   /**
    * The layer style loader service.
@@ -34,7 +34,7 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
   protected $layerStyleLoader;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager, LayerStyleLoaderInterface $layer_style_loader) {
-    $this->assetTypes = $entity_type_manager->getStorage('asset_type')->loadMultiple();
+    $this->entityTypeManager = $entity_type_manager;
     $this->layerStyleLoader = $layer_style_loader;
   }
 
@@ -91,7 +91,8 @@ class MapRenderEventSubscriber implements EventSubscriberInterface {
 
       // Add separate layers for all asset types that are locations by default.
       $other_location_asset_types = [];
-      foreach ($this->assetTypes as $type) {
+      $asset_types = $this->entityTypeManager->getStorage('asset_type')->loadMultiple();
+      foreach ($asset_types as $type) {
 
         // Add a dedicated layer if the asset type is a location by default.
         if ($type->getThirdPartySetting('farm_location', 'is_location', FALSE)) {

--- a/modules/core/ui/menu/src/Menu/DefaultSecondaryLocalTaskProvider.php
+++ b/modules/core/ui/menu/src/Menu/DefaultSecondaryLocalTaskProvider.php
@@ -18,15 +18,10 @@ class DefaultSecondaryLocalTaskProvider implements EntityLocalTaskProviderInterf
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeInterface
-   */
-  protected $entityType;
-
-  public function __construct(EntityTypeInterface $entity_type, TranslationInterface $string_translation) {
-    $this->entityType = $entity_type;
+  public function __construct(
+    protected EntityTypeInterface $entityType,
+    TranslationInterface $string_translation,
+  ) {
     $this->setStringTranslation($string_translation);
   }
 

--- a/modules/core/ui/menu/src/Menu/DefaultSecondaryLocalTaskProvider.php
+++ b/modules/core/ui/menu/src/Menu/DefaultSecondaryLocalTaskProvider.php
@@ -25,14 +25,6 @@ class DefaultSecondaryLocalTaskProvider implements EntityLocalTaskProviderInterf
    */
   protected $entityType;
 
-  /**
-   * Constructs a DefaultEntityLocalTaskProvider object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeInterface $entity_type
-   *   The entity type.
-   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
-   *   The string translation.
-   */
   public function __construct(EntityTypeInterface $entity_type, TranslationInterface $string_translation) {
     $this->entityType = $entity_type;
     $this->setStringTranslation($string_translation);

--- a/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
+++ b/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
@@ -27,18 +27,6 @@ class EntityTypeLabelLocalTask extends LocalTaskDefault implements ContainerFact
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs an AddEntity object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
+++ b/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
@@ -20,16 +20,13 @@ class EntityTypeLabelLocalTask extends LocalTaskDefault implements ContainerFact
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -36,20 +36,6 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
    */
   protected $bundleInfo;
 
-  /**
-   * Constructs a \Drupal\Component\Plugin\PluginBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $bundle_info
-   *   The bundle info service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $bundle_info) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -22,24 +22,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The bundle info service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $bundleInfo;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $bundle_info) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityTypeBundleInfoInterface $bundleInfo,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->bundleInfo = $bundle_info;
   }
 
   /**

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -29,17 +29,10 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
    */
   protected $dateFormatter;
 
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
   public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, DateFormatterInterface $date_formatter, ModuleHandlerInterface $module_handler) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->dateFormatter = $date_formatter;
-    $this->moduleHandler = $module_handler;
+    $this->setModuleHandler($module_handler);
   }
 
   /**

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -36,20 +36,6 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
    */
   protected $moduleHandler;
 
-  /**
-   * Constructs a ContentEntityForm object.
-   *
-   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
-   *   The entity repository service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle service.
-   * @param \Drupal\Component\Datetime\TimeInterface $time
-   *   The time service.
-   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
-   *   The date formatter service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   */
   public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, DateFormatterInterface $date_formatter, ModuleHandlerInterface $module_handler) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->dateFormatter = $date_formatter;

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -22,16 +22,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class GinContentFormBase extends ContentEntityForm implements RenderCallbackInterface {
 
-  /**
-   * The date formatter service.
-   *
-   * @var \Drupal\Core\Datetime\DateFormatterInterface
-   */
-  protected $dateFormatter;
-
-  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info, TimeInterface $time, DateFormatterInterface $date_formatter, ModuleHandlerInterface $module_handler) {
+  public function __construct(
+    EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info,
+    TimeInterface $time,
+    protected DateFormatterInterface $dateFormatter,
+    ModuleHandlerInterface $module_handler,
+  ) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
-    $this->dateFormatter = $date_formatter;
     $this->setModuleHandler($module_handler);
   }
 

--- a/modules/core/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
@@ -16,11 +16,11 @@ use Drupal\farm_location\AssetLocationInterface;
 class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
 
   /**
-   * The asset storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetStorage;
+  protected $entityTypeManager;
 
   /**
    * The asset location service.
@@ -30,7 +30,7 @@ class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
   protected $assetLocation;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
-    $this->assetStorage = $entity_type_manager->getStorage('asset');
+    $this->entityTypeManager = $entity_type_manager;
     $this->assetLocation = $asset_location;
   }
 
@@ -42,12 +42,15 @@ class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
    */
   public function access(RouteMatchInterface $route_match) {
 
+    // Get asset storage.
+    $asset_storage = $this->entityTypeManager->getStorage('asset');
+
     // Get the "asset" parameter and attempt to load the asset.
     // If the asset cannot be loaded, allow access so that Views contextual
     // filter validation returns a 404.
     $asset_id = $route_match->getParameter('asset');
     /** @var \Drupal\asset\Entity\AssetInterface|null $asset */
-    $asset = $this->assetStorage->load($asset_id);
+    $asset = $asset_storage->load($asset_id);
     if (is_null($asset)) {
       return AccessResult::allowed();
     }
@@ -60,7 +63,7 @@ class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
 
     // Run a count query to see if there are any assets that reference this
     // asset as a parent.
-    $count = $this->assetStorage->getAggregateQuery()
+    $count = $asset_storage->getAggregateQuery()
       ->accessCheck(TRUE)
       ->condition('parent.entity.id', $asset_id)
       ->count()

--- a/modules/core/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
@@ -29,14 +29,6 @@ class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
    */
   protected $assetLocation;
 
-  /**
-   * FarmAssetChildrenViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   The asset location service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
     $this->assetStorage = $entity_type_manager->getStorage('asset');
     $this->assetLocation = $asset_location;

--- a/modules/core/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetChildrenViewsAccessCheck.php
@@ -15,24 +15,10 @@ use Drupal\farm_location\AssetLocationInterface;
  */
 class FarmAssetChildrenViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->assetLocation = $asset_location;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AssetLocationInterface $assetLocation,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
@@ -28,12 +28,6 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
    */
   protected $logStorage;
 
-  /**
-   * FarmAssetLogViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->assetStorage = $entity_type_manager->getStorage('asset');
     $this->logStorage = $entity_type_manager->getStorage('log');

--- a/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
@@ -15,22 +15,14 @@ use Drupal\Core\Routing\RouteMatchInterface;
 class FarmAssetLogViewsAccessCheck implements AccessInterface {
 
   /**
-   * The asset storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetStorage;
-
-  /**
-   * The log storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $logStorage;
+  protected $entityTypeManager;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->assetStorage = $entity_type_manager->getStorage('asset');
-    $this->logStorage = $entity_type_manager->getStorage('log');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -46,7 +38,7 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
     // filter validation returns a 404.
     $asset_id = $route_match->getParameter('asset');
     /** @var \Drupal\asset\Entity\AssetInterface|null $asset */
-    $asset = $this->assetStorage->load($asset_id);
+    $asset = $this->entityTypeManager->getStorage('asset')->load($asset_id);
     if (is_null($asset)) {
       return AccessResult::allowed();
     }
@@ -59,7 +51,7 @@ class FarmAssetLogViewsAccessCheck implements AccessInterface {
     }
 
     // Build a count query for logs of this type.
-    $query = $this->logStorage->getAggregateQuery()
+    $query = $this->entityTypeManager->getStorage('log')->getAggregateQuery()
       ->accessCheck(TRUE)
       ->condition('type', $log_type)
       ->count();

--- a/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmAssetLogViewsAccessCheck.php
@@ -14,16 +14,9 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 class FarmAssetLogViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/ui/views/src/Access/FarmInventoryAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmInventoryAssetViewsAccessCheck.php
@@ -15,14 +15,14 @@ use Drupal\Core\Routing\RouteMatchInterface;
 class FarmInventoryAssetViewsAccessCheck implements AccessInterface {
 
   /**
-   * The asset storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetStorage;
+  protected $entityTypeManager;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->assetStorage = $entity_type_manager->getStorage('asset');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -38,7 +38,7 @@ class FarmInventoryAssetViewsAccessCheck implements AccessInterface {
     // filter validation returns a 404.
     $asset_id = $route_match->getParameter('asset');
     /** @var \Drupal\asset\Entity\AssetInterface|null $asset */
-    $asset = $this->assetStorage->load($asset_id);
+    $asset = $this->entityTypeManager->getStorage('asset')->load($asset_id);
     if (is_null($asset)) {
       return AccessResult::allowed();
     }

--- a/modules/core/ui/views/src/Access/FarmInventoryAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmInventoryAssetViewsAccessCheck.php
@@ -21,12 +21,6 @@ class FarmInventoryAssetViewsAccessCheck implements AccessInterface {
    */
   protected $assetStorage;
 
-  /**
-   * FarmInventoryAssetViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->assetStorage = $entity_type_manager->getStorage('asset');
   }

--- a/modules/core/ui/views/src/Access/FarmInventoryAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmInventoryAssetViewsAccessCheck.php
@@ -14,16 +14,9 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 class FarmInventoryAssetViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
@@ -16,11 +16,11 @@ use Drupal\farm_location\AssetLocationInterface;
 class FarmLocationAssetViewsAccessCheck implements AccessInterface {
 
   /**
-   * The asset storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetStorage;
+  protected $entityTypeManager;
 
   /**
    * The asset location service.
@@ -30,7 +30,7 @@ class FarmLocationAssetViewsAccessCheck implements AccessInterface {
   protected $assetLocation;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
-    $this->assetStorage = $entity_type_manager->getStorage('asset');
+    $this->entityTypeManager = $entity_type_manager;
     $this->assetLocation = $asset_location;
   }
 
@@ -47,7 +47,7 @@ class FarmLocationAssetViewsAccessCheck implements AccessInterface {
     // filter validation returns a 404.
     $asset_id = $route_match->getParameter('asset');
     /** @var \Drupal\asset\Entity\AssetInterface|null $asset */
-    $asset = $this->assetStorage->load($asset_id);
+    $asset = $this->entityTypeManager->getStorage('asset')->load($asset_id);
     if (is_null($asset)) {
       return AccessResult::allowed();
     }

--- a/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
@@ -15,24 +15,10 @@ use Drupal\farm_location\AssetLocationInterface;
  */
 class FarmLocationAssetViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->assetLocation = $asset_location;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AssetLocationInterface $assetLocation,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmLocationAssetViewsAccessCheck.php
@@ -29,14 +29,6 @@ class FarmLocationAssetViewsAccessCheck implements AccessInterface {
    */
   protected $assetLocation;
 
-  /**
-   * FarmLocationAssetViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   The asset location service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, AssetLocationInterface $asset_location) {
     $this->assetStorage = $entity_type_manager->getStorage('asset');
     $this->assetLocation = $asset_location;

--- a/modules/core/ui/views/src/Access/FarmOrganizationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmOrganizationAssetViewsAccessCheck.php
@@ -14,16 +14,9 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 class FarmOrganizationAssetViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/ui/views/src/Access/FarmOrganizationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmOrganizationAssetViewsAccessCheck.php
@@ -15,22 +15,14 @@ use Drupal\Core\Routing\RouteMatchInterface;
 class FarmOrganizationAssetViewsAccessCheck implements AccessInterface {
 
   /**
-   * The asset storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $assetStorage;
-
-  /**
-   * The organization storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $organizationStorage;
+  protected $entityTypeManager;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->assetStorage = $entity_type_manager->getStorage('asset');
-    $this->organizationStorage = $entity_type_manager->getStorage('organization');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -46,7 +38,7 @@ class FarmOrganizationAssetViewsAccessCheck implements AccessInterface {
     // contextual filter validation returns a 404.
     $organization_id = $route_match->getParameter('organization');
     /** @var \Drupal\organization\Entity\OrganizationInterface|null $organization */
-    $organization = $this->organizationStorage->load($organization_id);
+    $organization = $this->entityTypeManager->getStorage('organization')->load($organization_id);
     if (is_null($organization)) {
       return AccessResult::allowed();
     }
@@ -60,7 +52,7 @@ class FarmOrganizationAssetViewsAccessCheck implements AccessInterface {
 
     // Build a count query for asset of this type.
     // Only include assets that reference the organization.
-    $query = $this->assetStorage->getAggregateQuery()
+    $query = $this->entityTypeManager->getStorage('asset')->getAggregateQuery()
       ->accessCheck(TRUE)
       ->condition('type', $asset_type)
       ->condition('farm.entity.id', $organization_id)

--- a/modules/core/ui/views/src/Access/FarmOrganizationAssetViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmOrganizationAssetViewsAccessCheck.php
@@ -28,12 +28,6 @@ class FarmOrganizationAssetViewsAccessCheck implements AccessInterface {
    */
   protected $organizationStorage;
 
-  /**
-   * FarmOrganizationAssetViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->assetStorage = $entity_type_manager->getStorage('asset');
     $this->organizationStorage = $entity_type_manager->getStorage('organization');

--- a/modules/core/ui/views/src/Access/FarmOrganizationLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmOrganizationLogViewsAccessCheck.php
@@ -14,16 +14,9 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 class FarmOrganizationLogViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * A custom access check.

--- a/modules/core/ui/views/src/Access/FarmOrganizationLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmOrganizationLogViewsAccessCheck.php
@@ -15,22 +15,14 @@ use Drupal\Core\Routing\RouteMatchInterface;
 class FarmOrganizationLogViewsAccessCheck implements AccessInterface {
 
   /**
-   * The log storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $logStorage;
-
-  /**
-   * The organization storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $organizationStorage;
+  protected $entityTypeManager;
 
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->logStorage = $entity_type_manager->getStorage('log');
-    $this->organizationStorage = $entity_type_manager->getStorage('organization');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -46,7 +38,7 @@ class FarmOrganizationLogViewsAccessCheck implements AccessInterface {
     // contextual filter validation returns a 404.
     $organization_id = $route_match->getParameter('organization');
     /** @var \Drupal\organization\Entity\OrganizationInterface|null $organization */
-    $organization = $this->organizationStorage->load($organization_id);
+    $organization = $this->entityTypeManager->getStorage('organization')->load($organization_id);
     if (is_null($organization)) {
       return AccessResult::allowed();
     }
@@ -59,7 +51,7 @@ class FarmOrganizationLogViewsAccessCheck implements AccessInterface {
     }
 
     // Build a count query for logs of this type.
-    $query = $this->logStorage->getAggregateQuery()
+    $query = $this->entityTypeManager->getStorage('log')->getAggregateQuery()
       ->accessCheck(TRUE)
       ->condition('type', $log_type)
       ->count();

--- a/modules/core/ui/views/src/Access/FarmOrganizationLogViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmOrganizationLogViewsAccessCheck.php
@@ -28,12 +28,6 @@ class FarmOrganizationLogViewsAccessCheck implements AccessInterface {
    */
   protected $organizationStorage;
 
-  /**
-   * FarmOrganizationAssetViewsAccessCheck constructor.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->logStorage = $entity_type_manager->getStorage('log');
     $this->organizationStorage = $entity_type_manager->getStorage('organization');

--- a/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
@@ -24,11 +24,11 @@ class FarmTaxonomyTermEntityViewsAccessCheck implements AccessInterface {
   protected $baseEntityType;
 
   /**
-   * The taxonomy term storage.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $taxonomyTermStorage;
+  protected $entityTypeManager;
 
   /**
    * The entity type bundle info.
@@ -46,7 +46,7 @@ class FarmTaxonomyTermEntityViewsAccessCheck implements AccessInterface {
 
   public function __construct(string $base_entity_type, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info, EntityFieldManagerInterface $entity_field_manager) {
     $this->baseEntityType = $base_entity_type;
-    $this->taxonomyTermStorage = $entity_type_manager->getStorage('taxonomy_term');
+    $this->entityTypeManager = $entity_type_manager;
     $this->entityTypeBundleInfo = $entity_bundle_info;
     $this->entityFieldManager = $entity_field_manager;
   }
@@ -64,7 +64,7 @@ class FarmTaxonomyTermEntityViewsAccessCheck implements AccessInterface {
     // filter validation returns a 404.
     $term_id = $route_match->getParameter('taxonomy_term');
     /** @var \Drupal\taxonomy\TermInterface|null $term */
-    $term = $this->taxonomyTermStorage->load($term_id);
+    $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($term_id);
     if (is_null($term)) {
       return AccessResult::allowed();
     }

--- a/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
@@ -44,18 +44,6 @@ class FarmTaxonomyTermEntityViewsAccessCheck implements AccessInterface {
    */
   protected $entityFieldManager;
 
-  /**
-   * FarmTaxonomyTermEntityViewsAccessCheck constructor.
-   *
-   * @param string $base_entity_type
-   *   The base entity type of the views this access check will be applied to.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_bundle_info
-   *   The entity type bundle info service.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager service.
-   */
   public function __construct(string $base_entity_type, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info, EntityFieldManagerInterface $entity_field_manager) {
     $this->baseEntityType = $base_entity_type;
     $this->taxonomyTermStorage = $entity_type_manager->getStorage('taxonomy_term');

--- a/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
+++ b/modules/core/ui/views/src/Access/FarmTaxonomyTermEntityViewsAccessCheck.php
@@ -16,40 +16,12 @@ use Drupal\Core\Routing\RouteMatchInterface;
  */
 class FarmTaxonomyTermEntityViewsAccessCheck implements AccessInterface {
 
-  /**
-   * The base entity type of the views this access check will be applied to.
-   *
-   * @var string
-   */
-  protected $baseEntityType;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity type bundle info.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  /**
-   * The entity field manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
-  public function __construct(string $base_entity_type, EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info, EntityFieldManagerInterface $entity_field_manager) {
-    $this->baseEntityType = $base_entity_type;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityTypeBundleInfo = $entity_bundle_info;
-    $this->entityFieldManager = $entity_field_manager;
-  }
+  public function __construct(
+    protected string $baseEntityType,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+    protected EntityFieldManagerInterface $entityFieldManager,
+  ) {}
 
   /**
    * A custom access check to filter out irrelevant entity bundles.

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
@@ -24,12 +24,6 @@ class FarmLogViewsTaskLink extends DeriverBase implements ContainerDeriverInterf
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a FarmActions object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
@@ -17,16 +17,9 @@ class FarmLogViewsTaskLink extends DeriverBase implements ContainerDeriverInterf
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmOrganizationViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmOrganizationViewsTaskLink.php
@@ -24,12 +24,6 @@ class FarmOrganizationViewsTaskLink extends DeriverBase implements ContainerDeri
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a FarmActions object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmOrganizationViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmOrganizationViewsTaskLink.php
@@ -17,16 +17,9 @@ class FarmOrganizationViewsTaskLink extends DeriverBase implements ContainerDeri
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -32,14 +32,6 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
    */
   protected $entityTypeBundleInfo;
 
-  /**
-   * Constructs a FarmTaxonomyTermViewsTaskLink instance.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_bundle_info
-   *   The entity type bundle info service.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info) {
     $this->entityTypeManager = $entity_type_manager;
     $this->entityTypeBundleInfo = $entity_bundle_info;

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -18,24 +18,10 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
 
   use StringTranslationTrait;
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity type bundle info.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, EntityTypeBundleInfoInterface $entity_bundle_info) {
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityTypeBundleInfo = $entity_bundle_info;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
@@ -37,14 +37,6 @@ class FarmViewsMenuLink extends ViewsMenuLink {
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a FarmActions object.
-   *
-   * @param \Drupal\Core\Entity\EntityStorageInterface $view_storage
-   *   The view storage.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   */
   public function __construct(EntityStorageInterface $view_storage, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($view_storage);
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
@@ -30,16 +30,11 @@ class FarmViewsMenuLink extends ViewsMenuLink {
    */
   protected string $viewId;
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityStorageInterface $view_storage, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(
+    EntityStorageInterface $view_storage,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
     parent::__construct($view_storage);
-    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**

--- a/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
@@ -8,7 +8,6 @@ use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
-use Drupal\taxonomy\TermStorageInterface;
 use Drupal\views\Attribute\ViewsArgument;
 use Drupal\views\Plugin\views\argument\NumericArgument;
 use Drupal\views\Plugin\views\query\Sql;
@@ -23,46 +22,25 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 #[ViewsArgument("entity_taxonomy_term_reference")]
 class EntityTaxonomyTermReferenceArgument extends NumericArgument {
 
-  /**
-   * The entity type manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The entity type bundle info.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeBundleInfoInterface
-   */
-  protected $entityTypeBundleInfo;
-
-  /**
-   * The entity field manager service.
-   *
-   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
-   */
-  protected $entityFieldManager;
-
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    EntityTypeManagerInterface $entity_type_manager,
-    EntityTypeBundleInfoInterface $entity_bundle_info,
-    EntityFieldManagerInterface $entity_field_manager,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
+    protected EntityFieldManagerInterface $entityFieldManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->entityTypeManager = $entity_type_manager;
-    $this->entityTypeBundleInfo = $entity_bundle_info;
-    $this->entityFieldManager = $entity_field_manager;
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static($configuration, $plugin_id, $plugin_definition,
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('entity_type.bundle.info'),
       $container->get('entity_field.manager'));

--- a/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
@@ -51,24 +51,6 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
    */
   protected $entityFieldManager;
 
-  /**
-   * EntityTaxonomyTermReferenceArgument constructor.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\taxonomy\TermStorageInterface $term_storage
-   *   The taxonomy term storage service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_bundle_info
-   *   The entity type bundle info service.
-   * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
-   *   The entity field manager service.
-   */
   public function __construct(
     array $configuration,
     $plugin_id,

--- a/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
@@ -24,13 +24,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class EntityTaxonomyTermReferenceArgument extends NumericArgument {
 
   /**
-   * The taxonomy term storage.
-   *
-   * @var \Drupal\taxonomy\TermStorageInterface
-   */
-  protected $termStorage;
-
-  /**
    * The entity type manager service.
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
@@ -55,13 +48,11 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
     array $configuration,
     $plugin_id,
     $plugin_definition,
-    TermStorageInterface $term_storage,
     EntityTypeManagerInterface $entity_type_manager,
     EntityTypeBundleInfoInterface $entity_bundle_info,
     EntityFieldManagerInterface $entity_field_manager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->termStorage = $term_storage;
     $this->entityTypeManager = $entity_type_manager;
     $this->entityTypeBundleInfo = $entity_bundle_info;
     $this->entityFieldManager = $entity_field_manager;
@@ -72,7 +63,6 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static($configuration, $plugin_id, $plugin_definition,
-      $container->get('entity_type.manager')->getStorage('taxonomy_term'),
       $container->get('entity_type.manager'),
       $container->get('entity_type.bundle.info'),
       $container->get('entity_field.manager'));
@@ -99,7 +89,7 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
       return;
     }
 
-    $term = $this->termStorage->load($term_id);
+    $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($term_id);
 
     // This is a value like 'asset' or 'log'.
     $base_entity_type = $this->view->getBaseEntityType()->id();

--- a/modules/core/update/src/Drush/Commands/FarmUpdateCommands.php
+++ b/modules/core/update/src/Drush/Commands/FarmUpdateCommands.php
@@ -19,9 +19,6 @@ final class FarmUpdateCommands extends DrushCommands {
 
   use AutowireTrait;
 
-  /**
-   * Constructs a FarmUpdateCommands object.
-   */
   public function __construct(
     #[Autowire(service: 'farm.update')]
     private readonly FarmUpdateInterface $farmUpdate,

--- a/modules/core/update/src/FarmUpdate.php
+++ b/modules/core/update/src/FarmUpdate.php
@@ -22,64 +22,15 @@ class FarmUpdate implements FarmUpdateInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * The logger.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $logger;
-
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * The entity manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityManager;
-
-  /**
-   * The config factory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
-   * The config differ.
-   *
-   * @var \Drupal\config_update\ConfigDiffer
-   */
-  protected $configDiff;
-
-  /**
-   * The config lister.
-   *
-   * @var \Drupal\config_update\ConfigListerWithProviders
-   */
-  protected $configList;
-
-  /**
-   * The config reverter.
-   *
-   * @var \Drupal\config_update\ConfigReverter
-   */
-  protected $configUpdate;
-
-  public function __construct(LoggerInterface $logger, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_manager, ConfigFactoryInterface $config_factory, ConfigDiffer $config_diff, ConfigListerWithProviders $config_list, ConfigReverter $config_update) {
-    $this->logger = $logger;
-    $this->moduleHandler = $module_handler;
-    $this->entityManager = $entity_manager;
-    $this->configFactory = $config_factory;
-    $this->configDiff = $config_diff;
-    $this->configList = $config_list;
-    $this->configUpdate = $config_update;
-  }
+  public function __construct(
+    protected LoggerInterface $logger,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected ConfigFactoryInterface $configFactory,
+    protected ConfigDiffer $configDiff,
+    protected ConfigListerWithProviders $configList,
+    protected ConfigReverter $configUpdate,
+  ) {}
 
   /**
    * {@inheritdoc}
@@ -206,7 +157,7 @@ class FarmUpdate implements FarmUpdateInterface {
     $shortname = $name;
     if ($type != 'system.simple') {
       /** @var \Drupal\Core\Config\Entity\ConfigEntityTypeInterface $definition */
-      $definition = $this->entityManager->getDefinition($type);
+      $definition = $this->entityTypeManager->getDefinition($type);
       $prefix = $definition->getConfigPrefix() . '.';
       if (str_starts_with($name, $prefix)) {
         $shortname = substr($name, strlen($prefix));

--- a/modules/core/update/src/FarmUpdate.php
+++ b/modules/core/update/src/FarmUpdate.php
@@ -71,24 +71,6 @@ class FarmUpdate implements FarmUpdateInterface {
    */
   protected $configUpdate;
 
-  /**
-   * Constructs a FarmUpdate object.
-   *
-   * @param \Psr\Log\LoggerInterface $logger
-   *   The logger.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory.
-   * @param \Drupal\config_update\ConfigDiffer $config_diff
-   *   The config differ.
-   * @param \Drupal\config_update\ConfigListerWithProviders $config_list
-   *   The config lister.
-   * @param \Drupal\config_update\ConfigReverter $config_update
-   *   The config reverter.
-   */
   public function __construct(LoggerInterface $logger, ModuleHandlerInterface $module_handler, EntityTypeManagerInterface $entity_manager, ConfigFactoryInterface $config_factory, ConfigDiffer $config_diff, ConfigListerWithProviders $config_list, ConfigReverter $config_update) {
     $this->logger = $logger;
     $this->moduleHandler = $module_handler;

--- a/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
@@ -23,12 +23,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
    */
   protected $messenger;
 
-  /**
-   * MyModuleService constructor.
-   *
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   */
   public function __construct(MessengerInterface $messenger) {
     $this->messenger = $messenger;
   }

--- a/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
@@ -16,16 +16,9 @@ class LogEventSubscriber implements EventSubscriberInterface {
 
   use StringTranslationTrait;
 
-  /**
-   * The Messenger service.
-   *
-   * @var \Drupal\Core\Messenger\MessengerInterface
-   */
-  protected $messenger;
-
-  public function __construct(MessengerInterface $messenger) {
-    $this->messenger = $messenger;
-  }
+  public function __construct(
+    protected MessengerInterface $messenger,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
+++ b/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
@@ -15,16 +15,9 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class UniqueBirthLogConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
-    $this->entityTypeManager = $entity_type_manager;
-  }
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
+++ b/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
@@ -22,12 +22,6 @@ class UniqueBirthLogConstraintValidator extends ConstraintValidator implements C
    */
   protected $entityTypeManager;
 
-  /**
-   * Constructs a UniqueBirthLogConstraintValidator object.
-   *
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   */
   public function __construct(EntityTypeManagerInterface $entity_type_manager) {
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/modules/organization/farm/src/Form/AssetFarmActionForm.php
+++ b/modules/organization/farm/src/Form/AssetFarmActionForm.php
@@ -21,27 +21,6 @@ use Symfony\Component\HttpFoundation\Request;
 class AssetFarmActionForm extends ConfirmFormBase {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface|null
@@ -55,19 +34,12 @@ class AssetFarmActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  /**
-   * The current Request object.
-   *
-   * @var \Symfony\Component\HttpFoundation\Request
-   */
-  protected $request;
-
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->user = $user;
-    $this->request = $request;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountInterface $user,
+    protected Request $request,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/organization/farm/src/Form/AssetFarmActionForm.php
+++ b/modules/organization/farm/src/Form/AssetFarmActionForm.php
@@ -62,18 +62,6 @@ class AssetFarmActionForm extends ConfirmFormBase {
    */
   protected $request;
 
-  /**
-   * Constructs an AssetFarmActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The current Request object.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
     $this->tempStore = $temp_store_factory->get('asset_farm_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/organization/farm/src/Form/AssetFarmActionForm.php
+++ b/modules/organization/farm/src/Form/AssetFarmActionForm.php
@@ -21,11 +21,11 @@ use Symfony\Component\HttpFoundation\Request;
 class AssetFarmActionForm extends ConfirmFormBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -63,7 +63,7 @@ class AssetFarmActionForm extends ConfirmFormBase {
   protected $request;
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, Request $request) {
-    $this->tempStore = $temp_store_factory->get('asset_farm_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->user = $user;
     $this->request = $request;
@@ -137,7 +137,7 @@ class AssetFarmActionForm extends ConfirmFormBase {
     }
     // Else load entities from the tempStore state.
     else {
-      $this->entities = $this->tempStore->get((string) $this->user->id());
+      $this->entities = $this->tempStoreFactory->get('asset_farm_confirm')->get((string) $this->user->id());
     }
 
     $this->entityType = $this->entityTypeManager->getDefinition('asset', FALSE);
@@ -237,7 +237,7 @@ class AssetFarmActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete((string) $this->currentUser()->id());
+    $this->tempStoreFactory->get('asset_farm_confirm')->delete((string) $this->currentUser()->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/organization/farm/src/Plugin/Action/AssetFarm.php
+++ b/modules/organization/farm/src/Plugin/Action/AssetFarm.php
@@ -37,22 +37,6 @@ class AssetFarm extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new AssetFarm object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
     $this->tempStore = $temp_store_factory->get('asset_farm_confirm');

--- a/modules/organization/farm/src/Plugin/Action/AssetFarm.php
+++ b/modules/organization/farm/src/Plugin/Action/AssetFarm.php
@@ -23,23 +23,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class AssetFarm extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 

--- a/modules/organization/farm/src/Plugin/Action/AssetFarm.php
+++ b/modules/organization/farm/src/Plugin/Action/AssetFarm.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AssetFarm extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class AssetFarm extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('asset_farm_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 
@@ -62,7 +62,7 @@ class AssetFarm extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set((string) $this->currentUser->id(), $entities);
+    $this->tempStoreFactory->get('asset_farm_confirm')->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -9,7 +9,6 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -70,8 +69,8 @@ class Birth extends QuickFormBase {
    */
   protected $groupMembership = NULL;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, ?GroupMembershipInterface $group_membership = NULL) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, ?GroupMembershipInterface $group_membership = NULL) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
     $this->moduleHandler = $module_handler;
     $this->configFactory = $config_factory;
     $this->assetLocation = $asset_location;
@@ -88,7 +87,6 @@ class Birth extends QuickFormBase {
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('config.factory'),
       $container->get('asset.location'),

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -70,30 +70,6 @@ class Birth extends QuickFormBase {
    */
   protected $groupMembership = NULL;
 
-  /**
-   * Constructs a QuickFormBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   Asset location service.
-   * @param \Drupal\farm_group\GroupMembershipInterface|null $group_membership
-   *   Group membership service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, ?GroupMembershipInterface $group_membership = NULL) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->moduleHandler = $module_handler;

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -41,40 +41,18 @@ class Birth extends QuickFormBase {
   use QuickLogTrait;
   use QuickStringTrait;
 
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * The config factory service.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  /**
-   * Asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  /**
-   * Group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface|null
-   */
-  protected $groupMembership = NULL;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, ModuleHandlerInterface $module_handler, ConfigFactoryInterface $config_factory, AssetLocationInterface $asset_location, ?GroupMembershipInterface $group_membership = NULL) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountInterface $current_user,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected ConfigFactoryInterface $configFactory,
+    protected AssetLocationInterface $assetLocation,
+    protected ?GroupMembershipInterface $groupMembership = NULL,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-    $this->moduleHandler = $module_handler;
-    $this->configFactory = $config_factory;
-    $this->assetLocation = $asset_location;
-    $this->groupMembership = $group_membership;
   }
 
   /**

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -48,24 +48,6 @@ class Group extends QuickFormBase implements QuickFormInterface {
    */
   protected $groupMembership;
 
-  /**
-   * Constructs a QuickFormBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   * @param \Drupal\farm_group\GroupMembershipInterface $group_membership
-   *   Group membership service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, GroupMembershipInterface $group_membership) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->groupMembership = $group_membership;

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_quick_group\Plugin\QuickForm;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -48,8 +47,8 @@ class Group extends QuickFormBase implements QuickFormInterface {
    */
   protected $groupMembership;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, GroupMembershipInterface $group_membership) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, GroupMembershipInterface $group_membership) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
     $this->groupMembership = $group_membership;
   }
 
@@ -63,7 +62,6 @@ class Group extends QuickFormBase implements QuickFormInterface {
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('messenger'),
       $container->get('group.membership'),
     );
   }

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -40,16 +40,15 @@ class Group extends QuickFormBase implements QuickFormInterface {
   use QuickPrepopulateTrait;
   use QuickStringTrait;
 
-  /**
-   * Group membership service.
-   *
-   * @var \Drupal\farm_group\GroupMembershipInterface
-   */
-  protected $groupMembership;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, GroupMembershipInterface $group_membership) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountInterface $current_user,
+    protected GroupMembershipInterface $groupMembership,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-    $this->groupMembership = $group_membership;
   }
 
   /**

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -8,7 +8,6 @@ use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -49,8 +48,8 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
    */
   protected $assetInventory;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, AssetInventoryInterface $asset_inventory) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, AssetInventoryInterface $asset_inventory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
     $this->assetInventory = $asset_inventory;
   }
 
@@ -64,7 +63,6 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('messenger'),
       $container->get('asset.inventory'),
     );
   }

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -49,24 +49,6 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
    */
   protected $assetInventory;
 
-  /**
-   * Constructs a QuickFormBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   * @param \Drupal\farm_inventory\AssetInventoryInterface $asset_inventory
-   *   Asset inventory service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, AssetInventoryInterface $asset_inventory) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->assetInventory = $asset_inventory;

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -41,16 +41,15 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
   use QuickFormElementsTrait;
   use QuickTermTrait;
 
-  /**
-   * Asset inventory service.
-   *
-   * @var \Drupal\farm_inventory\AssetInventoryInterface
-   */
-  protected $assetInventory;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, AssetInventoryInterface $asset_inventory) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountInterface $current_user,
+    protected AssetInventoryInterface $assetInventory,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-    $this->assetInventory = $asset_inventory;
   }
 
   /**

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -50,24 +50,6 @@ class Movement extends QuickFormBase implements QuickFormInterface {
    */
   protected $assetLocation;
 
-  /**
-   * Constructs a QuickFormBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   * @param \Drupal\farm_location\AssetLocationInterface $asset_location
-   *   Asset location service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, AssetLocationInterface $asset_location) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->assetLocation = $asset_location;

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_quick_movement\Plugin\QuickForm;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
@@ -50,8 +49,8 @@ class Movement extends QuickFormBase implements QuickFormInterface {
    */
   protected $assetLocation;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, AssetLocationInterface $asset_location) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, AssetLocationInterface $asset_location) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
     $this->assetLocation = $asset_location;
   }
 
@@ -65,7 +64,6 @@ class Movement extends QuickFormBase implements QuickFormInterface {
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('messenger'),
       $container->get('asset.location'),
     );
   }

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -42,16 +42,15 @@ class Movement extends QuickFormBase implements QuickFormInterface {
   use QuickStringTrait;
   use WktTrait;
 
-  /**
-   * Asset location service.
-   *
-   * @var \Drupal\farm_location\AssetLocationInterface
-   */
-  protected $assetLocation;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, AssetLocationInterface $asset_location) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountInterface $current_user,
+    protected AssetLocationInterface $assetLocation,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-    $this->assetLocation = $asset_location;
   }
 
   /**

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -8,7 +8,6 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\State\StateInterface;
@@ -59,8 +58,8 @@ class Planting extends QuickFormBase {
    */
   protected $state;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, StateInterface $state) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, ModuleHandlerInterface $module_handler, StateInterface $state) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
     $this->moduleHandler = $module_handler;
     $this->state = $state;
   }
@@ -75,7 +74,6 @@ class Planting extends QuickFormBase {
       $plugin_definition,
       $container->get('entity_type.manager'),
       $container->get('current_user'),
-      $container->get('messenger'),
       $container->get('module_handler'),
       $container->get('state'),
     );

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -44,24 +44,16 @@ class Planting extends QuickFormBase {
   use QuickStringTrait;
   use QuickFormElementsTrait;
 
-  /**
-   * The module handler.
-   *
-   * @var \Drupal\Core\Extension\ModuleHandlerInterface
-   */
-  protected $moduleHandler;
-
-  /**
-   * The state service.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected $state;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, ModuleHandlerInterface $module_handler, StateInterface $state) {
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    AccountInterface $current_user,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected StateInterface $state,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-    $this->moduleHandler = $module_handler;
-    $this->state = $state;
   }
 
   /**

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -59,26 +59,6 @@ class Planting extends QuickFormBase {
    */
   protected $state;
 
-  /**
-   * Constructs a QuickFormBase object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin_id for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager service.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user object.
-   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
-   *   The messenger service.
-   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   The module handler.
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state service.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AccountInterface $current_user, MessengerInterface $messenger, ModuleHandlerInterface $module_handler, StateInterface $state) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user, $messenger);
     $this->moduleHandler = $module_handler;

--- a/modules/role/account_admin/src/AccountAdminPermissions.php
+++ b/modules/role/account_admin/src/AccountAdminPermissions.php
@@ -15,24 +15,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class AccountAdminPermissions implements ContainerInjectionInterface {
 
-  /**
-   * The managed role permissions manager.
-   *
-   * @var \Drupal\farm_role\ManagedRolePermissionsManagerInterface
-   */
-  protected $managedRolePermissionsManager;
-
-  /**
-   * The config factory service.
-   *
-   * @var \Drupal\Core\Config\ConfigFactoryInterface
-   */
-  protected $configFactory;
-
-  public function __construct(ManagedRolePermissionsManagerInterface $managed_role_permissions_manager, ConfigFactoryInterface $config_factory) {
-    $this->managedRolePermissionsManager = $managed_role_permissions_manager;
-    $this->configFactory = $config_factory;
-  }
+  public function __construct(
+    protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
+    protected ConfigFactoryInterface $configFactory,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/role/account_admin/src/AccountAdminPermissions.php
+++ b/modules/role/account_admin/src/AccountAdminPermissions.php
@@ -29,14 +29,6 @@ class AccountAdminPermissions implements ContainerInjectionInterface {
    */
   protected $configFactory;
 
-  /**
-   * Constructs an AccountAdminPermissions object.
-   *
-   * @param \Drupal\farm_role\ManagedRolePermissionsManagerInterface $managed_role_permissions_manager
-   *   The managed role permissions manager.
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The config factory service.
-   */
   public function __construct(ManagedRolePermissionsManagerInterface $managed_role_permissions_manager, ConfigFactoryInterface $config_factory) {
     $this->managedRolePermissionsManager = $managed_role_permissions_manager;
     $this->configFactory = $config_factory;

--- a/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
+++ b/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
@@ -29,14 +29,6 @@ class AccountAdminSettingsForm extends ConfigFormbase {
    */
   protected $cacheTagsInvalidator;
 
-  /**
-   * Constructs a \Drupal\system\ConfigFormBase object.
-   *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The factory for configuration objects.
-   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
-   *   The cache tags invalidator.
-   */
   public function __construct(ConfigFactoryInterface $config_factory, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
     $this->setConfigFactory($config_factory);
     $this->cacheTagsInvalidator = $cache_tags_invalidator;

--- a/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
+++ b/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
@@ -23,16 +23,12 @@ class AccountAdminSettingsForm extends ConfigFormbase {
    */
   const SETTINGS = 'farm_account_admin.settings';
 
-  /**
-   * The cache tags invalidator.
-   *
-   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
-   */
-  protected $cacheTagsInvalidator;
-
-  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config_manager, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+  public function __construct(
+    ConfigFactoryInterface $config_factory,
+    TypedConfigManagerInterface $typed_config_manager,
+    protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
+  ) {
     parent::__construct($config_factory, $typed_config_manager);
-    $this->cacheTagsInvalidator = $cache_tags_invalidator;
   }
 
   /**

--- a/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
+++ b/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_account_admin\Form;
 
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -29,8 +30,8 @@ class AccountAdminSettingsForm extends ConfigFormbase {
    */
   protected $cacheTagsInvalidator;
 
-  public function __construct(ConfigFactoryInterface $config_factory, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
-    $this->setConfigFactory($config_factory);
+  public function __construct(ConfigFactoryInterface $config_factory, TypedConfigManagerInterface $typed_config_manager, CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+    parent::__construct($config_factory, $typed_config_manager);
     $this->cacheTagsInvalidator = $cache_tags_invalidator;
   }
 
@@ -40,6 +41,7 @@ class AccountAdminSettingsForm extends ConfigFormbase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('config.factory'),
+      $container->get('config.typed'),
       $container->get('cache_tags.invalidator'),
     );
   }

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -54,16 +54,6 @@ class LogCategorizeActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  /**
-   * Constructs a LogCategorizeActionForm form object.
-   *
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\Session\AccountInterface $user
-   *   The current user.
-   */
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user) {
     $this->tempStore = $temp_store_factory->get('log_categorize_confirm');
     $this->entityTypeManager = $entity_type_manager;

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -20,11 +20,11 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class LogCategorizeActionForm extends ConfirmFormBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The entity type manager.
@@ -55,7 +55,7 @@ class LogCategorizeActionForm extends ConfirmFormBase {
   protected $entities;
 
   public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user) {
-    $this->tempStore = $temp_store_factory->get('log_categorize_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->user = $user;
   }
@@ -112,7 +112,7 @@ class LogCategorizeActionForm extends ConfirmFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
     $this->entityType = $this->entityTypeManager->getDefinition('log', FALSE);
-    $this->entities = $this->tempStore->get((string) $this->user->id());
+    $this->entities = $this->tempStoreFactory->get('log_categorize_confirm')->get((string) $this->user->id());
     if (!$this->entityType || empty($this->entities)) {
       return new RedirectResponse($this->getCancelUrl()
         ->setAbsolute()
@@ -226,7 +226,7 @@ class LogCategorizeActionForm extends ConfirmFormBase {
       ]));
     }
 
-    $this->tempStore->delete($this->currentUser()->id() . ':' . $this->entityType->id());
+    $this->tempStoreFactory->get('log_categorize_confirm')->delete($this->currentUser()->id() . ':' . $this->entityType->id());
     $form_state->setRedirectUrl($this->getCancelUrl());
   }
 

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -20,27 +20,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class LogCategorizeActionForm extends ConfirmFormBase {
 
   /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $user;
-
-  /**
    * The entity type.
    *
    * @var \Drupal\Core\Entity\EntityTypeInterface|null
@@ -54,11 +33,11 @@ class LogCategorizeActionForm extends ConfirmFormBase {
    */
   protected $entities;
 
-  public function __construct(PrivateTempStoreFactory $temp_store_factory, EntityTypeManagerInterface $entity_type_manager, AccountInterface $user) {
-    $this->tempStoreFactory = $temp_store_factory;
-    $this->entityTypeManager = $entity_type_manager;
-    $this->user = $user;
-  }
+  public function __construct(
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
+    protected AccountInterface $user,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -37,22 +37,6 @@ class LogCategorize extends EntityActionBase {
    */
   protected $currentUser;
 
-  /**
-   * Constructs a new LogCategorize object.
-   *
-   * @param array $configuration
-   *   A configuration array containing information about the plugin instance.
-   * @param string $plugin_id
-   *   The plugin ID for the plugin instance.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
-   *   The entity type manager.
-   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
-   *   The tempstore factory.
-   * @param \Drupal\Core\Session\AccountInterface $current_user
-   *   Current user.
-   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
     $this->tempStore = $temp_store_factory->get('log_categorize_confirm');

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -24,11 +24,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LogCategorize extends EntityActionBase {
 
   /**
-   * The private temp store.
+   * The private tempstore factory.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStore
+   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
    */
-  protected $tempStore;
+  protected $tempStoreFactory;
 
   /**
    * The current user.
@@ -39,7 +39,7 @@ class LogCategorize extends EntityActionBase {
 
   public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
     $this->currentUser = $current_user;
-    $this->tempStore = $temp_store_factory->get('log_categorize_confirm');
+    $this->tempStoreFactory = $temp_store_factory;
 
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
@@ -63,7 +63,7 @@ class LogCategorize extends EntityActionBase {
    */
   public function executeMultiple(array $entities) {
     /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
-    $this->tempStore->set((string) $this->currentUser->id(), $entities);
+    $this->tempStoreFactory->get('log_categorize_confirm')->set((string) $this->currentUser->id(), $entities);
   }
 
   /**

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -23,24 +23,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class LogCategorize extends EntityActionBase {
 
-  /**
-   * The private tempstore factory.
-   *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
-   */
-  protected $tempStoreFactory;
-
-  /**
-   * The current user.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  protected $currentUser;
-
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
-    $this->currentUser = $current_user;
-    $this->tempStoreFactory = $temp_store_factory;
-
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    protected PrivateTempStoreFactory $tempStoreFactory,
+    protected AccountInterface $currentUser,
+  ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
   }
 

--- a/src/Form/FarmModulesForm.php
+++ b/src/Form/FarmModulesForm.php
@@ -23,12 +23,6 @@ class FarmModulesForm extends FormBase {
    */
   protected $state;
 
-  /**
-   * Constructs a new FarmModulesForm.
-   *
-   * @param \Drupal\Core\State\StateInterface $state
-   *   The state keyvalue collection to use.
-   */
   public function __construct(StateInterface $state) {
     $this->state = $state;
   }

--- a/src/Form/FarmModulesForm.php
+++ b/src/Form/FarmModulesForm.php
@@ -16,16 +16,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FarmModulesForm extends FormBase {
 
-  /**
-   * The state keyvalue collection.
-   *
-   * @var \Drupal\Core\State\StateInterface
-   */
-  protected $state;
-
-  public function __construct(StateInterface $state) {
-    $this->state = $state;
-  }
+  public function __construct(
+    protected StateInterface $state,
+  ) {}
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
This refactors all of the PHP class constructors in farmOS to make use of PHP 8 constructor property promotion.

https://php.watch/versions/8.0/constructor-property-promotion

Drupal core is in the process of doing the same: https://www.drupal.org/project/drupal/issues/3278431

This also removes docblock comments from all constructors, because they are no longer required by Drupal coding standards. See: https://www.drupal.org/project/coder/issues/3400560

There is one big commit in the middle of this branch (called "Use PHP 8 constructor property promotion.") which makes the actual changes that are the namesake of this PR. The purpose of all of the commits leading up to that are to refactor our constructors to make them as simple as possible, in preparation for using property promotion. All of the commits after are minor cleanups or linting fixes. A Rector rule is also added to ensure future classes use property promotion when possible.