### PR TITLE
Do not use birth log label in child revision log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ requirements (inherited from Drupal 11):
 - [Do not set blank revision log messages #1029](https://github.com/farmOS/farmOS/pull/1029)
 - [Sort user selection alphabetically by name #1026](https://github.com/farmOS/farmOS/pull/1026)
 - [Sort "Active plans" by last updated #1027](https://github.com/farmOS/farmOS/pull/1027)
+- [Do not use birth log label in child revision log message #1019](https://github.com/farmOS/farmOS/pull/1019)
 
 ### Deprecated
 

--- a/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
+++ b/modules/log/birth/src/EventSubscriber/LogEventSubscriber.php
@@ -74,8 +74,9 @@ class LogEventSubscriber implements EventSubscriberInterface {
         $args = [
           ':child_url' => $child->toUrl()->toString(),
           '%child_name' => $child->label(),
+          ':birth_url' => $log->toUrl()->toString(),
         ];
-        $message = $this->t('<a href=":child_url">%child_name</a> date of birth was updated to match their birth log.', $args);
+        $message = $this->t('<a href=":child_url">%child_name</a> date of birth was updated to match their <a href=":birth_url">birth log</a>.', $args);
         $this->messenger->addMessage($message);
         $revision_log[] = $message;
         $child->set('birthdate', $log->get('timestamp')->value);
@@ -103,7 +104,6 @@ class LogEventSubscriber implements EventSubscriberInterface {
 
       // Save the child, if necessary.
       if ($save) {
-        $revision_log[] = $this->t('Birth log saved: <a href=":birth_url">%birth_label</a>', [':birth_url' => $log->toUrl()->toString(), '%birth_label' => $log->label()]);
         $child->setRevisionLogMessage(implode(" ", $revision_log));
         $child->save();
       }


### PR DESCRIPTION
I discovered this issue while doing manual testing for #1005, #1006, and #1007. This was unrelated to those changes, so I'm opening this as a follow-up fix.

This is related to logic we have for automatically maintaining a link between birth logs and the birthdate field on animal assets. If you create a birth log that references an animal, it will automatically update the birthday of the animal to match the timestamp of the log.

The issue occurs if you do not give the birth log a name (taking advantage of the `log` module's logic for automatically assigning log names). The following error occurs:

Uncaught PHP Exception TypeError:
"Drupal\\Component\\Utility\\Html::escape(): Argument #1 ($text) must be of type string, null given, called in
/opt/drupal/web/core/lib/Drupal/Component/Render/FormattableMarkup.php on line 238" at /opt/drupal/web/core/lib/Drupal/Component/Utility/Html.php line 433

This is because we were adding a link to the birth log in the animal asset's revision message, and passing in the blank log name (because it wasn't set yet).

This changes the logic so that we don't try to use the name of the log anymore, thereby sidestepping the issue.