### PR TITLE
Autowire injected service dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ requirements (inherited from Drupal 11):
 - [Allow the "type" base field view display to be configured #990](https://github.com/farmOS/farmOS/pull/990)
 - [Title improvements to entity forms, buttons, and Views #996](https://github.com/farmOS/farmOS/pull/996)
 - [Use PHP 8 constructor property promotion #1005](https://github.com/farmOS/farmOS/pull/1005)
+- [Autowire injected service dependencies #1006](https://github.com/farmOS/farmOS/pull/1006)
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "drupal/entity_reference_revisions": "1.12",
         "drupal/entity_reference_validators": "^2.0",
         "drupal/fraction": "^3.0",
-        "drupal/geofield": "^1.62",
+        "drupal/geofield": "^1.66",
         "drupal/gin": "5.0.3",
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/inspire_tree": "^1.0.6",

--- a/modules/asset/group/farm_group.services.yml
+++ b/modules/asset/group/farm_group.services.yml
@@ -1,13 +1,11 @@
 services:
+  _defaults:
+    autowire: true
   group.membership:
     class: Drupal\farm_group\GroupMembership
-    arguments:
-      [ '@farm.log_query', '@entity_type.manager', '@datetime.time', '@database' ]
   Drupal\farm_group\GroupMembershipInterface: '@group.membership'
   farm_group.log_event_subscriber:
     class: Drupal\farm_group\EventSubscriber\LogEventSubscriber
-    arguments:
-      [ '@cache_tags.invalidator', '@datetime.time', '@group.membership' ]
     tags:
       - { name: 'event_subscriber' }
   farm_group.route_subscriber:
@@ -16,6 +14,5 @@ services:
       - { name: event_subscriber }
   farm_group.group_members_access:
     class: Drupal\farm_group\Access\FarmGroupMembersViewsAccessCheck
-    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: access_check, applies_to: _group_members_access }

--- a/modules/asset/group/farm_group.services.yml
+++ b/modules/asset/group/farm_group.services.yml
@@ -3,6 +3,7 @@ services:
     class: Drupal\farm_group\GroupMembership
     arguments:
       [ '@farm.log_query', '@entity_type.manager', '@datetime.time', '@database' ]
+  Drupal\farm_group\GroupMembershipInterface: '@group.membership'
   farm_group.log_event_subscriber:
     class: Drupal\farm_group\EventSubscriber\LogEventSubscriber
     arguments:

--- a/modules/asset/group/src/FarmGroupServiceProvider.php
+++ b/modules/asset/group/src/FarmGroupServiceProvider.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_group;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceProviderBase;
 use Drupal\Core\DependencyInjection\ServiceProviderInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Override the asset.location service with our own class.
@@ -19,7 +18,6 @@ class FarmGroupServiceProvider extends ServiceProviderBase implements ServicePro
    */
   public function alter(ContainerBuilder $container) {
     $definition = $container->getDefinition('asset.location');
-    $definition->addArgument(new Reference('group.membership'));
     $definition->setClass('Drupal\farm_group\GroupAssetLocation');
   }
 

--- a/modules/asset/group/src/GroupAssetLocation.php
+++ b/modules/asset/group/src/GroupAssetLocation.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_group;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_location\AssetLocation;
@@ -13,12 +14,13 @@ use Drupal\farm_location\AssetLocationInterface;
 use Drupal\farm_location\LogLocationInterface;
 use Drupal\farm_log\LogQueryFactoryInterface;
 use Drupal\log\Entity\LogInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Asset location logic, accounting for group membership.
  */
 class GroupAssetLocation extends AssetLocation implements AssetLocationInterface {
+
+  use AutowireTrait;
 
   public function __construct(
     protected LogLocationInterface $logLocation,
@@ -29,20 +31,6 @@ class GroupAssetLocation extends AssetLocation implements AssetLocationInterface
     protected GroupMembershipInterface $groupMembership,
   ) {
     parent::__construct($logLocation, $logQueryFactory, $entityTypeManager, $time, $database);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('log.location'),
-      $container->get('farm.log_query'),
-      $container->get('entity_type.manager'),
-      $container->get('datetime.time'),
-      $container->get('database'),
-      $container->get('group.membership')
-    );
   }
 
   /**

--- a/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
+++ b/modules/asset/group/src/Plugin/Validation/Constraint/CircularGroupMembershipConstraintValidator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group\Plugin\Validation\Constraint;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_group\GroupMembershipInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -16,18 +16,11 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class CircularGroupMembershipConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
+  use AutowireTrait;
+
   public function __construct(
     protected GroupMembershipInterface $groupMembership,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('group.membership'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/asset/land/farm_land.services.yml
+++ b/modules/asset/land/farm_land.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   farm_land.map_render_event_subscriber:
     class: Drupal\farm_land\EventSubscriber\MapRenderEventSubscriber
-    arguments:
-      [ '@entity_type.manager', '@farm_map.layer_style_loader' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/asset/sensor/src/Controller/SensorDataController.php
+++ b/modules/asset/sensor/src/Controller/SensorDataController.php
@@ -6,11 +6,12 @@ namespace Drupal\farm_sensor\Controller;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\data_stream\DataStreamTypeManager;
 use Drupal\data_stream\Entity\DataStreamInterface;
 use Drupal\jsonapi\Exception\UnprocessableHttpEntityException;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,18 +24,12 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 class SensorDataController extends ControllerBase {
 
+  use AutowireTrait;
+
   public function __construct(
+    #[Autowire(service: 'plugin.manager.data_stream_type')]
     protected DataStreamTypeManager $dataStreamTypeManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.data_stream_type')
-    );
-  }
 
   /**
    * Respond to GET or POST requests referencing sensor assets by UUID.

--- a/modules/asset/structure/farm_structure.services.yml
+++ b/modules/asset/structure/farm_structure.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   farm_structure.map_render_event_subscriber:
     class: Drupal\farm_structure\EventSubscriber\MapRenderEventSubscriber
-    arguments:
-      [ '@entity_type.manager', '@farm_map.layer_style_loader' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/api/farm_api.services.yml
+++ b/modules/core/api/farm_api.services.yml
@@ -1,8 +1,9 @@
 services:
+  _defaults:
+    autowire: true
   # Disable certain JSON:API resource types.
   farm_api.jsonapi_build_subscriber:
     class: Drupal\farm_api\EventSubscriber\JsonApiBuildSubscriber
-    arguments: ['@module_handler']
     tags:
       - { name: event_subscriber }
   # Alter the root /api endpoint to include a meta.farm object.

--- a/modules/core/api/modules/farm_api_oauth/farm_api_oauth.services.yml
+++ b/modules/core/api/modules/farm_api_oauth/farm_api_oauth.services.yml
@@ -1,7 +1,8 @@
 services:
+  _defaults:
+    autowire: true
   # Add CORS headers for allowed origins configured on consumers.
   farm_api_oauth.cors_event_subscriber:
     class: Drupal\farm_api_oauth\EventSubscriber\CorsResponseEventSubscriber
-    arguments: ['@entity_type.manager']
     tags:
       - { name: event_subscriber }

--- a/modules/core/api/src/Controller/FarmEntryPoint.php
+++ b/modules/core/api/src/Controller/FarmEntryPoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_api\Controller;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ProfileExtensionList;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\jsonapi\CacheableResourceResponse;
@@ -12,7 +13,6 @@ use Drupal\jsonapi\JsonApiResource\JsonApiDocumentTopLevel;
 use Drupal\jsonapi\JsonApiResource\NullIncludedData;
 use Drupal\jsonapi\JsonApiResource\ResourceObjectData;
 use Drupal\jsonapi\ResourceType\ResourceTypeRepositoryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Extend the core jsonapi EntryPoint controller.
@@ -31,23 +31,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FarmEntryPoint extends EntryPoint {
 
+  use AutowireTrait;
+
   public function __construct(
     ResourceTypeRepositoryInterface $resourceTypeRepository,
     AccountInterface $user,
     protected ProfileExtensionList $profileExtensionList,
   ) {
     parent::__construct($resourceTypeRepository, $user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('jsonapi.resource_type.repository'),
-      $container->get('current_user'),
-      $container->get('extension.list.profile'),
-    );
   }
 
   /**

--- a/modules/core/csv/farm_csv.services.yml
+++ b/modules/core/csv/farm_csv.services.yml
@@ -1,4 +1,6 @@
 services:
+  _defaults:
+    autowire: true
   farm_csv.encoder.csv:
     class: Drupal\farm_csv\Encoder\CsvEncoder
     tags:
@@ -7,12 +9,10 @@ services:
     class: Drupal\farm_csv\Normalizer\ContentEntityNormalizer
     tags:
       - { name: normalizer, priority: 10 }
-    arguments: ['@entity_type.manager', '@entity_type.repository', '@entity_field.manager']
   farm_csv.normalizer.quantity_normalizer:
     class: Drupal\farm_csv\Normalizer\QuantityNormalizer
     tags:
       - { name: normalizer, priority: 15 }
-    arguments: [ '@entity_type.manager', '@entity_type.repository', '@entity_field.manager' ]
   farm_csv.normalizer.fraction_field_item:
     class: Drupal\farm_csv\Normalizer\FractionFieldItemNormalizer
     tags:
@@ -29,7 +29,6 @@ services:
     class: Drupal\farm_csv\Normalizer\EntityReferenceFieldItemNormalizer
     tags:
       - { name: normalizer, priority: 10 }
-    arguments: ['@entity.repository']
   farm_csv.normalizer.timestamp_item:
     class: Drupal\farm_csv\Normalizer\TimestampItemNormalizer
     tags:

--- a/modules/core/data_stream/modules/notification/data_stream_notification.services.yml
+++ b/modules/core/data_stream/modules/notification/data_stream_notification.services.yml
@@ -1,4 +1,6 @@
 services:
+  _defaults:
+    autowire: true
   plugin.manager.data_stream_notification_condition:
     class: Drupal\data_stream_notification\NotificationConditionManager
     parent: default_plugin_manager
@@ -7,7 +9,5 @@ services:
     parent: default_plugin_manager
   data_stream_notification.data_stream_event_subscriber:
     class: Drupal\data_stream_notification\EventSubscriber\DataStreamEventSubscriber
-    arguments:
-      [ '@entity_type.manager' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/data_stream/modules/notification/src/Form/DataStreamNotificationForm.php
+++ b/modules/core/data_stream/modules/notification/src/Form/DataStreamNotificationForm.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\data_stream_notification\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\SubformState;
 use Drupal\data_stream_notification\NotificationConditionManagerInterface;
 use Drupal\data_stream_notification\NotificationDeliveryManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Data stream notification entity form.
  */
 class DataStreamNotificationForm extends EntityForm {
+
+  use AutowireTrait;
 
   /**
    * The data stream notification entity.
@@ -25,19 +28,11 @@ class DataStreamNotificationForm extends EntityForm {
   protected $entity;
 
   public function __construct(
+    #[Autowire(service: 'plugin.manager.data_stream_notification_condition')]
     protected NotificationConditionManagerInterface $conditionManager,
+    #[Autowire(service: 'plugin.manager.data_stream_notification_delivery')]
     protected NotificationDeliveryManagerInterface $deliveryManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.data_stream_notification_condition'),
-      $container->get('plugin.manager.data_stream_notification_delivery'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
+++ b/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
@@ -17,6 +17,7 @@ use Drupal\data_stream\Event\DataStreamEvent;
 use Drupal\data_stream\Traits\DataStreamPrivateKeyAccess;
 use Drupal\fraction\Fraction;
 use Drupal\jsonapi\Exception\UnprocessableHttpEntityException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -51,6 +52,7 @@ class Basic extends DataStreamTypeBase implements DataStreamStorageInterface, Da
     string $plugin_id,
     $plugin_definition,
     protected Connection $connection,
+    #[Autowire(service: 'event_dispatcher')]
     protected EventDispatcherInterface $eventDispatcher,
     protected TimeInterface $time,
   ) {

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -1,8 +1,9 @@
 services:
+  _defaults:
+    autowire: true
   farm_entity.bundle_plugin_installer:
     class: Drupal\farm_entity\BundlePlugin\BundlePluginInstaller
     decorates: entity.bundle_plugin_installer
-    arguments: [ '@entity_type.manager', '@entity_bundle.listener', '@field_storage_definition.listener', '@field_definition.listener']
   plugin.manager.asset_type:
     class: Drupal\farm_entity\AssetTypeManager
     parent: default_plugin_manager

--- a/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
+++ b/modules/core/export/modules/csv/src/Form/EntityCsvActionForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_export_csv\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
@@ -15,7 +16,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\file\FileRepositoryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -26,6 +27,8 @@ use Symfony\Component\Serializer\SerializerInterface;
  * @see \Drupal\Core\Entity\Form\DeleteMultipleForm
  */
 class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -45,28 +48,13 @@ class EntityCsvActionForm extends ConfirmFormBase implements BaseFormIdInterface
     protected PrivateTempStoreFactory $tempStoreFactory,
     protected EntityTypeManagerInterface $entityTypeManager,
     protected EntityFieldManagerInterface $entityFieldManager,
+    #[Autowire(service: 'serializer')]
     protected SerializerInterface $serializer,
     protected FileSystemInterface $fileSystem,
     protected FileRepositoryInterface $fileRepository,
     protected FileUrlGeneratorInterface $fileUrlGenerator,
     protected AccountInterface $user,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('entity_field.manager'),
-      $container->get('serializer'),
-      $container->get('file_system'),
-      $container->get('file.repository'),
-      $container->get('file_url_generator'),
-      $container->get('current_user'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/field/farm_field.services.yml
+++ b/modules/core/field/farm_field.services.yml
@@ -1,3 +1,4 @@
 services:
   farm_field.factory:
     class: Drupal\farm_field\FarmFieldFactory
+  Drupal\farm_field\FarmFieldFactoryInterface: '@farm_field.factory'

--- a/modules/core/fieldkit/src/Controller/FieldModuleController.php
+++ b/modules/core/fieldkit/src/Controller/FieldModuleController.php
@@ -6,8 +6,8 @@ namespace Drupal\farm_fieldkit\Controller;
 
 use Drupal\Core\Asset\LibraryDiscoveryInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\farm_fieldkit\Entity\FieldModuleInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 
@@ -16,18 +16,11 @@ use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
  */
 class FieldModuleController extends ControllerBase {
 
+  use AutowireTrait;
+
   public function __construct(
     protected LibraryDiscoveryInterface $libraryDiscovery,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('library.discovery')
-    );
-  }
 
   /**
    * Returns the FieldModule JS.

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_flag\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
@@ -11,7 +12,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -21,6 +21,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  * @see \Drupal\Core\Entity\Form\DeleteMultipleForm
  */
 class EntityFlagActionForm extends ConfirmFormBase {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -49,18 +51,6 @@ class EntityFlagActionForm extends ConfirmFormBase {
     protected EntityFieldManagerInterface $entityFieldManager,
     protected AccountInterface $user,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('entity_field.manager'),
-      $container->get('current_user')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/geo/farm_geo.services.yml
+++ b/modules/core/geo/farm_geo.services.yml
@@ -1,6 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   serializer.farm_geo.geometry.content_entity_geometry:
     class: Drupal\farm_geo\Normalizer\ContentEntityGeometryNormalizer
-    arguments: ['@geofield.geophp']
     tags:
       - { name: normalizer, priority: 10 }

--- a/modules/core/import/modules/csv/farm_import_csv.services.yml
+++ b/modules/core/import/modules/csv/farm_import_csv.services.yml
@@ -1,16 +1,15 @@
 services:
+  _defaults:
+    autowire: true
   farm_import_csv.access:
     class: Drupal\farm_import_csv\Access\CsvImportMigrationAccess
-    arguments: [ '@plugin.manager.migration' ]
     tags:
       - { name: 'access_check' }
   farm_import_csv.migration_subscriber:
     class: Drupal\farm_import_csv\EventSubscriber\CsvMigrationSubscriber
-    arguments: [ '@database', '@current_user', '@tempstore.private', '@messenger' ]
     tags:
       - { name: 'event_subscriber' }
   farm_import_csv.config_subscriber:
     class: Drupal\farm_import_csv\EventSubscriber\CsvMigrationConfigSubscriber
-    arguments: [ '@router.builder' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -8,6 +8,7 @@ use Drupal\Component\Plugin\Exception\PluginNotFoundException;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Database\Connection;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Link;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
@@ -16,7 +17,7 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\farm_import_csv\Access\CsvImportMigrationAccess;
 use Drupal\migrate\Plugin\MigrationPluginManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -25,26 +26,17 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
  */
 class CsvImportController extends ControllerBase {
 
+  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(
     protected MenuLinkTreeInterface $menuLinkTree,
+    #[Autowire(service: 'plugin.manager.migration')]
     protected MigrationPluginManager $pluginManagerMigration,
+    #[Autowire(service: 'farm_import_csv.access')]
     protected CsvImportMigrationAccess $migrationAccess,
     protected Connection $database,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('menu.link_tree'),
-      $container->get('plugin.manager.migration'),
-      $container->get('farm_import_csv.access'),
-      $container->get('database'),
-    );
-  }
 
   /**
    * The index of importers.

--- a/modules/core/import/modules/csv/src/Form/CsvImportForm.php
+++ b/modules/core/import/modules/csv/src/Form/CsvImportForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_import_csv\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormBase;
@@ -17,37 +18,27 @@ use Drupal\migrate\MigrateMessage;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\Plugin\MigrationPluginManager;
 use Drupal\migrate_tools\MigrateBatchExecutable;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Provides the CSV import form.
  */
 class CsvImportForm extends FormBase {
 
+  use AutowireTrait;
+
   public function __construct(
+    #[Autowire(service: 'plugin.manager.migration')]
     protected MigrationPluginManager $migrationPluginManager,
     protected FileSystemInterface $fileSystem,
     protected TimeInterface $time,
+    #[Autowire(service: 'keyvalue')]
     protected KeyValueFactoryInterface $keyValueFactory,
+    #[Autowire(service: 'string_translation')]
     protected TranslationManager $translationManager,
     protected FileUsageInterface $fileUsage,
     protected PrivateTempStoreFactory $tempStoreFactory,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container): static {
-    return new static(
-      $container->get('plugin.manager.migration'),
-      $container->get('file_system'),
-      $container->get('datetime.time'),
-      $container->get('keyvalue'),
-      $container->get('string_translation'),
-      $container->get('file.usage'),
-      $container->get('tempstore.private'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/modules/kml/src/Form/KmlImporter.php
+++ b/modules/core/import/modules/kml/src/Form/KmlImporter.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\farm_import_kml\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\GeometryWrapper;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -23,22 +24,14 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class KmlImporter extends FormBase {
 
+  use AutowireTrait;
+
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'serializer')]
     protected SerializerInterface $serializer,
     protected FileSystemInterface $fileSystem,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('serializer'),
-      $container->get('file_system')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/import/src/Controller/ImportController.php
+++ b/modules/core/import/src/Controller/ImportController.php
@@ -6,30 +6,22 @@ namespace Drupal\farm_import\Controller;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Import controller.
  */
 class ImportController extends ControllerBase {
 
+  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(
     protected MenuLinkTreeInterface $menuLinkTree,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('menu.link_tree')
-    );
-  }
 
   /**
    * The index of importers.

--- a/modules/core/inventory/farm_inventory.services.yml
+++ b/modules/core/inventory/farm_inventory.services.yml
@@ -3,6 +3,7 @@ services:
     class: Drupal\farm_inventory\AssetInventory
     arguments:
       [ '@database', '@entity_type.manager', '@datetime.time' ]
+  Drupal\farm_inventory\AssetInventoryInterface: '@asset.inventory'
   farm_inventory.log_event_subscriber:
     class: Drupal\farm_inventory\EventSubscriber\LogEventSubscriber
     arguments:

--- a/modules/core/inventory/farm_inventory.services.yml
+++ b/modules/core/inventory/farm_inventory.services.yml
@@ -1,12 +1,10 @@
 services:
+  _defaults:
+    autowire: true
   asset.inventory:
     class: Drupal\farm_inventory\AssetInventory
-    arguments:
-      [ '@database', '@entity_type.manager', '@datetime.time' ]
   Drupal\farm_inventory\AssetInventoryInterface: '@asset.inventory'
   farm_inventory.log_event_subscriber:
     class: Drupal\farm_inventory\EventSubscriber\LogEventSubscriber
-    arguments:
-      [ '@cache_tags.invalidator', '@datetime.time' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/kml/farm_kml.services.yml
+++ b/modules/core/kml/farm_kml.services.yml
@@ -1,10 +1,11 @@
 services:
+  _defaults:
+    autowire: true
   serializer.farm_kml.kml.encoder:
     class: Drupal\farm_kml\Encoder\Kml
     tags:
       - { name: encoder, priority: 10, format: geometry_kml }
   serializer.farm_kml.kml.geometry_wrapper:
     class: Drupal\farm_kml\Normalizer\KmlNormalizer
-    arguments: ['@geofield.geophp']
     tags:
       - { name: normalizer, priority: 10 }

--- a/modules/core/l10n/src/Form/L10nSettingsForm.php
+++ b/modules/core/l10n/src/Form/L10nSettingsForm.php
@@ -6,10 +6,10 @@ namespace Drupal\farm_l10n\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\language\Form\NegotiationSelectedForm;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Configure the selected language negotiation method for this site.
@@ -26,23 +26,14 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class L10nSettingsForm extends NegotiationSelectedForm {
 
+  use AutowireTrait;
+
   public function __construct(
     ConfigFactoryInterface $config_factory,
     protected TypedConfigManagerInterface $typedConfigManager,
     protected EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct($config_factory, $typedConfigManager);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory'),
-      $container->get('config.typed'),
-      $container->get('entity_type.manager'),
-    );
   }
 
   /**

--- a/modules/core/location/farm_location.services.yml
+++ b/modules/core/location/farm_location.services.yml
@@ -1,15 +1,13 @@
 services:
+  _defaults:
+    autowire: true
   asset.location:
     class: Drupal\farm_location\AssetLocation
-    arguments:
-      [ '@log.location', '@farm.log_query', '@entity_type.manager', '@datetime.time' , '@database']
   Drupal\farm_location\AssetLocationInterface: '@asset.location'
   log.location:
     class: Drupal\farm_location\LogLocation
   Drupal\farm_location\LogLocationInterface: '@log.location'
   farm_location.log_event_subscriber:
     class: Drupal\farm_location\EventSubscriber\LogEventSubscriber
-    arguments:
-      [ '@log.location', '@asset.location', '@cache_tags.invalidator' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/location/farm_location.services.yml
+++ b/modules/core/location/farm_location.services.yml
@@ -3,8 +3,10 @@ services:
     class: Drupal\farm_location\AssetLocation
     arguments:
       [ '@log.location', '@farm.log_query', '@entity_type.manager', '@datetime.time' , '@database']
+  Drupal\farm_location\AssetLocationInterface: '@asset.location'
   log.location:
     class: Drupal\farm_location\LogLocation
+  Drupal\farm_location\LogLocationInterface: '@log.location'
   farm_location.log_event_subscriber:
     class: Drupal\farm_location\EventSubscriber\LogEventSubscriber
     arguments:

--- a/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
+++ b/modules/core/location/src/Plugin/Validation/Constraint/CircularAssetLocationConstraintValidator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location\Plugin\Validation\Constraint;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_location\AssetLocationInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -16,18 +16,11 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class CircularAssetLocationConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
+  use AutowireTrait;
+
   public function __construct(
     protected AssetLocationInterface $assetLocation,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('asset.location'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/log/farm_log.services.yml
+++ b/modules/core/log/farm_log.services.yml
@@ -1,11 +1,9 @@
 services:
+  _defaults:
+    autowire: true
   asset.logs:
     class: Drupal\farm_log\AssetLogs
-    arguments:
-      [ '@entity_type.manager', '@farm.log_query' ]
   Drupal\farm_log\AssetLogsInterface: '@asset.logs'
   farm.log_query:
     class: Drupal\farm_log\LogQueryFactory
-    arguments:
-      [ '@entity_type.manager' ]
   Drupal\farm_log\LogQueryFactoryInterface: '@farm.log_query'

--- a/modules/core/log/farm_log.services.yml
+++ b/modules/core/log/farm_log.services.yml
@@ -3,7 +3,9 @@ services:
     class: Drupal\farm_log\AssetLogs
     arguments:
       [ '@entity_type.manager', '@farm.log_query' ]
+  Drupal\farm_log\AssetLogsInterface: '@asset.logs'
   farm.log_query:
     class: Drupal\farm_log\LogQueryFactory
     arguments:
       [ '@entity_type.manager' ]
+  Drupal\farm_log\LogQueryFactoryInterface: '@farm.log_query'

--- a/modules/core/log/modules/quantity/farm_log_quantity.services.yml
+++ b/modules/core/log/modules/quantity/farm_log_quantity.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   farm_log_quantity.event_subscriber:
     class: Drupal\farm_log_quantity\EventSubscriber\LogQuantityEventSubscriber
-    arguments:
-      [ '@entity_type.manager' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/log/src/Form/AssetAddLogActionForm.php
+++ b/modules/core/log/src/Form/AssetAddLogActionForm.php
@@ -4,19 +4,21 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Provides an asset add log confirmation form.
  */
 class AssetAddLogActionForm extends ConfirmFormBase {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -37,17 +39,6 @@ class AssetAddLogActionForm extends ConfirmFormBase {
     protected EntityTypeManagerInterface $entityTypeManager,
     protected AccountInterface $user,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('current_user')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/login/farm_login.services.yml
+++ b/modules/core/login/farm_login.services.yml
@@ -1,5 +1,6 @@
 services:
+  _defaults:
+    autowire: true
   farm_login.user.auth:
     class: Drupal\farm_login\UserAuth
     decorates: user.auth
-    arguments: ['@entity_type.manager', '@password']

--- a/modules/core/map/farm_map.services.yml
+++ b/modules/core/map/farm_map.services.yml
@@ -7,3 +7,4 @@ services:
       - { name: 'event_subscriber' }
   farm_map.layer_style_loader:
     class: Drupal\farm_map\LayerStyleLoader
+  Drupal\farm_map\LayerStyleLoaderInterface: '@farm_map.layer_style_loader'

--- a/modules/core/map/farm_map.services.yml
+++ b/modules/core/map/farm_map.services.yml
@@ -1,8 +1,8 @@
 services:
+  _defaults:
+    autowire: true
   farm_map.map_render_event_subscriber:
     class: Drupal\farm_map\EventSubscriber\MapRenderEventSubscriber
-    arguments:
-      - '@config.factory'
     tags:
       - { name: 'event_subscriber' }
   farm_map.layer_style_loader:

--- a/modules/core/map/modules/mapbox/farm_map_mapbox.services.yml
+++ b/modules/core/map/modules/mapbox/farm_map_mapbox.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   mapbox_map_render_event_subscriber:
     class: Drupal\farm_map_mapbox\EventSubscriber\MapRenderEventSubscriber
-    arguments:
-      - '@config.factory'
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/owner/farm_owner.services.yml
+++ b/modules/core/owner/farm_owner.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   farm_owner.log_event_subscriber:
     class: Drupal\farm_owner\EventSubscriber\LogEventSubscriber
-    arguments:
-      [ '@current_user' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_owner\Form;
 
 use Drupal\Component\Plugin\Exception\PluginException;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -12,13 +13,14 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\farm_role\ManagedRolePermissionsManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Provides an assign confirmation form.
  */
 class AssignActionForm extends ConfirmFormBase {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -40,18 +42,6 @@ class AssignActionForm extends ConfirmFormBase {
     protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
     protected AccountInterface $user,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('plugin.manager.managed_role_permissions'),
-      $container->get('current_user')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_parent\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -11,14 +12,14 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\asset\Entity\AssetInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Provides a form for assigning asset parent.
  */
 class AssetParentActionForm extends ConfirmFormBase {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -38,20 +39,7 @@ class AssetParentActionForm extends ConfirmFormBase {
     protected PrivateTempStoreFactory $tempStoreFactory,
     protected EntityTypeManagerInterface $entityTypeManager,
     protected AccountInterface $user,
-    protected Request $request,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('request_stack')->getCurrentRequest(),
-    );
-  }
 
   /**
    * {@inheritdoc}
@@ -95,7 +83,7 @@ class AssetParentActionForm extends ConfirmFormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
 
     // Check if asset IDs were provided in the asset query param.
-    if ($asset_ids = $this->request->get('asset')) {
+    if ($asset_ids = $this->getRequest()->get('asset')) {
 
       // Wrap in an array, if necessary.
       if (!is_array($asset_ids)) {

--- a/modules/core/plan/src/Form/PlanTypeForm.php
+++ b/modules/core/plan/src/Form/PlanTypeForm.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\plan\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\state_machine\WorkflowManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Form controller for plan type entities.
@@ -15,6 +16,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @package Drupal\plan\Form
  */
 class PlanTypeForm extends EntityForm {
+
+  use AutowireTrait;
 
   /**
    * The plan type entity.
@@ -24,17 +27,9 @@ class PlanTypeForm extends EntityForm {
   protected $entity;
 
   public function __construct(
+    #[Autowire(service: 'plugin.manager.workflow')]
     protected WorkflowManagerInterface $workflowManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.workflow')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/quantity/quantity.services.yml
+++ b/modules/core/quantity/quantity.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   quantity_event_subscriber:
     class: Drupal\quantity\EventSubscriber\MapRenderEventSubscriber
-    arguments:
-      - '@config.factory'
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/quick/farm_quick.services.yml
+++ b/modules/core/quick/farm_quick.services.yml
@@ -1,9 +1,9 @@
 services:
+  _defaults:
+    autowire: true
   plugin.manager.quick_form:
     class: Drupal\farm_quick\QuickFormPluginManager
     parent: default_plugin_manager
   quick_form.instance_manager:
     class: Drupal\farm_quick\QuickFormInstanceManager
-    arguments:
-      ['@entity_type.manager', '@plugin.manager.quick_form']
   Drupal\farm_quick\QuickFormInstanceManagerInterface: '@quick_form.instance_manager'

--- a/modules/core/quick/farm_quick.services.yml
+++ b/modules/core/quick/farm_quick.services.yml
@@ -6,3 +6,4 @@ services:
     class: Drupal\farm_quick\QuickFormInstanceManager
     arguments:
       ['@entity_type.manager', '@plugin.manager.quick_form']
+  Drupal\farm_quick\QuickFormInstanceManagerInterface: '@quick_form.instance_manager'

--- a/modules/core/quick/src/Controller/QuickFormAddPage.php
+++ b/modules/core/quick/src/Controller/QuickFormAddPage.php
@@ -6,28 +6,23 @@ namespace Drupal\farm_quick\Controller;
 
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Link;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
 use Drupal\farm_quick\QuickFormPluginManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Page that renders links to create instances of quick form plugins.
  */
 class QuickFormAddPage extends ControllerBase {
 
+  use AutowireTrait;
+
   public function __construct(
+    #[Autowire(service: 'plugin.manager.quick_form')]
     protected QuickFormPluginManager $quickFormPluginManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.quick_form'),
-    );
-  }
 
   /**
    * Add quick form page callback.

--- a/modules/core/quick/src/Controller/QuickFormController.php
+++ b/modules/core/quick/src/Controller/QuickFormController.php
@@ -7,31 +7,23 @@ namespace Drupal\farm_quick\Controller;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\farm_quick\QuickFormInstanceManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Quick form controller.
  */
 class QuickFormController extends ControllerBase {
 
+  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(
     protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('quick_form.instance_manager'),
-    );
-  }
 
   /**
    * The index of quick forms.

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityMalformedException;
 use Drupal\Core\Form\BaseFormIdInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\farm_quick\QuickFormInstanceManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
 /**
@@ -19,6 +19,8 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
  * @ingroup farm
  */
 class QuickForm extends FormBase implements BaseFormIdInterface {
+
+  use AutowireTrait;
 
   /**
    * The quick form ID.
@@ -30,15 +32,6 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
   public function __construct(
     protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('quick_form.instance_manager'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Form/QuickFormEntityForm.php
+++ b/modules/core/quick/src/Form/QuickFormEntityForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_quick\Form;
 
 use Drupal\Component\Utility\Html;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\SubformState;
@@ -12,13 +13,15 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\farm_quick\Entity\QuickFormInstance;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
 use Drupal\farm_quick\QuickFormPluginManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 /**
  * Form that renders quick form configuration forms.
  */
 class QuickFormEntityForm extends EntityForm {
+
+  use AutowireTrait;
 
   /**
    * The entity being used by this form.
@@ -28,17 +31,9 @@ class QuickFormEntityForm extends EntityForm {
   protected $entity;
 
   public function __construct(
+    #[Autowire(service: 'plugin.manager.quick_form')]
     protected QuickFormPluginManager $quickFormPluginManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.quick_form'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/QuickFormInstanceManager.php
+++ b/modules/core/quick/src/QuickFormInstanceManager.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_quick;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\farm_quick\Entity\QuickFormInstance;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -15,6 +16,7 @@ class QuickFormInstanceManager implements QuickFormInstanceManagerInterface {
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'plugin.manager.quick_form')]
     protected QuickFormPluginManager $quickFormPluginManager,
   ) {}
 

--- a/modules/core/quick/src/QuickFormInstanceManager.php
+++ b/modules/core/quick/src/QuickFormInstanceManager.php
@@ -4,31 +4,23 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\farm_quick\Entity\QuickFormInstance;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Quick form instance manager.
  */
 class QuickFormInstanceManager implements QuickFormInstanceManagerInterface {
 
+  use AutowireTrait;
+
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     #[Autowire(service: 'plugin.manager.quick_form')]
     protected QuickFormPluginManager $quickFormPluginManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('plugin.manager.quick_form'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/quick/src/Routing/QuickFormRoutes.php
+++ b/modules/core/quick/src/Routing/QuickFormRoutes.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick\Routing;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\farm_quick\Form\QuickForm;
 use Drupal\farm_quick\QuickFormInstanceManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
@@ -16,18 +16,11 @@ use Symfony\Component\Routing\RouteCollection;
  */
 class QuickFormRoutes implements ContainerInjectionInterface {
 
+  use AutowireTrait;
+
   public function __construct(
     protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('quick_form.instance_manager'),
-    );
-  }
 
   /**
    * Provides routes for quick forms.

--- a/modules/core/report/src/Controller/ReportController.php
+++ b/modules/core/report/src/Controller/ReportController.php
@@ -6,30 +6,22 @@ namespace Drupal\farm_report\Controller;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Report controller.
  */
 class ReportController extends ControllerBase {
 
+  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(
     protected MenuLinkTreeInterface $menuLinkTree,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('menu.link_tree')
-    );
-  }
 
   /**
    * The index of reports.

--- a/modules/core/role/farm_role.services.yml
+++ b/modules/core/role/farm_role.services.yml
@@ -1,5 +1,6 @@
 services:
+  _defaults:
+    autowire: true
   plugin.manager.managed_role_permissions:
     class: Drupal\farm_role\ManagedRolePermissionsManager
-    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@controller_resolver', '@entity_type.bundle.info', '@entity_type.manager']
   Drupal\farm_role\ManagedRolePermissionsManagerInterface: '@plugin.manager.managed_role_permissions'

--- a/modules/core/role/farm_role.services.yml
+++ b/modules/core/role/farm_role.services.yml
@@ -2,3 +2,4 @@ services:
   plugin.manager.managed_role_permissions:
     class: Drupal\farm_role\ManagedRolePermissionsManager
     arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@controller_resolver', '@entity_type.bundle.info', '@entity_type.manager']
+  Drupal\farm_role\ManagedRolePermissionsManagerInterface: '@plugin.manager.managed_role_permissions'

--- a/modules/core/role/src/FarmRoleServiceProvider.php
+++ b/modules/core/role/src/FarmRoleServiceProvider.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_role;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\Core\DependencyInjection\ServiceProviderBase;
 use Drupal\Core\DependencyInjection\ServiceProviderInterface;
-use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * Override the permission_checker service with our own class.
@@ -19,9 +18,9 @@ class FarmRoleServiceProvider extends ServiceProviderBase implements ServiceProv
    */
   public function alter(ContainerBuilder $container) {
     $definition = $container->getDefinition('permission_checker');
-    $definition->addArgument(new Reference('entity_type.manager'));
-    $definition->addArgument(new Reference('plugin.manager.managed_role_permissions'));
     $definition->setClass('Drupal\farm_role\ManagedRolePermissionChecker');
+    $definition->setAutowired(TRUE);
+    $definition->setArguments([]);
   }
 
 }

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -13,6 +13,7 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\Core\Plugin\Discovery\ContainerDerivativeDiscoveryDecorator;
 use Drupal\Core\Plugin\Discovery\YamlDiscovery;
 use Drupal\user\RoleInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * ManagedRolePermissions Plugin Manager.
@@ -43,7 +44,9 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
   protected $rolePermissions = [];
 
   public function __construct(
+    #[Autowire(service: 'container.namespaces')]
     \Traversable $namespaces,
+    #[Autowire(service: 'cache.discovery')]
     CacheBackendInterface $cache_backend,
     ModuleHandlerInterface $module_handler,
     protected ControllerResolverInterface $controllerResolver,

--- a/modules/core/settings/src/Form/FarmSettingsModulesForm.php
+++ b/modules/core/settings/src/Form/FarmSettingsModulesForm.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm_settings\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for installing farmOS modules.
@@ -15,6 +15,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @ingroup farm
  */
 class FarmSettingsModulesForm extends FormBase {
+
+  use AutowireTrait;
 
   /**
    * The package name for farmOS contrib modules.
@@ -40,15 +42,6 @@ class FarmSettingsModulesForm extends FormBase {
   public function __construct(
     protected ModuleExtensionList $moduleExtensionList,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('extension.list.module'),
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/setup/src/Controller/SetupController.php
+++ b/modules/core/setup/src/Controller/SetupController.php
@@ -6,30 +6,22 @@ namespace Drupal\farm_setup\Controller;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Setup controller.
  */
 class SetupController extends ControllerBase {
 
+  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(
     protected MenuLinkTreeInterface $menuLinkTree,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('menu.link_tree')
-    );
-  }
 
   /**
    * The index of reports.

--- a/modules/core/ui/breadcrumb/farm_ui_breadcrumb.services.yml
+++ b/modules/core/ui/breadcrumb/farm_ui_breadcrumb.services.yml
@@ -1,7 +1,10 @@
 services:
+  _defaults:
+    autowire: true
   farm_ui_breadcrumb.breadcrumb:
     class: Drupal\farm_ui_breadcrumb\Breadcrumb\FarmBreadcrumbBuilder
     arguments:
-      [ '@router.request_context', '@access_manager', '@router.no_access_checks', '@path_processor_manager', '@config.factory', '@title_resolver', '@current_user', '@path.current' ]
+      $context: '@router.request_context'
+      $router: '@router.no_access_checks'
     tags:
       - { name: breadcrumb_builder, priority: 100 }

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -6,9 +6,9 @@ namespace Drupal\farm_ui_dashboard\Controller;
 
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Layout\LayoutPluginManagerInterface;
 use Drupal\views\Views;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Dashboard controller.
@@ -17,20 +17,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class DashboardController extends ControllerBase {
 
+  use AutowireTrait;
+
   public function __construct(
     protected LayoutPluginManagerInterface $layoutPluginManager,
     protected BlockManagerInterface $blockManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.core.layout'),
-      $container->get('plugin.manager.block'),
-    );
-  }
 
   /**
    * Builds the farm dashboard page.

--- a/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
+++ b/modules/core/ui/location/src/Form/BaseLocationHierarchyForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_location\Form;
 
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Query\QueryInterface;
 use Drupal\Core\Form\FormBase;
@@ -12,7 +13,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\farm_location\AssetLocationInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base form for changing the hierarchy of location assets.
@@ -21,20 +21,12 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 abstract class BaseLocationHierarchyForm extends FormBase {
 
+  use AutowireTrait;
+
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
     protected AssetLocationInterface $assetLocation,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager'),
-      $container->get('asset.location'),
-    );
-  }
 
   /**
    * Helper function to build the location form.

--- a/modules/core/ui/map/farm_ui_map.services.yml
+++ b/modules/core/ui/map/farm_ui_map.services.yml
@@ -1,7 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   farm_ui_map.map_render_event_subscriber:
     class: Drupal\farm_ui_map\EventSubscriber\MapRenderEventSubscriber
-    arguments:
-      [ '@entity_type.manager', '@farm_map.layer_style_loader' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -6,6 +6,7 @@ namespace Drupal\farm_ui_theme\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Entity\EntityChangedInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
@@ -15,12 +16,13 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element\RenderCallbackInterface;
 use Drupal\user\EntityOwnerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Entity form for gin content form styling.
  */
 class GinContentFormBase extends ContentEntityForm implements RenderCallbackInterface {
+
+  use AutowireTrait;
 
   public function __construct(
     EntityRepositoryInterface $entity_repository,
@@ -31,19 +33,6 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
   ) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->setModuleHandler($module_handler);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity.repository'),
-      $container->get('entity_type.bundle.info'),
-      $container->get('datetime.time'),
-      $container->get('date.formatter'),
-      $container->get('module_handler'),
-    );
   }
 
   /**

--- a/modules/core/ui/views/farm_ui_views.services.yml
+++ b/modules/core/ui/views/farm_ui_views.services.yml
@@ -1,53 +1,43 @@
 services:
+  _defaults:
+    autowire: true
   farm_ui_views.route_subscriber:
     class: Drupal\farm_ui_views\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
   farm_ui_views.asset_logs_access:
     class: Drupal\farm_ui_views\Access\FarmAssetLogViewsAccessCheck
-    arguments: ['@entity_type.manager']
     tags:
       - { name: access_check, applies_to: _asset_logs_access }
   farm_ui_views.asset_children_access:
     class: Drupal\farm_ui_views\Access\FarmAssetChildrenViewsAccessCheck
-    arguments: [ '@entity_type.manager', '@asset.location' ]
     tags:
       - { name: access_check, applies_to: _asset_children_access }
   farm_ui_views.asset_term_access:
     class: Drupal\farm_ui_views\Access\FarmTaxonomyTermEntityViewsAccessCheck
     arguments:
-     - 'asset'
-     - '@entity_type.manager'
-     - '@entity_type.bundle.info'
-     - '@entity_field.manager'
+      $baseEntityType: 'asset'
     tags:
       - { name: access_check, applies_to: _asset_term_access }
   farm_ui_views.log_term_access:
     class: Drupal\farm_ui_views\Access\FarmTaxonomyTermEntityViewsAccessCheck
     arguments:
-     - 'log'
-     - '@entity_type.manager'
-     - '@entity_type.bundle.info'
-     - '@entity_field.manager'
+      $baseEntityType: 'log'
     tags:
       - { name: access_check, applies_to: _log_term_access }
   farm_ui_views.asset_inventory_access:
     class: Drupal\farm_ui_views\Access\FarmInventoryAssetViewsAccessCheck
-    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: access_check, applies_to: _asset_inventory_access }
   farm_ui_views.location_assets_access:
     class: Drupal\farm_ui_views\Access\FarmLocationAssetViewsAccessCheck
-    arguments: [ '@entity_type.manager', '@asset.location' ]
     tags:
       - { name: access_check, applies_to: _location_assets_access }
   farm_ui_views.organization_assets_access:
     class: Drupal\farm_ui_views\Access\FarmOrganizationAssetViewsAccessCheck
-    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: access_check, applies_to: _farm_organization_assets_access }
   farm_ui_views.organization_logs_access:
     class: Drupal\farm_ui_views\Access\FarmOrganizationLogViewsAccessCheck
-    arguments: [ '@entity_type.manager' ]
     tags:
       - { name: access_check, applies_to: _organization_logs_access }

--- a/modules/core/update/farm_update.services.yml
+++ b/modules/core/update/farm_update.services.yml
@@ -5,3 +5,4 @@ services:
   farm.update:
     class: Drupal\farm_update\FarmUpdate
     arguments: [ '@logger.channel.farm_update', '@module_handler', '@entity_type.manager', '@config.factory', '@config_update.config_diff', '@config_update.config_list', '@config_update.config_update' ]
+  Drupal\farm_update\FarmUpdateInterface: '@farm.update'

--- a/modules/core/update/farm_update.services.yml
+++ b/modules/core/update/farm_update.services.yml
@@ -1,8 +1,10 @@
 services:
+  _defaults:
+    autowire: true
   logger.channel.farm_update:
     parent: logger.channel_base
-    arguments: [ 'farm_update' ]
+    arguments:
+      $channel: 'farm_update'
   farm.update:
     class: Drupal\farm_update\FarmUpdate
-    arguments: [ '@logger.channel.farm_update', '@module_handler', '@entity_type.manager', '@config.factory', '@config_update.config_diff', '@config_update.config_list', '@config_update.config_update' ]
   Drupal\farm_update\FarmUpdateInterface: '@farm.update'

--- a/modules/core/update/src/Drush/Commands/FarmUpdateCommands.php
+++ b/modules/core/update/src/Drush/Commands/FarmUpdateCommands.php
@@ -8,7 +8,6 @@ use Drupal\farm_update\FarmUpdateInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Farm Update Drush commands.
@@ -20,7 +19,6 @@ final class FarmUpdateCommands extends DrushCommands {
   use AutowireTrait;
 
   public function __construct(
-    #[Autowire(service: 'farm.update')]
     private readonly FarmUpdateInterface $farmUpdate,
   ) {
     parent::__construct();

--- a/modules/core/update/src/FarmUpdate.php
+++ b/modules/core/update/src/FarmUpdate.php
@@ -12,6 +12,7 @@ use Drupal\config_update\ConfigDiffer;
 use Drupal\config_update\ConfigListerWithProviders;
 use Drupal\config_update\ConfigReverter;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Farm update service.
@@ -23,12 +24,16 @@ class FarmUpdate implements FarmUpdateInterface {
   use StringTranslationTrait;
 
   public function __construct(
+    #[Autowire(service: 'logger.channel.farm_update')]
     protected LoggerInterface $logger,
     protected ModuleHandlerInterface $moduleHandler,
     protected EntityTypeManagerInterface $entityTypeManager,
     protected ConfigFactoryInterface $configFactory,
+    #[Autowire(service: 'config_update.config_diff')]
     protected ConfigDiffer $configDiff,
+    #[Autowire(service: 'config_update.config_list')]
     protected ConfigListerWithProviders $configList,
+    #[Autowire(service: 'config_update.config_update')]
     protected ConfigReverter $configUpdate,
   ) {}
 

--- a/modules/log/birth/farm_birth.services.yml
+++ b/modules/log/birth/farm_birth.services.yml
@@ -1,6 +1,7 @@
 services:
+  _defaults:
+    autowire: true
   farm_birth.log_event_subscriber:
     class: Drupal\farm_birth\EventSubscriber\LogEventSubscriber
-    arguments: [ '@messenger' ]
     tags:
       - { name: 'event_subscriber' }

--- a/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
+++ b/modules/log/birth/src/Plugin/Validation/Constraint/UniqueBirthLogConstraintValidator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Drupal\farm_birth\Plugin\Validation\Constraint;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
@@ -15,18 +15,11 @@ use Symfony\Component\Validator\ConstraintValidator;
  */
 class UniqueBirthLogConstraintValidator extends ConstraintValidator implements ContainerInjectionInterface {
 
+  use AutowireTrait;
+
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('entity_type.manager')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/modules/organization/farm/src/Form/AssetFarmActionForm.php
+++ b/modules/organization/farm/src/Form/AssetFarmActionForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_farm\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -11,14 +12,14 @@ use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
 use Drupal\asset\Entity\AssetInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Provides a form for assigning asset to a farm organization.
  */
 class AssetFarmActionForm extends ConfirmFormBase {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -38,20 +39,7 @@ class AssetFarmActionForm extends ConfirmFormBase {
     protected PrivateTempStoreFactory $tempStoreFactory,
     protected EntityTypeManagerInterface $entityTypeManager,
     protected AccountInterface $user,
-    protected Request $request,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('request_stack')->getCurrentRequest(),
-    );
-  }
 
   /**
    * {@inheritdoc}
@@ -95,7 +83,7 @@ class AssetFarmActionForm extends ConfirmFormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array|RedirectResponse {
 
     // Check if asset IDs were provided in the asset query param.
-    if ($asset_ids = $this->request->get('asset')) {
+    if ($asset_ids = $this->getRequest()->get('asset')) {
 
       // Wrap in an array, if necessary.
       if (!is_array($asset_ids)) {

--- a/modules/role/account_admin/src/AccountAdminPermissions.php
+++ b/modules/role/account_admin/src/AccountAdminPermissions.php
@@ -5,30 +5,22 @@ declare(strict_types=1);
 namespace Drupal\farm_account_admin;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\farm_role\ManagedRolePermissionsManagerInterface;
 use Drupal\user\RoleInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Add permissions to the Account Admin role.
  */
 class AccountAdminPermissions implements ContainerInjectionInterface {
 
+  use AutowireTrait;
+
   public function __construct(
     protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
     protected ConfigFactoryInterface $configFactory,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('plugin.manager.managed_role_permissions'),
-      $container->get('config.factory'),
-    );
-  }
 
   /**
    * Add permissions to default farmOS roles.

--- a/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
+++ b/modules/role/account_admin/src/Form/AccountAdminSettingsForm.php
@@ -7,14 +7,16 @@ namespace Drupal\farm_account_admin\Form;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Config\TypedConfigManagerInterface;
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a settings form for the Account Admin Role module.
  */
 class AccountAdminSettingsForm extends ConfigFormbase {
+
+  use AutowireTrait;
 
   /**
    * Config settings.
@@ -29,17 +31,6 @@ class AccountAdminSettingsForm extends ConfigFormbase {
     protected CacheTagsInvalidatorInterface $cacheTagsInvalidator,
   ) {
     parent::__construct($config_factory, $typed_config_manager);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('config.factory'),
-      $container->get('config.typed'),
-      $container->get('cache_tags.invalidator'),
-    );
   }
 
   /**

--- a/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
+++ b/modules/taxonomy/log_category/src/Form/LogCategorizeActionForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log_category\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -11,13 +12,14 @@ use Drupal\Core\Render\Element\Checkboxes;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Provides a categorize log confirmation form.
  */
 class LogCategorizeActionForm extends ConfirmFormBase {
+
+  use AutowireTrait;
 
   /**
    * The entity type.
@@ -38,17 +40,6 @@ class LogCategorizeActionForm extends ConfirmFormBase {
     protected EntityTypeManagerInterface $entityTypeManager,
     protected AccountInterface $user,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('tempstore.private'),
-      $container->get('entity_type.manager'),
-      $container->get('current_user')
-    );
-  }
 
   /**
    * {@inheritdoc}

--- a/src/Form/FarmModulesForm.php
+++ b/src/Form/FarmModulesForm.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm\Form;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\State\StateInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form for selecting farmOS modules to install.
@@ -16,18 +16,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class FarmModulesForm extends FormBase {
 
+  use AutowireTrait;
+
   public function __construct(
     protected StateInterface $state,
   ) {}
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('state'),
-    );
-  }
 
   /**
    * {@inheritdoc}


### PR DESCRIPTION
~**Note:** this PR builds on top of #1005 and therefore includes all of its commits. When that is merged I will rebase this so it only includes the relevant commits for these changes. In the meantime, to see this PR's changes by themselves, use this link: https://github.com/mstenta/farmOS/compare/4.x-property-promotion...4.x-autowire~ Edit: #1005 has been merged.

This leverage's [Symfony's autowiring](https://symfony.com/doc/current/service_container/autowiring.html) to reduce a lot of boilerplate and cross-file maintenance. Combined with #1005, most of the classes in farmOS are much easier to jump into and understand for a newcomer.

This PR includes 4 commits, which can be summarized as follows:

- ~`Patch drupal/geofield for Issue #3545961: Provide geofield.geophp and geofield.wkt_generator service aliases for autowiring` - This is just a small patch to the [Geofield](https://drupal.org/project/geofield) to support autowiring in farmOS. We use two of that module's services in some of our classes, but the latest release of that module does not currently provide an autowiring alias for them, which means we would need to explicitly add `#[Autowire(service: 'geofield.geophp')]` in each of their constructors to use autowiring. The Geofield maintainers have already committed aliases to the dev branch, so we will be able to remove this patch as soon as they release a new stable version that includes those changes. At that point, our automated builds will start to fail (because this patch will no longer apply), which will tell us it's time to remove the patch.~ **Edit:** A new version of Geofield was released which includes this. We no longer need to patch. Now this first commit just bumps our required Geofield version to ^1.66.
- `Provide aliases for farmOS core services.` - This provides the same kind of aliases as the Geofield module to all the core services that farmOS provides. This allows Symfony to infer the service based on the interface that is passed into the constructor. Drupal core recently did the same thing: https://www.drupal.org/node/3323122
- `Autowire farmOS core services.` - This adds `autowire: true` and removes `arguments: [...]` from all module `*.services.yml` files. We will no longer need to keep these arguments (lists of service aliases) in sync with the classes that they point to. It also adds `#[Autowire(service: '...')]` in a few constructors for services that do not have an alias.
- `Use AutowireTrait to autowire ContainerInjectionInterface classes.` - A lot of our classes implement `ContainerInjectionInterface`, which requires that we add a `create()` method that declares the names of the services our class requires. These must correspond with the constructor parameters so that Symfony can initialize the class and pass in the correct dependencies to the constructor. Drupal core now provides an `AutowireTrait` that adds the `create()` method for us. This method uses reflection to figure out which services need to be passed, and allows us to remove (and stop maintaining) a lot of our `create()` methods.

Worth noting, this comment in Drupal core's `AutowireTrait`:

```
 * This trait uses reflection and may cause performance issues with classes
 * that will be instantiated multiple times.
```

I haven't experienced any performance issues in testing, so IMO we can address those individually if/when they are encountered.

Also worth noting, this PR only adds `AutowireTrait` to classes that implement `ContainerInjectionInterface`. There are other classes that still require `create()` methods to be maintained (with different method arguments), for now...

- `ContainerFactoryPluginInterface` - Plugin classes (see upstream issue: https://www.drupal.org/project/drupal/issues/3452852)
  - `public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition);`
- `ContainerDeriverInterface` - Deriver classes (I couldn't find an upstream issue for this)
  - `public static function create(ContainerInterface $container, $base_plugin_id)`

... so hopefully we can remove those in the future when Drupal core figures out how they are going to handle them.