### PR TITLE
Allow API access to organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ requirements (inherited from Drupal 11):
 ### Added
 
 - [Add an Organization entity type with a Farm bundle #849](https://github.com/farmOS/farmOS/pull/849)
+- [Allow API access to organizations #1010](https://github.com/farmOS/farmOS/pull/1010)
 - [Issue #3304608: Add an "abandoned" log status](https://www.drupal.org/project/farm/issues/3304608)
 - [Add default plan status options: "planning", "done", "abandoned" #986](https://github.com/farmOS/farmOS/pull/986)
 - [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)

--- a/modules/core/api/src/Hook/ApiHooks.php
+++ b/modules/core/api/src/Hook/ApiHooks.php
@@ -27,6 +27,8 @@ class ApiHooks {
       'file',
       'log',
       'log_type',
+      'organization',
+      'organization_type',
       'plan',
       'plan_type',
       'plan_record',


### PR DESCRIPTION
This is a follow-up to #849 (which added the `organization` entity type) and #964 (which replaced the `jsonapi_extras` module with our own logic for hiding internal resource types in `/api` endpoints).

This simply adds `organization` and `organization_type` to the list of "allowed" resource types that farmOS makes accessible via the `/api` endpoints.

(Thanks to @ktohalloran for reporting this omission.)