### PR TITLE
Autowire classes that extend from PluginBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ requirements (inherited from Drupal 11):
 - [Title improvements to entity forms, buttons, and Views #996](https://github.com/farmOS/farmOS/pull/996)
 - [Use PHP 8 constructor property promotion #1005](https://github.com/farmOS/farmOS/pull/1005)
 - [Autowire injected service dependencies #1006](https://github.com/farmOS/farmOS/pull/1006)
+- [Autowire classes that extend from PluginBase #1008](https://github.com/farmOS/farmOS/pull/1008)
 - [Convert all procedural hook implementations to Hook classes #1007](https://github.com/farmOS/farmOS/pull/1007)
 - [Implement ManagedRolePermissions access policy and simple_oauth scope granularity #922](https://github.com/farmOS/farmOS/pull/922)
 - [Change farmOS Update config revert logic from opt-out to opt-in #1011](https://github.com/farmOS/farmOS/pull/1011)

--- a/modules/asset/group/src/Plugin/views/argument/AssetGroup.php
+++ b/modules/asset/group/src/Plugin/views/argument/AssetGroup.php
@@ -9,7 +9,6 @@ use Drupal\farm_group\GroupMembershipInterface;
 use Drupal\views\Attribute\ViewsArgument;
 use Drupal\views\Plugin\views\argument\ArgumentPluginBase;
 use Drupal\views\Plugin\views\query\Sql;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * An argument for filtering assets by their current group.
@@ -27,19 +26,6 @@ class AssetGroup extends ArgumentPluginBase {
     protected GroupMembershipInterface $groupMembership,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('group.membership'),
-    );
   }
 
   /**

--- a/modules/core/asset/src/Plugin/Action/AssetClone.php
+++ b/modules/core/asset/src/Plugin/Action/AssetClone.php
@@ -36,6 +36,8 @@ class AssetClone extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
+++ b/modules/core/data_stream/modules/notification/src/Plugin/DataStream/NotificationDelivery/Email.php
@@ -12,7 +12,6 @@ use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\data_stream_notification\Attribute\NotificationDelivery;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Email notification delivery.
@@ -37,19 +36,6 @@ class Email extends NotificationDeliveryBase implements ContainerFactoryPluginIn
     protected MailManagerInterface $mailManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('email.validator'),
-      $container->get('plugin.manager.mail'),
-    );
   }
 
   /**

--- a/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
+++ b/modules/core/data_stream/src/Plugin/DataStream/DataStreamType/Basic.php
@@ -18,7 +18,6 @@ use Drupal\data_stream\Traits\DataStreamPrivateKeyAccess;
 use Drupal\fraction\Fraction;
 use Drupal\jsonapi\Exception\UnprocessableHttpEntityException;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -57,20 +56,6 @@ class Basic extends DataStreamTypeBase implements DataStreamStorageInterface, Da
     protected TimeInterface $time,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('database'),
-      $container->get('event_dispatcher'),
-      $container->get('datetime.time'),
-    );
   }
 
   /**

--- a/modules/core/entity/modules/access/src/Plugin/views/access/EntityCollection.php
+++ b/modules/core/entity/modules/access/src/Plugin/views/access/EntityCollection.php
@@ -13,7 +13,6 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_entity_access\Access\EntityCollectionAccessCheck;
 use Drupal\views\Attribute\ViewsAccess;
 use Drupal\views\Plugin\views\access\AccessPluginBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\Route;
 
 /**
@@ -38,18 +37,6 @@ class EntityCollection extends AccessPluginBase implements CacheableDependencyIn
     protected EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-    );
   }
 
   /**

--- a/modules/core/entity/src/FarmEntityTypeBase.php
+++ b/modules/core/entity/src/FarmEntityTypeBase.php
@@ -7,7 +7,6 @@ namespace Drupal\farm_entity;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\farm_field\FarmFieldFactoryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a FarmEntityTypeBase for plugins to extends.
@@ -21,18 +20,6 @@ abstract class FarmEntityTypeBase extends PluginBase implements ContainerFactory
     protected FarmFieldFactoryInterface $farmFieldFactory,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('farm_field.factory')
-    );
   }
 
 }

--- a/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/EntityCsv.php
@@ -38,6 +38,8 @@ class EntityCsv extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
+++ b/modules/core/export/modules/csv/src/Plugin/Action/LogQuantityCsv.php
@@ -38,6 +38,8 @@ class LogQuantityCsv extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
+++ b/modules/core/export/modules/kml/src/Plugin/Action/EntityKml.php
@@ -45,6 +45,8 @@ class EntityKml extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/flag/src/Plugin/Action/EntityFlag.php
+++ b/modules/core/flag/src/Plugin/Action/EntityFlag.php
@@ -38,6 +38,8 @@ class EntityFlag extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
+++ b/modules/core/id_tag/src/Plugin/Field/FieldFormatter/IdTagFormatter.php
@@ -39,6 +39,8 @@ class IdTagFormatter extends FormatterBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $plugin_id,
       $plugin_definition,

--- a/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
+++ b/modules/core/image/src/Plugin/ImageEffect/AutoOrientImageEffect.php
@@ -37,6 +37,8 @@ class AutoOrientImageEffect extends ImageEffectBase implements ContainerFactoryP
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMenuLink.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMenuLink.php
@@ -22,6 +22,8 @@ class CsvImportMenuLink extends DeriverBase implements ContainerDeriverInterface
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('plugin.manager.migration'),
     );

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationBase.php
@@ -40,6 +40,8 @@ abstract class CsvImportMigrationBase extends DeriverBase implements ContainerDe
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager'),
       $container->get('entity_field.manager'),

--- a/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
+++ b/modules/core/import/modules/csv/src/Plugin/migrate/source/CSVFile.php
@@ -56,6 +56,8 @@ class CSVFile extends CSV implements ContainerFactoryPluginInterface {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/location/src/Plugin/views/argument/AssetLocation.php
+++ b/modules/core/location/src/Plugin/views/argument/AssetLocation.php
@@ -9,7 +9,6 @@ use Drupal\farm_location\AssetLocationInterface;
 use Drupal\views\Attribute\ViewsArgument;
 use Drupal\views\Plugin\views\argument\ArgumentPluginBase;
 use Drupal\views\Plugin\views\query\Sql;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * An argument for filtering assets by their current location.
@@ -27,19 +26,6 @@ class AssetLocation extends ArgumentPluginBase {
     protected AssetLocationInterface $assetLocation,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('asset.location'),
-    );
   }
 
   /**

--- a/modules/core/log/src/Plugin/Action/AssetAddLog.php
+++ b/modules/core/log/src/Plugin/Action/AssetAddLog.php
@@ -38,6 +38,8 @@ class AssetAddLog extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/map/src/Plugin/Block/MapBlock.php
+++ b/modules/core/map/src/Plugin/Block/MapBlock.php
@@ -11,7 +11,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginDependencyTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a map block.
@@ -31,18 +30,6 @@ class MapBlock extends BlockBase implements ContainerFactoryPluginInterface {
     protected EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-    );
   }
 
   /**

--- a/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
+++ b/modules/core/map/src/Plugin/Field/FieldFormatter/GeofieldFormatter.php
@@ -39,6 +39,8 @@ class GeofieldFormatter extends FormatterBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $plugin_id,
       $plugin_definition,

--- a/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
+++ b/modules/core/map/src/Plugin/Field/FieldWidget/GeofieldWidget.php
@@ -68,6 +68,8 @@ class GeofieldWidget extends GeofieldBaseWidget {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $plugin_id,
       $plugin_definition,

--- a/modules/core/organization/src/Plugin/Action/OrganizationClone.php
+++ b/modules/core/organization/src/Plugin/Action/OrganizationClone.php
@@ -36,6 +36,8 @@ class OrganizationClone extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/owner/src/Plugin/Action/AssignBase.php
+++ b/modules/core/owner/src/Plugin/Action/AssignBase.php
@@ -30,6 +30,8 @@ abstract class AssignBase extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/parent/src/Plugin/Action/AssetParent.php
+++ b/modules/core/parent/src/Plugin/Action/AssetParent.php
@@ -38,6 +38,8 @@ class AssetParent extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/quantity/src/Plugin/migrate/process/CreateQuantity.php
+++ b/modules/core/quantity/src/Plugin/migrate/process/CreateQuantity.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\quantity\Plugin\migrate\process;
 
 use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\Attribute\MigrateProcess;
 use Drupal\migrate\MigrateExecutableInterface;
@@ -28,24 +29,25 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 )]
 class CreateQuantity extends ProcessPluginBase implements ContainerFactoryPluginInterface {
 
-  /**
-   * Quantity entity storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $quantityStorage;
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = new static(
+    return new static(
       $configuration,
       $plugin_id,
-      $plugin_definition
+      $plugin_definition,
+      $container->get('entity_type.manager'),
     );
-    $instance->quantityStorage = $container->get('entity_type.manager')->getStorage('quantity');
-    return $instance;
   }
 
   /**
@@ -78,7 +80,7 @@ class CreateQuantity extends ProcessPluginBase implements ContainerFactoryPlugin
 
         // Create the entity.
         /** @var \Drupal\quantity\Entity\QuantityInterface $entity */
-        $entity = $this->quantityStorage->create($entity_values);
+        $entity = $this->entityTypeManager->getStorage('quantity')->create($entity_values);
 
         // Validate the entity.
         /** @var \Symfony\Component\Validator\ConstraintViolationInterface[] $violations */

--- a/modules/core/quantity/src/Plugin/migrate/process/CreateQuantity.php
+++ b/modules/core/quantity/src/Plugin/migrate/process/CreateQuantity.php
@@ -12,7 +12,6 @@ use Drupal\migrate\MigrateExecutableInterface;
 use Drupal\migrate\MigrateSkipRowException;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\Row;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Create quantity entities.
@@ -36,18 +35,6 @@ class CreateQuantity extends ProcessPluginBase implements ContainerFactoryPlugin
     protected EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-    );
   }
 
   /**

--- a/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
+++ b/modules/core/quick/src/Plugin/Action/QuickFormActionBase.php
@@ -30,6 +30,8 @@ abstract class QuickFormActionBase extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormMenuLink.php
@@ -23,6 +23,8 @@ class QuickFormMenuLink extends DeriverBase implements ContainerDeriverInterface
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('quick_form.instance_manager'),
     );

--- a/modules/core/quick/src/Plugin/Derivative/QuickFormTaskLink.php
+++ b/modules/core/quick/src/Plugin/Derivative/QuickFormTaskLink.php
@@ -25,6 +25,8 @@ class QuickFormTaskLink extends DeriverBase implements ContainerDeriverInterface
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('quick_form.instance_manager')
     );

--- a/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
+++ b/modules/core/quick/src/Plugin/QuickForm/QuickFormBase.php
@@ -12,7 +12,6 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Psr\Container\ContainerInterface;
 
 /**
  * Base class for quick forms.
@@ -37,19 +36,6 @@ class QuickFormBase extends PluginBase implements QuickFormInterface, ContainerF
     protected AccountInterface $currentUser,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-    );
   }
 
   /**

--- a/modules/core/role/src/Plugin/ScopeGranularity/ManagedRole.php
+++ b/modules/core/role/src/Plugin/ScopeGranularity/ManagedRole.php
@@ -35,6 +35,7 @@ class ManagedRole extends Role implements ContainerFactoryPluginInterface {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $pluginId, $pluginDefinition) {
+    // @todo Use autowiring and remove this when the parent class does.
     return new static(
       $configuration,
       $pluginId,

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -29,6 +29,8 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager'),
       $container->get('module_handler'),

--- a/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
+++ b/modules/core/ui/action/src/Plugin/Menu/LocalAction/AddEntity.php
@@ -37,6 +37,8 @@ class AddEntity extends LocalActionDefault {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/ui/location/src/Plugin/Derivative/AddLocationAssetAction.php
+++ b/modules/core/ui/location/src/Plugin/Derivative/AddLocationAssetAction.php
@@ -25,6 +25,8 @@ class AddLocationAssetAction extends DeriverBase implements ContainerDeriverInte
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager'),
     );

--- a/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
+++ b/modules/core/ui/menu/src/Menu/EntityTypeLabelLocalTask.php
@@ -33,6 +33,9 @@ class EntityTypeLabelLocalTask extends LocalTaskDefault implements ContainerFact
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Remove this when \Drupal\Core\Menu\LocalTaskDefault extends from
+    // \Drupal\Core\Plugin\PluginBase.
+    // @see https://www.drupal.org/project/drupal/issues/3565337
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
+++ b/modules/core/ui/metrics/src/Plugin/Block/FarmMetricsBlock.php
@@ -11,7 +11,6 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a 'Metrics' block.
@@ -30,19 +29,6 @@ class FarmMetricsBlock extends BlockBase implements ContainerFactoryPluginInterf
     protected EntityTypeBundleInfoInterface $bundleInfo,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('entity_type.bundle.info')
-    );
   }
 
   /**

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmLogViewsTaskLink.php
@@ -25,6 +25,8 @@ class FarmLogViewsTaskLink extends DeriverBase implements ContainerDeriverInterf
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager'),
     );

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmOrganizationViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmOrganizationViewsTaskLink.php
@@ -25,6 +25,8 @@ class FarmOrganizationViewsTaskLink extends DeriverBase implements ContainerDeri
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager'),
     );

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmTaxonomyTermViewsTaskLink.php
@@ -27,6 +27,8 @@ class FarmTaxonomyTermViewsTaskLink extends DeriverBase implements ContainerDeri
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager'),
       $container->get('entity_type.bundle.info')

--- a/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
+++ b/modules/core/ui/views/src/Plugin/Derivative/FarmViewsMenuLink.php
@@ -41,6 +41,8 @@ class FarmViewsMenuLink extends ViewsMenuLink {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, $base_plugin_id) {
+    // @todo Remove when DeriverBase provides a create() method with autowiring.
+    // @see https://www.drupal.org/project/drupal/issues/3565338
     return new static(
       $container->get('entity_type.manager')->getStorage('view'),
       $container->get('entity_type.manager'),

--- a/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
@@ -12,7 +12,6 @@ use Drupal\views\Attribute\ViewsArgument;
 use Drupal\views\Plugin\views\argument\NumericArgument;
 use Drupal\views\Plugin\views\query\Sql;
 use Drupal\views\Views;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Argument handler for taxonomy term references from an arbitrary entity field.
@@ -31,19 +30,6 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
     protected EntityFieldManagerInterface $entityFieldManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('entity_type.bundle.info'),
-      $container->get('entity_field.manager'));
   }
 
   /**

--- a/modules/organization/farm/src/Plugin/Action/AssetFarm.php
+++ b/modules/organization/farm/src/Plugin/Action/AssetFarm.php
@@ -38,6 +38,8 @@ class AssetFarm extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick_birth\Plugin\QuickForm;
 
+use Drupal\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -12,7 +13,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\farm_group\GroupMembershipInterface;
 use Drupal\farm_id_tag\FarmIdTagHelper;
 use Drupal\farm_location\AssetLocationInterface;
 use Drupal\farm_quick\Attribute\QuickForm;
@@ -20,7 +20,7 @@ use Drupal\farm_quick\Plugin\QuickForm\QuickFormBase;
 use Drupal\farm_quick\Traits\QuickAssetTrait;
 use Drupal\farm_quick\Traits\QuickLogTrait;
 use Drupal\farm_quick\Traits\QuickStringTrait;
-use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Birth quick form.
@@ -51,7 +51,8 @@ class Birth extends QuickFormBase {
     protected ModuleHandlerInterface $moduleHandler,
     protected ConfigFactoryInterface $configFactory,
     protected AssetLocationInterface $assetLocation,
-    protected ?GroupMembershipInterface $groupMembership = NULL,
+    #[Autowire(service: 'service_container')]
+    protected ContainerInterface $container,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
   }
@@ -69,12 +70,6 @@ class Birth extends QuickFormBase {
       $container->get('module_handler'),
       $container->get('config.factory'),
       $container->get('asset.location'),
-      // PHPStan level 3+ throws the following error on the next line:
-      // Ternary operator condition is always true.
-      // We ignore this because we know that the group.membership service will
-      // not exist if the group module is not installed.
-      // @phpstan-ignore ternary.alwaysTrue
-      $container->has('group.membership') ? $container->get('group.membership') : NULL,
     );
   }
 
@@ -433,8 +428,13 @@ class Birth extends QuickFormBase {
       if (!empty($group)) {
         $group = [$this->entityTypeManager->getStorage('asset')->load($group)];
       }
-      if (empty($group) && $this->groupMembership !== NULL) {
-        $group = $this->groupMembership->getGroup($birth_mother, $birthdate->getTimestamp());
+      // PHPStan throws the following error on the next line:
+      // Right side of && is always true.
+      // We ignore this because we need to check that the group.membership
+      // container service exists before we use it.
+      // @phpstan-ignore booleanAnd.rightAlwaysTrue
+      if (empty($group) && $this->container->has('group.membership')) {
+        $group = $this->container->get('group.membership')->getGroup($birth_mother, $birthdate->getTimestamp());
       }
       if (!empty($group)) {
         $birth_log_values['group'] = $group;

--- a/modules/quick/birth/src/Plugin/QuickForm/Birth.php
+++ b/modules/quick/birth/src/Plugin/QuickForm/Birth.php
@@ -60,22 +60,6 @@ class Birth extends QuickFormBase {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('module_handler'),
-      $container->get('config.factory'),
-      $container->get('asset.location'),
-    );
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
     // Date of birth.

--- a/modules/quick/group/src/Plugin/QuickForm/Group.php
+++ b/modules/quick/group/src/Plugin/QuickForm/Group.php
@@ -19,7 +19,6 @@ use Drupal\farm_quick\Traits\QuickFormElementsTrait;
 use Drupal\farm_quick\Traits\QuickLogTrait;
 use Drupal\farm_quick\Traits\QuickPrepopulateTrait;
 use Drupal\farm_quick\Traits\QuickStringTrait;
-use Psr\Container\ContainerInterface;
 
 /**
  * Group quick form.
@@ -49,20 +48,6 @@ class Group extends QuickFormBase implements QuickFormInterface {
     protected GroupMembershipInterface $groupMembership,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('group.membership'),
-    );
   }
 
   /**

--- a/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
+++ b/modules/quick/inventory/src/Plugin/QuickForm/Inventory.php
@@ -23,7 +23,6 @@ use Drupal\farm_quick\Traits\QuickTermTrait;
 use Drupal\log\Entity\Log;
 use Drupal\quantity\QuantityHelper;
 use Drupal\taxonomy\TermInterface;
-use Psr\Container\ContainerInterface;
 
 /**
  * Inventory quick form.
@@ -51,20 +50,6 @@ class Inventory extends QuickFormBase implements ConfigurableQuickFormInterface 
     protected AssetInventoryInterface $assetInventory,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('asset.inventory'),
-    );
   }
 
   /**

--- a/modules/quick/movement/src/Plugin/QuickForm/Movement.php
+++ b/modules/quick/movement/src/Plugin/QuickForm/Movement.php
@@ -20,7 +20,6 @@ use Drupal\farm_quick\Traits\QuickFormElementsTrait;
 use Drupal\farm_quick\Traits\QuickLogTrait;
 use Drupal\farm_quick\Traits\QuickPrepopulateTrait;
 use Drupal\farm_quick\Traits\QuickStringTrait;
-use Psr\Container\ContainerInterface;
 
 /**
  * Movement quick form.
@@ -51,20 +50,6 @@ class Movement extends QuickFormBase implements QuickFormInterface {
     protected AssetLocationInterface $assetLocation,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('asset.location'),
-    );
   }
 
   /**

--- a/modules/quick/planting/src/Plugin/QuickForm/Planting.php
+++ b/modules/quick/planting/src/Plugin/QuickForm/Planting.php
@@ -20,7 +20,6 @@ use Drupal\farm_quick\Traits\QuickLogTrait;
 use Drupal\farm_quick\Traits\QuickStringTrait;
 use Drupal\quantity\QuantityHelper;
 use Drupal\taxonomy\TermInterface;
-use Psr\Container\ContainerInterface;
 
 /**
  * Planting quick form.
@@ -53,21 +52,6 @@ class Planting extends QuickFormBase {
     protected StateInterface $state,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $current_user);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('entity_type.manager'),
-      $container->get('current_user'),
-      $container->get('module_handler'),
-      $container->get('state'),
-    );
   }
 
   /**

--- a/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
+++ b/modules/taxonomy/log_category/src/Plugin/Action/LogCategorize.php
@@ -38,6 +38,8 @@ class LogCategorize extends EntityActionBase {
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @todo Use autowiring and remove this when the parent class does.
+    // @see https://www.drupal.org/project/drupal/issues/3552110
     return new static(
       $configuration,
       $plugin_id,


### PR DESCRIPTION
Follow-up to #1006. This removes the `create()` class from *many* of our classes that extend from `PluginBase`.

Depends on Drupal 11.3. See relevant change record: https://www.drupal.org/node/3542837

This includes two commits before the change which simplify the `create()` methods in the `CreateQuantity` class and `Birth` quick form class.

There are many classes that we still cannot remove the `create()` function from, specifically ones that extend from core/contrib base classes that still implement their own versions of the method (for various reasons), including:

- `\Drupal\Core\Action\Plugin\Action` (eg: `AssetAddLog`, `AssetClone`, `EntityCsv`, and 9 others)
- `\Drupal\Core\Field\FormatterBase` (eg: `IdTagFormatter` and `GeofieldFormatter`)
- `\Drupal\Core\Field\WidgetBase` (eg: `GeofieldWidget`)
- `\Drupal\Core\Menu\LocalTaskDefault` (eg: `AddEntity`)
- `\Drupal\image\ImageEffectBase` (eg: `AutoOrientImageEffect`)
- `\Drupal\migrate\Plugin\migrate\source\SourcePluginBase` (eg: `CSVFile`)
- `\Drupal\simple_oauth\Plugin\ScopeGranularity\Role` (eg: `ManagedRole`)

Many of these will be resolved by this upstream issue: https://www.drupal.org/project/drupal/issues/3552110

I added `@todo` comments (in a followup commit) to all the remaining <code>create()</code> methods and opened the following upstream Drupal core issue for `LocalTaskDefault`: [Extend \Drupal\Core\Menu\LocalTaskDefault from \Drupal\Core\Plugin\PluginBase](https://www.drupal.org/project/drupal/issues/3565337)

I also created an upstream Drupal core issue for `DeriverBase`, which is technically different but represents the other set of `create()` methods we use: [Add create() factory method with autowired parameters to DeriverBase](https://www.drupal.org/project/drupal/issues/3565338)