### PR TITLE
Run Docker container as www-data user

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -183,12 +183,14 @@ jobs:
           docker compose -f docker-compose.testing.common.yml -f docker-compose.testing.${{ matrix.dbms }}.yml config > docker-compose.yml
           # Replace the generic 'farmos/farmos:${FARMOS_DEV_BRANCH}-dev' image name/tag with the reference to our local platform-specific tagged image
           sed -i "s%farmos/farmos:${FARMOS_DEV_BRANCH}-dev%${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-${{ matrix.platform }}%g" docker-compose.yml
+      - name: Create www directory owned by www-data for bind-mount volume.
+        run: mkdir www && sudo chown 1000:1000 www
       - name: Start containers
         run: docker compose up -d
       - name: Wait until www container is ready
       # The www-container-fs-ready file is only created once we expect the containers to be online
       # so waiting for that lets us know it is safe to start the tests
-        run: until [ -f ./www/www-container-fs-ready ]; do sleep 0.1; done
+        run: sudo bash -c 'until [ -f ./www/www-container-fs-ready ]; do sleep 0.1; done'
       - name: Install pg_trgm PostgreSQL extension
       # This avoids race conditions when trying to automatically install it in concurrently run tests.
         if: matrix.dbms == 'pgsql'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ requirements (inherited from Drupal 11):
 
 - [farmOS 4.x requires PHP 8.4 #979](https://github.com/farmOS/farmOS/pull/979)
 - [Issue #3488916: Update Drupal core to 11.x](https://www.drupal.org/project/farm/issues/3488916)
+- [Run Docker container as www-data user #1009](https://github.com/farmOS/farmOS/pull/1009)
 - [Update Drupal to v11.2, PHPUnit to v11, PHPStan to v2 #980](https://github.com/farmOS/farmOS/pull/980)
 - [Update Docker base image to Debian Trixie #992](https://github.com/farmOS/farmOS/pull/992)
 - [Change how assets and plans are archived #986](https://github.com/farmOS/farmOS/pull/986)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -146,6 +146,12 @@ RUN rm -r ${DRUPAL_PATH} && cp -rp ${BUILD_PATH} ${DRUPAL_PATH}
 # Create a Composer config directory for the www-data user.
 RUN mkdir /var/www/.composer && chown www-data:www-data /var/www/.composer
 
+# Run as www-data.
+USER www-data
+
 ##
 # Build the final production image.
 FROM production
+
+# Run as www-data.
+USER www-data

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -9,14 +9,24 @@ set -e
 
 # If the Drupal directory is empty, populate it from pre-built files.
 if [ -d ${DRUPAL_PATH} ] && ! [ "$(ls -A ${DRUPAL_PATH}/)" ]; then
-  echo "farmOS codebase not detected. Copying from pre-built files in the Docker image."
-  cp -rp ${BUILD_PATH}/. ${DRUPAL_PATH}
+  if [ -w "${DRUPAL_PATH}" ]; then
+    echo "farmOS codebase not detected. Copying from pre-built files in the Docker image."
+    cp -rp ${BUILD_PATH}/. ${DRUPAL_PATH}
+  else
+    echo "Error initializing ${DRUPAL_PATH}. The directory must be writable by ${USER} (user ID $(id -u)) inside the container."
+    exit 1
+  fi
 fi
 
 # If the sites directory is empty, populate it from pre-built files.
 if [ -d ${DRUPAL_PATH}/web/sites ] && ! [ "$(ls -A ${DRUPAL_PATH}/web/sites/)" ]; then
-  echo "farmOS sites directory not detected. Copying from pre-built files in the Docker image."
-  cp -rp ${BUILD_PATH}/web/sites/. ${DRUPAL_PATH}/web/sites
+  if [ -w "${DRUPAL_PATH}/web/sites" ]; then
+    echo "farmOS sites directory is empty. Copying from pre-built files in the Docker image."
+    cp -rp ${BUILD_PATH}/web/sites/. ${DRUPAL_PATH}/web/sites
+  else
+    echo "Error initializing ${DRUPAL_PATH}/web/sites. The directory must be writable by ${USER} (user ID $(id -u)) inside the container."
+    exit 1
+  fi
 fi
 
 if [ -n "$FARMOS_FS_READY_SENTINEL_FILENAME" ]; then

--- a/docs/development/environment/index.md
+++ b/docs/development/environment/index.md
@@ -6,10 +6,10 @@ The only requirement is [Docker](https://www.docker.com).
 
 ## 1. Set up Docker containers
 
-Run the following commands to create a farmOS directory and set up Docker
-containers for farmOS and PostgreSQL:
+Run the following commands to create directories for your local environment and
+set up Docker containers for farmOS and PostgreSQL:
 
-    mkdir farmOS && cd farmOS
+    mkdir -p farmOS/www && cd farmOS
     curl https://raw.githubusercontent.com/farmOS/farmOS/4.x/docker/docker-compose.development.yml -o docker-compose.yml
     docker compose up -d
 

--- a/docs/hosting/docker.md
+++ b/docs/hosting/docker.md
@@ -17,7 +17,12 @@ continue with the [farmOS installation steps](/hosting/install).
 
 ## Docker Run
 
-The following command will run farmOS in a Docker container (replace `x.y.z`
+Start by creating a directory for site data to be stored in, owned by user/group
+ID `33` (`www-data` inside the Docker container).
+
+    mkdir sites && sudo chown 33:33 sites
+
+Use the following command to run farmOS in a Docker container (replace `x.y.z`
 with the latest stable release version from the
 [GitHub releases page](https://github.com/farmOS/farmOS/releases)):
 


### PR DESCRIPTION
Opening up this draft PR in the hopes that we can include it as a breaking change for 4.x.

The official farmOS Docker images currently run as `root` by default. It would be better security practice to run as `www-data` by default.

We looked into this previously (in #734), and found some considerations that warranted more review and discussion, so we decided to tackle it in its own PR.