### PR TITLE
Remove unused ManagedRolePermissionsManager service from AssignActionForm

### DIFF
--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -12,7 +12,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
-use Drupal\farm_role\ManagedRolePermissionsManagerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -39,7 +38,6 @@ class AssignActionForm extends ConfirmFormBase {
   public function __construct(
     protected PrivateTempStoreFactory $tempStoreFactory,
     protected EntityTypeManagerInterface $entityTypeManager,
-    protected ManagedRolePermissionsManagerInterface $managedRolePermissionsManager,
     protected AccountInterface $user,
   ) {}
 


### PR DESCRIPTION
The `AssignActionForm` of `farm_owner` was injecting a service provided by `farm_role` but then not using it, adding an unnecessary dependency on the `farm_role` module. 