### PR TITLE
Soften farm_field module dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ requirements (inherited from Drupal 11):
 - [Sort user selection alphabetically by name #1026](https://github.com/farmOS/farmOS/pull/1026)
 - [Sort "Active plans" by last updated #1027](https://github.com/farmOS/farmOS/pull/1027)
 - [Do not use birth log label in child revision log message #1019](https://github.com/farmOS/farmOS/pull/1019)
+- [Soften farm_field module dependencies #1020](https://github.com/farmOS/farmOS/pull/1020)
 
 ### Deprecated
 

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -68,6 +68,7 @@ class GroupTest extends KernelTestBase {
     'farm_location',
     'farm_log',
     'farm_log_asset',
+    'farm_map',
     'geofield',
     'state_machine',
     'system',

--- a/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
@@ -43,9 +43,14 @@ class FarmEntityFieldTest extends KernelTestBase {
     'farm_location',
     'farm_log',
     'farm_log_asset',
+    'farm_map',
     'farm_owner',
     'farm_parent',
+    'file',
+    'image',
+    'options',
     'taxonomy',
+    'text',
     'user',
   ];
 

--- a/modules/core/field/farm_field.info.yml
+++ b/modules/core/field/farm_field.info.yml
@@ -6,6 +6,4 @@ core_version_requirement: ^11
 dependencies:
   - drupal:field
   - entity:entity
-  - farm:farm_map
-  - fraction:fraction
   - inline_entity_form:inline_entity_form

--- a/modules/core/field/farm_field.services.yml
+++ b/modules/core/field/farm_field.services.yml
@@ -1,4 +1,6 @@
 services:
+  _defaults:
+    autowire: true
   farm_field.factory:
     class: Drupal\farm_field\FarmFieldFactory
   Drupal\farm_field\FarmFieldFactoryInterface: '@farm_field.factory'

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_field;
 
+use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Field\FieldException;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
@@ -14,6 +15,10 @@ use Drupal\inline_entity_form\Plugin\Field\FieldWidget\InlineEntityFormComplex;
  * Factory for generating farmOS field definitions.
  */
 class FarmFieldFactory implements FarmFieldFactoryInterface {
+
+  public function __construct(
+    protected ModuleHandlerInterface $moduleHandler,
+  ) {}
 
   /**
    * Generate a base field definition.
@@ -136,19 +141,27 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         break;
 
       case 'file':
+        $this->checkModuleDependency($options['type'], 'file');
+        $this->modifyFileField($field, $options);
+        break;
+
       case 'image':
+        $this->checkModuleDependency($options['type'], 'image');
         $this->modifyFileField($field, $options);
         break;
 
       case 'fraction':
+        $this->checkModuleDependency($options['type'], 'fraction');
         $this->modifyFractionField($field, $options);
         break;
 
       case 'geofield':
+        $this->checkModuleDependency($options['type'], 'farm_map');
         $this->modifyGeofieldField($field, $options);
         break;
 
       case 'id_tag':
+        $this->checkModuleDependency($options['type'], 'farm_id_tag');
         $this->modifyIdTagField($field, $options);
         break;
 
@@ -157,10 +170,12 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         break;
 
       case 'inventory':
+        $this->checkModuleDependency($options['type'], 'farm_inventory');
         $this->modifyInventoryField($field, $options);
         break;
 
       case 'list_string':
+        $this->checkModuleDependency($options['type'], 'options');
         $this->modifyListStringField($field, $options);
         break;
 
@@ -170,6 +185,7 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
         break;
 
       case 'text_long':
+        $this->checkModuleDependency($options['type'], 'text');
         $this->modifyTextField($field, $options);
         break;
 
@@ -349,13 +365,25 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
             'auto_create_bundle' => '',
           ];
         }
-        else {
+        elseif ($this->moduleHandler->moduleExists('farm_log_asset')) {
           $handler = 'views';
           $handler_settings = [
             'view' => [
               'view_name' => 'farm_asset_reference',
               'display_name' => 'entity_reference',
             ],
+          ];
+        }
+        else {
+          $handler = 'default:asset';
+          $handler_settings = [
+            'target_bundles' => NULL,
+            'sort' => [
+              'field' => 'name',
+              'direction' => 'asc',
+            ],
+            'auto_create' => FALSE,
+            'auto_create_bundle' => '',
           ];
         }
         $form_display_options = [
@@ -1006,6 +1034,20 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
 
     // Add URI validation constraint.
     $field->addConstraint('Uri');
+  }
+
+  /**
+   * Check if a field type's module is installed.
+   *
+   * @param string $field_type
+   *   The field type machine name.
+   * @param string $module
+   *   The module machine name.
+   */
+  protected function checkModuleDependency(string $field_type, string $module): void {
+    if (!$this->moduleHandler->moduleExists($module)) {
+      throw new FieldException('The field type "' . $field_type . '" requires the ' . $module . ' module.');
+    }
   }
 
 }

--- a/modules/core/flag/tests/src/Kernel/FlagTest.php
+++ b/modules/core/flag/tests/src/Kernel/FlagTest.php
@@ -19,11 +19,12 @@ class FlagTest extends KernelTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'asset',
     'entity',
     'farm_field',
     'farm_flag',
     'log',
-    'asset',
+    'options',
     'state_machine',
     'user',
   ];

--- a/modules/core/location/farm_location.info.yml
+++ b/modules/core/location/farm_location.info.yml
@@ -10,6 +10,7 @@ dependencies:
   - farm:farm_field
   - farm:farm_geo
   - farm:farm_log
+  - farm:farm_map
   - geofield:geofield
   - log:log
   - views_geojson:views_geojson

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -75,6 +75,7 @@ class LocationTest extends KernelTestBase {
     'farm_location_test',
     'farm_log',
     'farm_log_asset',
+    'farm_map',
     'rest',
     'serialization',
     'state_machine',

--- a/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
+++ b/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
@@ -37,6 +37,7 @@ class FieldConstraintsTest extends KernelTestBase {
     'farm_location',
     'farm_log',
     'farm_log_asset',
+    'farm_map',
     'farm_parent',
     'geofield',
     'log',


### PR DESCRIPTION
I realized recently that the `farm_field` module's `FarmFieldFactory` class has an expectation that the `farm_log_asset` module is installed, because it references the `farm_asset_reference` View provided by that module:

https://github.com/farmOS/farmOS/blob/ae67d20d8c26d067d4223a1db2ac51090bf6ee31/modules/core/field/src/FarmFieldFactory.php#L356

However, `farm_log_asset` depends on `farm_field` already, because it uses `farm_field.factory` to add the `asset` field to `log` entities. So, there is an implicit circular dependency currently.

https://github.com/farmOS/farmOS/blob/ae67d20d8c26d067d4223a1db2ac51090bf6ee31/modules/core/log/modules/asset/farm_log_asset.info.yml#L9

A simple way to fix this, without major refactoring, is to accept that `farm_field` will have some knowledge of other modules (which it does), but instead of explicitly depending on them we can add checks to see if those modules are installed before making use of their features. Aka "soft dependencies" instead of "hard dependencies"...

As I was addressing this soft dependency on `farm_log_asset`, I realized we could also soften dependencies on some other modules as well. So this PR also removes the hard dependencies on `farm_map` and `fraction` from `farm_field`. It adds checks for these modules and other core modules that `farm_field` makes use of (and should otherwise have hard dependencies on, but didn't, like `file`, `image`, etc).

This means that modules that use `farm_field.factory` are responsible for ensuring that they depend on the modules that provide the field types they use, because `farm_field` will not ensure that.

One small thing this revealed is that we were depending on `farm_field` to install `farm_map`. So I moved that dependency to the `farm_location` module.