### PR TITLE
Show violation messages when validation fails in bulk action forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ requirements (inherited from Drupal 11):
 - Add support for decimal and integer fields in CSV importers.
 - [Add map layer for "Other Location" assets #966](https://github.com/farmOS/farmOS/pull/966)
 - [Add ability to assign plan ownership #1015](https://github.com/farmOS/farmOS/pull/1015)
+- [Show violation messages when validation fails in bulk action forms #1018](https://github.com/farmOS/farmOS/pull/1018)
 
 ### Changed
 

--- a/modules/core/flag/src/Form/EntityFlagActionForm.php
+++ b/modules/core/flag/src/Form/EntityFlagActionForm.php
@@ -187,6 +187,9 @@ class EntityFlagActionForm extends ConfirmFormBase {
             ],
           ),
         );
+        foreach ($violations as $violation) {
+          $this->messenger()->addWarning($violation->getMessage());
+        }
         continue;
       }
 

--- a/modules/core/owner/src/Form/AssignActionForm.php
+++ b/modules/core/owner/src/Form/AssignActionForm.php
@@ -188,6 +188,9 @@ class AssignActionForm extends ConfirmFormBase {
             ],
           ),
         );
+        foreach ($violations as $violation) {
+          $this->messenger()->addWarning($violation->getMessage());
+        }
         continue;
       }
 

--- a/modules/core/parent/src/Form/AssetParentActionForm.php
+++ b/modules/core/parent/src/Form/AssetParentActionForm.php
@@ -193,6 +193,9 @@ class AssetParentActionForm extends ConfirmFormBase {
             ],
           ),
         );
+        foreach ($violations as $violation) {
+          $this->messenger()->addWarning($violation->getMessage());
+        }
         continue;
       }
 

--- a/modules/organization/farm/src/Form/AssetFarmActionForm.php
+++ b/modules/organization/farm/src/Form/AssetFarmActionForm.php
@@ -168,6 +168,9 @@ class AssetFarmActionForm extends ConfirmFormBase {
             ],
           ),
         );
+        foreach ($violations as $violation) {
+          $this->messenger()->addWarning($violation->getMessage());
+        }
         continue;
       }
 


### PR DESCRIPTION
farmOS provides a number of bulk action forms (eg: for flagging assets/logs, assigning owners, etc). All of these forms perform entity validation (`$entity->validate()`) and print a standard message if validation fails (eg: "Could not flag <a href=":entity_link">%entity_label</a>: validation failed."). But they do not provide any details on what failed, specifically.

This PR adds warning messages for each violation, so the user can see exactly what was invalid.