### PR TITLE
 Prevent creation of revision when a log is saved without a name

### DIFF
--- a/modules/core/entity/src/Hook/EntityHooks.php
+++ b/modules/core/entity/src/Hook/EntityHooks.php
@@ -124,6 +124,15 @@ class EntityHooks {
     $entity_type = $entity->get($entity->getEntityType()->getKey('bundle'))->entity;
     if ($entity_type instanceof RevisionableEntityBundleInterface && $entity_type->shouldCreateNewRevision() && $entity->getEntityType()->isRevisionable()) {
 
+      // If this is a log, and it does not have a name, do not create a new
+      // revision so that the log module's LogStorage::doPostSave() logic can
+      // fill in its name and save it again. We don't want to create two
+      // revisions during this process.
+      if ($entity->getEntityTypeId() == 'log' && (is_null($entity->label()) || (!empty($entity->getOriginal()) && is_null($entity->getOriginal()->label())))) {
+        $entity->setNewRevision(FALSE);
+        return;
+      }
+
       // Always create a new revision.
       $entity->setNewRevision(TRUE);
 

--- a/modules/core/entity/src/Hook/EntityHooks.php
+++ b/modules/core/entity/src/Hook/EntityHooks.php
@@ -128,6 +128,7 @@ class EntityHooks {
       // revision so that the log module's LogStorage::doPostSave() logic can
       // fill in its name and save it again. We don't want to create two
       // revisions during this process.
+      // @todo this doesn't work as expected when saving an existing log and clearing its name
       if ($entity->getEntityTypeId() == 'log' && (is_null($entity->label()) || (!empty($entity->getOriginal()) && is_null($entity->getOriginal()->label())))) {
         $entity->setNewRevision(FALSE);
         return;

--- a/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
@@ -77,6 +77,19 @@ class FarmEntityRevisionsTest extends KernelTestBase {
       $this->assertCount(2, $this->revisionIds($entity));
     }
 
+    // Test saving a log without a name only creates a single revision, but
+    // saving it again creates a separate revision. The log module will re-save
+    // log entities that don't have a name, and we don't want an extra
+    // revision for that.
+    $storage = \Drupal::entityTypeManager()->getStorage('log');
+    $entity = $storage->create([
+      'type' => $bundle,
+    ]);
+    $entity->save();
+    $this->assertNotEmpty($entity->label());
+    $this->assertCount(1, $this->revisionIds($entity));
+    $entity->save();
+    $this->assertCount(2, $this->revisionIds($entity));
   }
 
   /**

--- a/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
@@ -90,6 +90,13 @@ class FarmEntityRevisionsTest extends KernelTestBase {
     $this->assertCount(1, $this->revisionIds($entity));
     $entity->save();
     $this->assertCount(2, $this->revisionIds($entity));
+
+    // Test clearing the log's name and changing the timestamp, and confirm that
+    // one new revision was created.
+    $entity->set('name', NULL);
+    $entity->set('timestamp', 1757969652);
+    $entity->save();
+    $this->assertCount(3, $this->revisionIds($entity));
   }
 
   /**


### PR DESCRIPTION
Opening this as a draft PR, but this still needs work (and perhaps rethinking). It's a lower priority than getting 4.0.0 out, so we can pick it up after that's done...

The problem is: if you create a log without a name, two revisions are created on the new log. This is because the `log` module uses `doPostSave()` to automatically fill in a blank log name, and then calls `$log->save()` again. This combined  farmOS's logic for forcing new revisions every time an entity is saved causes the duplicate revision.

This PR currently attempts to detect when a log without a name is being saved, and avoids creating a new revision. But this approach is not perfect, and maybe there's a better solution.

In either case, I wanted to get this code pushed to a draft PR so we can pick it up again later...