### PR TITLE
Add update hook to update entity revisions with revision_user set to anonymous user

### DIFF
--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -89,4 +89,16 @@ function farm_entity_post_update_update_anonymous_log_revisions(&$sandbox = NULL
       ->execute();
     \Drupal::logger('farm_entity')->notice('Updated @count plan revisions with correct revision_user.', ['@count' => $updated]);
   }
+
+  // Update quantities.
+  if (\Drupal::service('module_handler')->moduleExists('quantity')) {
+
+    // Note that quantities have a single quantity_revision table.
+    // Update anonymous quantity revision_user to the original creator uid.
+    $updated = $connection->update('quantity_revision')
+      ->expression('revision_user', 'quantity_revision.uid')
+      ->condition('revision_user', 0)
+      ->execute();
+    \Drupal::logger('farm_entity')->notice('Updated @count quantity revisions with correct revision_user.', ['@count' => $updated]);
+  }
 }

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Database\Database;
+
 /**
  * Enforce entity reference integrity on plan reference fields.
  */
@@ -35,4 +37,25 @@ function farm_entity_post_update_uninstall_exif_orientation() {
       \Drupal::service('module_installer')->uninstall(['exif_orientation']);
     }
   }
+}
+
+/**
+ * Update log revisions with revision_user set to anonymous user.
+ */
+function farm_entity_post_update_update_anonymous_log_revisions(&$sandbox = NULL) {
+
+  // Create a subquery to get the original creator uid.
+  $connection = Database::getConnection();
+  $subquery = $connection->select('log_field_revision', 'lfr')
+    ->fields('lfr', ['uid'])
+    ->where('lfr.id = log_revision.id')
+    ->where('lfr.revision_id = log_revision.revision_id');
+
+  // Update anonymous log revision_user to the original creator uid.
+  $updated = $connection->update('log_revision')
+    ->expression('revision_user', "($subquery)")
+    ->condition('revision_user', 0)
+    ->execute();
+
+  \Drupal::logger('farm_entity')->notice('Updated @count log revisions with correct revision_user.', ['@count' => $updated]);
 }

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -43,9 +43,10 @@ function farm_entity_post_update_uninstall_exif_orientation() {
  * Update log revisions with revision_user set to anonymous user.
  */
 function farm_entity_post_update_update_anonymous_log_revisions(&$sandbox = NULL) {
-
-  // Create a subquery to get the original creator uid.
   $connection = Database::getConnection();
+
+  // Update logs.
+  // Create a subquery to get the original creator uid.
   $subquery = $connection->select('log_field_revision', 'lfr')
     ->fields('lfr', ['uid'])
     ->where('lfr.id = log_revision.id')
@@ -56,6 +57,36 @@ function farm_entity_post_update_update_anonymous_log_revisions(&$sandbox = NULL
     ->expression('revision_user', "($subquery)")
     ->condition('revision_user', 0)
     ->execute();
-
   \Drupal::logger('farm_entity')->notice('Updated @count log revisions with correct revision_user.', ['@count' => $updated]);
+
+  // Update assets.
+  // Create a subquery to get the original creator uid.
+  $subquery = $connection->select('asset_field_revision', 'afr')
+    ->fields('afr', ['uid'])
+    ->where('afr.id = asset_revision.id')
+    ->where('afr.revision_id = asset_revision.revision_id');
+
+  // Update anonymous asset revision_user to the original creator uid.
+  $updated = $connection->update('asset_revision')
+    ->expression('revision_user', "($subquery)")
+    ->condition('revision_user', 0)
+    ->execute();
+  \Drupal::logger('farm_entity')->notice('Updated @count asset revisions with correct revision_user.', ['@count' => $updated]);
+
+  // Update plans.
+  if (\Drupal::service('module_handler')->moduleExists('plan')) {
+
+    // Create a subquery to get the original creator uid.
+    $subquery = $connection->select('plan_field_revision', 'pfr')
+      ->fields('pfr', ['uid'])
+      ->where('pfr.id = plan_revision.id')
+      ->where('pfr.revision_id = plan_revision.revision_id');
+
+    // Update anonymous plan revision_user to the original creator uid.
+    $updated = $connection->update('plan_revision')
+      ->expression('revision_user', "($subquery)")
+      ->condition('revision_user', 0)
+      ->execute();
+    \Drupal::logger('farm_entity')->notice('Updated @count plan revisions with correct revision_user.', ['@count' => $updated]);
+  }
 }


### PR DESCRIPTION
_As reported in https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/855 and tracking in https://github.com/Rothamsted-Ecoinformatics/farm_rothamsted/issues/861_

This is related to an issue we have since fixed concerning out logic to "force entity revision creation": https://github.com/farmOS/farmOS/pull/988

Throughout the time this bug existed it appears there was an additional side-effect: any entities entities that were _not created_ via standard entity forms had an issue where the `revision_user` was set to the Anonymous user. A common example of this would be logs/assets created via our Quick Forms. If the entity was later modified using the standard Edit form, the revision user would then be populated correctly on the new revision, but not old revisions.

Thankfully, because the user that originally created these entities is saved in the `uid` data field, we have the opportunity to update the original `revision_user` to this value.

Looking back at #988 I suppose we need to fix this for all of asset, log, plan and quantity entities.