### PR TITLE
Add a Config Admin role for granting access to farmOS configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ requirements (inherited from Drupal 11):
 - [Issue #3304608: Add an "abandoned" log status](https://www.drupal.org/project/farm/issues/3304608)
 - [Add default plan status options: "planning", "done", "abandoned" #986](https://github.com/farmOS/farmOS/pull/986)
 - [Add Term Merge module #961](https://github.com/farmOS/farmOS/pull/961)
+- [Add a Config Admin role for granting access to farmOS configuration #1022](https://github.com/farmOS/farmOS/pull/1022)
 - [Add support for attributes in farmOS plugin types #963](https://github.com/farmOS/farmOS/pull/963)
 - [Set asset/log flags via CSV importers #955](https://github.com/farmOS/farmOS/pull/955)
 - [Add a hook for excluding fields from CSV importers #958](https://github.com/farmOS/farmOS/pull/958)

--- a/docs/development/module/roles.md
+++ b/docs/development/module/roles.md
@@ -55,7 +55,7 @@ configuration):
 third_party_settings:
   farm_role:
     access:
-      config: true
+      manager: true
       entity:
         view all: true
         create all: true

--- a/docs/development/module/roles.md
+++ b/docs/development/module/roles.md
@@ -106,6 +106,8 @@ are provided by creating a `ManagedRolePermissions` plugin in the
 
 - `default_permissions`: A list of permissions that will be added to *all*
   managed roles.
+- `manager_permissions`: A list of permissions that will be added to managed
+  roles that have access to additional management features (`manager: true`).
 - `config_permissions`: A list of permissions that will be added to managed
   roles that have access to configuration (`config: true`).
 - `permission_callbacks`: A list of callbacks in controller notation that
@@ -123,8 +125,10 @@ farm_role:
     - access content
     - access user profiles
     - change own username
-  config_permissions:
+  manager_permissions:
     - access taxonomy overview
+  config_permissions:
+    - access farm setup
 ```
 
 #### Permission callbacks

--- a/docs/guide/people.md
+++ b/docs/guide/people.md
@@ -22,11 +22,15 @@ Three default managed roles are provided with farmOS:
   changes. For example, if you need to share your farm records with an Organic
   Certifying Agent, you can give them a user account with the Viewer role.
 
-The "farmOS Account Admin Role" module provides another optional managed role
-called **Account Admin**, which has permission to add/edit/remove other users.
-This is useful in situations where an instance administrator wants to give
-someone the ability to set up other accounts, without giving them full admin
-access.
+In addition to the 3 roles described above, farmOS provides two higher-level
+administrative roles. These are useful in situations where the system
+administrator (with full Drupal admin access) wants to grant some additional
+permissions without giving full Drupal admin access (which has the potential to
+break things.)
+
+- **Config Admin** - Has access to change certain farmOS configuration options.
+- **Account Admin** - Has access to add/edit/remove other user accounts and
+  grant/revoke roles.
 
 Each of these roles is provided by a separate module that can be turned on/off
 individually.

--- a/docs/guide/people.md
+++ b/docs/guide/people.md
@@ -10,12 +10,12 @@ can be added/edited through the UI.
 
 Three default managed roles are provided with farmOS:
 
-- **Manager** - Has access to everything in farmOS. They can create, edit, and
-  delete records, and they can change configuration settings.
-- **Worker** - Has most of the same permissions as Managers, but cannot change
-  configuration, and can only delete records that they created. They cannot
-  delete records created by others, even if they are assigned to them. They also
-  cannot update or delete taxonomy terms.
+- **Manager** - Has access to all data in farmOS. They can create, edit, and
+  delete records, and they have access to some additional management features.
+- **Worker** - Has most of the same permissions as Managers, without access to
+  additional management features, and can only delete records that they created.
+  They cannot delete records created by others, even if they are assigned to
+  them. They also cannot update or delete taxonomy terms.
 - **Viewer** - Limited to viewing farmOS records - but they cannot edit, delete
   or change configuration. This role is useful if you want to share your farm's
   activities with someone, but you don't want to give them the ability to make

--- a/modules/core/data_stream/modules/notification/data_stream_notification.managed_role_permissions.yml
+++ b/modules/core/data_stream/modules/notification/data_stream_notification.managed_role_permissions.yml
@@ -1,5 +1,5 @@
 data_stream_notification:
-  config_permissions:
+  manager_permissions:
     - access data_stream_notification overview
     - create data_stream_notification
     - delete data_stream_notification

--- a/modules/core/import/farm_import.managed_role_permissions.yml
+++ b/modules/core/import/farm_import.managed_role_permissions.yml
@@ -1,3 +1,3 @@
 farm_import:
-  config_permissions:
+  manager_permissions:
     - access farm import index

--- a/modules/core/map/farm_map.managed_role_permissions.yml
+++ b/modules/core/map/farm_map.managed_role_permissions.yml
@@ -1,0 +1,3 @@
+farm_map:
+  config_permissions:
+    - administer farm map

--- a/modules/core/report/farm_report.managed_role_permissions.yml
+++ b/modules/core/report/farm_report.managed_role_permissions.yml
@@ -1,3 +1,3 @@
 farm_report:
-  config_permissions:
+  manager_permissions:
     - access farm report index

--- a/modules/core/role/config/schema/farm_role.schema.yml
+++ b/modules/core/role/config/schema/farm_role.schema.yml
@@ -14,6 +14,9 @@ user.role.*.third_party.farm_role:
       type: mapping
       label: 'Access config'
       mapping:
+        manager:
+          type: boolean
+          label: 'Grant manager permissions'
         config:
           type: boolean
           label: 'Grant config permissions'

--- a/modules/core/role/farm_role.managed_role_permissions.yml
+++ b/modules/core/role/farm_role.managed_role_permissions.yml
@@ -3,5 +3,5 @@ farm_role:
     - access content
     - access user profiles
     - change own username
-  config_permissions:
+  manager_permissions:
     - access taxonomy overview

--- a/modules/core/role/modules/account_admin/farm_role_account_admin.post_update.php
+++ b/modules/core/role/modules/account_admin/farm_role_account_admin.post_update.php
@@ -11,7 +11,7 @@ use Drupal\user\Entity\Role;
 use Drupal\user\Entity\User;
 
 /**
- * Move farm_role_account_admin module to farm_account_admin.
+ * Move farm_account_admin role module and grant farm_config_admin role.
  */
 function farm_role_account_admin_post_update_move_module(&$sandbox = NULL) {
 
@@ -46,13 +46,23 @@ function farm_role_account_admin_post_update_move_module(&$sandbox = NULL) {
     $role->delete();
   }
 
-  // Install the farm_account_admin module.
-  \Drupal::service('module_installer')->install(['farm_account_admin']);
+  // If there are no users with the farm_account_admin role, stop here.
+  if (empty($uids)) {
+    return;
+  }
 
-  // Grant the farm_account_admin role to all users who had it originally.
+  // Install the farm_account_admin and farm_config_admin modules.
+  \Drupal::service('module_installer')->install([
+    'farm_account_admin',
+    'farm_config_admin',
+  ]);
+
+  // Grant the farm_account_admin and farm_config_admin roles to all users who
+  // had the farm_account_admin role originally.
   foreach ($uids as $uid) {
     $user = User::load($uid);
     $user->addRole('farm_account_admin');
+    $user->addRole('farm_config_admin');
     $user->save();
   }
 

--- a/modules/core/role/src/ManagedRolePermissions.php
+++ b/modules/core/role/src/ManagedRolePermissions.php
@@ -25,6 +25,13 @@ class ManagedRolePermissions extends PluginBase implements ManagedRolePermission
   /**
    * {@inheritdoc}
    */
+  public function getManagerPermissions() {
+    return (array) $this->pluginDefinition['manager_permissions'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getConfigPermissions() {
     return (array) $this->pluginDefinition['config_permissions'];
   }

--- a/modules/core/role/src/ManagedRolePermissionsInterface.php
+++ b/modules/core/role/src/ManagedRolePermissionsInterface.php
@@ -22,6 +22,14 @@ interface ManagedRolePermissionsInterface {
   public function getDefaultPermissions();
 
   /**
+   * Returns the manager permissions.
+   *
+   * @return array
+   *   Array of permission strings.
+   */
+  public function getManagerPermissions();
+
+  /**
    * Returns the config permissions.
    *
    * @return array

--- a/modules/core/role/src/ManagedRolePermissionsManager.php
+++ b/modules/core/role/src/ManagedRolePermissionsManager.php
@@ -32,6 +32,7 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
   protected $defaults = [
     'class' => 'Drupal\farm_role\ManagedRolePermissions',
     'default_permissions' => [],
+    'manager_permissions' => [],
     'config_permissions' => [],
     'permission_callbacks' => [],
   ];
@@ -136,6 +137,12 @@ class ManagedRolePermissionsManager extends DefaultPluginManager implements Mana
       // Always include default permissions.
       $default_perms = $plugin->getDefaultPermissions();
       $perms = array_merge($perms, $default_perms);
+
+      // Include manager permissions if the role has manager access.
+      if (!empty($access_settings['manager'])) {
+        $manager_perms = $plugin->getManagerPermissions();
+        $perms = array_merge($perms, $manager_perms);
+      }
 
       // Include config permissions if the role has config access.
       if (!empty($access_settings['config'])) {

--- a/modules/core/role/tests/modules/farm_role_test/config/install/user.role.farm_test.yml
+++ b/modules/core/role/tests/modules/farm_role_test/config/install/user.role.farm_test.yml
@@ -11,6 +11,7 @@ permissions:
 third_party_settings:
   farm_role:
     access:
+      manager: false
       config: false
       entity:
         view all: false

--- a/modules/core/role/tests/modules/farm_role_test/config/install/user.role.farm_test_config.yml
+++ b/modules/core/role/tests/modules/farm_role_test/config/install/user.role.farm_test_config.yml
@@ -1,0 +1,18 @@
+# Test role that has typical config access.
+langcode: en
+status: true
+id: farm_test_config
+label: 'Test config role for farm_role'
+weight: 1
+is_admin: false
+permissions: { }
+third_party_settings:
+  farm_role:
+    access:
+      manager: false
+      config: true
+      entity:
+        view all: false
+        create all: false
+        update all: false
+        delete all: false

--- a/modules/core/role/tests/modules/farm_role_test/config/install/user.role.farm_test_manager.yml
+++ b/modules/core/role/tests/modules/farm_role_test/config/install/user.role.farm_test_manager.yml
@@ -9,7 +9,8 @@ permissions: { }
 third_party_settings:
   farm_role:
     access:
-      config: true
+      manager: true
+      config: false
       entity:
         view all: true
         create all: true

--- a/modules/core/role/tests/modules/farm_role_test/farm_role_test.managed_role_permissions.yml
+++ b/modules/core/role/tests/modules/farm_role_test/farm_role_test.managed_role_permissions.yml
@@ -2,6 +2,8 @@
 test:
   default_permissions:
     - test default permission
+  manager_permissions:
+    - test manager access permission
   config_permissions:
     - test config access permission
   permission_callbacks:

--- a/modules/core/role/tests/src/Kernel/ManagedRolePermissionsTest.php
+++ b/modules/core/role/tests/src/Kernel/ManagedRolePermissionsTest.php
@@ -82,7 +82,7 @@ class ManagedRolePermissionsTest extends KernelTestBase {
   public function testManagedRoleConfigAccess() {
 
     /** @var \Drupal\user\RoleInterface $role */
-    $role = Role::load('farm_test_manager');
+    $role = Role::load('farm_test_config');
 
     // Test that the role's config setting is TRUE.
     $this->assertNotEmpty($role->getThirdPartySetting('farm_role', 'access', FALSE));
@@ -99,9 +99,45 @@ class ManagedRolePermissionsTest extends KernelTestBase {
     $user->addRole('farm_test');
     $this->assertFalse($user->hasPermission('test config access permission'));
 
-    // Ensure the farm_test_manager role provides config access permissions.
-    $user->addRole('farm_test_manager');
+    // Ensure the farm_test_config role provides config access permissions.
+    $user->addRole('farm_test_config');
     $this->assertTrue($user->hasPermission('test config access permission'));
+
+    // Ensure the farm_test_config role does not provide manager access
+    // permissions.
+    $this->assertFalse($user->hasPermission('test manager access permission'));
+  }
+
+  /**
+   * Test that managed roles with manager access get manager permissions.
+   */
+  public function testManagedRoleManagerAccess() {
+
+    /** @var \Drupal\user\RoleInterface $role */
+    $role = Role::load('farm_test_manager');
+
+    // Test that the role's manager setting is TRUE.
+    $this->assertNotEmpty($role->getThirdPartySetting('farm_role', 'access', FALSE));
+    $access_settings = $role->getThirdPartySetting('farm_role', 'access');
+    $this->assertTrue(!empty($access_settings['manager']));
+
+    // Create a user.
+    $user = $this->setUpCurrentUser([], [], FALSE);
+
+    // Ensure the user does not have manager access permissions.
+    $this->assertFalse($user->hasPermission('test manager access permission'));
+
+    // Ensure the farm_test does not provide manager access permissions.
+    $user->addRole('farm_test');
+    $this->assertFalse($user->hasPermission('test manager access permission'));
+
+    // Ensure the farm_test_manager role provides manager access permissions.
+    $user->addRole('farm_test_manager');
+    $this->assertTrue($user->hasPermission('test manager access permission'));
+
+    // Ensure the farm_test_manager role does not provide config access
+    // permissions.
+    $this->assertFalse($user->hasPermission('test config access permission'));
   }
 
   /**

--- a/modules/core/role/tests/src/Kernel/ScopeGranularityTest.php
+++ b/modules/core/role/tests/src/Kernel/ScopeGranularityTest.php
@@ -110,7 +110,6 @@ class ScopeGranularityTest extends KernelTestBase {
         'farm_test_manager',
         [
           'test default permission',
-          'test config access permission',
           'default callback permission',
           'my manager permission',
           'view any harvest log',
@@ -122,7 +121,28 @@ class ScopeGranularityTest extends KernelTestBase {
           'delete any harvest log',
           'delete own harvest log',
         ],
-        [],
+        [
+          'test config access permission',
+        ],
+      ],
+      'farm_test_config' => [
+        'farm_test_config',
+        [
+          'test config access permission',
+          'default callback permission',
+          'test default permission',
+        ],
+        [
+          'my manager permission',
+          'view any harvest log',
+          'view any observation log',
+          'create harvest log',
+          'create observation log',
+          'update any harvest log',
+          'update own harvest log',
+          'delete any harvest log',
+          'delete own harvest log',
+        ],
       ],
     ];
   }

--- a/modules/core/setup/farm_setup.managed_role_permissions.yml
+++ b/modules/core/setup/farm_setup.managed_role_permissions.yml
@@ -1,5 +1,6 @@
 farm_setup:
   config_permissions:
     - access farm setup
+    - administer farm settings
   manager_permissions:
     - access farm setup

--- a/modules/core/setup/farm_setup.managed_role_permissions.yml
+++ b/modules/core/setup/farm_setup.managed_role_permissions.yml
@@ -1,3 +1,5 @@
 farm_setup:
   config_permissions:
     - access farm setup
+  manager_permissions:
+    - access farm setup

--- a/modules/role/account_admin/config/install/user.role.farm_account_admin.yml
+++ b/modules/role/account_admin/config/install/user.role.farm_account_admin.yml
@@ -3,23 +3,22 @@ status: true
 dependencies:
   module:
     - farm_role
-    - farm_setup
   enforced:
     module:
       - farm_account_admin
-third_party_settings:
-  farm_role:
-    access:
-      config: true
-      entity:
-        'view all': false
-        'create all': false
-        'update all': false
-        'delete all': false
 id: farm_account_admin
 label: 'Account Admin'
 weight: 1
 is_admin: false
 permissions:
-  - 'administer farm settings'
   - 'administer users'
+third_party_settings:
+  farm_role:
+    access:
+      config: false
+      manager: false
+      entity:
+        view all: false
+        create all: false
+        update all: false
+        delete all: false

--- a/modules/role/account_admin/farm_account_admin.info.yml
+++ b/modules/role/account_admin/farm_account_admin.info.yml
@@ -5,5 +5,4 @@ package: farmOS Roles
 core_version_requirement: ^11
 dependencies:
   - farm:farm_role
-  - farm:farm_setup
   - role_delegation:role_delegation

--- a/modules/role/account_admin/farm_account_admin.managed_role_permissions.yml
+++ b/modules/role/account_admin/farm_account_admin.managed_role_permissions.yml
@@ -1,3 +1,5 @@
 farm_account_admin:
+  config_permissions:
+    - configure account admin role
   permission_callbacks:
     - Drupal\farm_account_admin\AccountAdminPermissions::permissions

--- a/modules/role/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
+++ b/modules/role/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
@@ -55,7 +55,6 @@ class AccountAdminPermissionsTest extends KernelTestBase {
 
     // List Account Admin permissions.
     $account_admin_permissions = [
-      'administer farm settings',
       'administer users',
       'assign farm_manager role',
       'assign farm_worker role',

--- a/modules/role/config_admin/farm_role_config_admin.info.yml
+++ b/modules/role/config_admin/farm_role_config_admin.info.yml
@@ -1,0 +1,7 @@
+name: farmOS Config Admin Role
+description: Provides a Config Admin role for managing system configuration.
+type: module
+package: farmOS
+core_version_requirement: ^11
+dependencies:
+  - farm:farm_role

--- a/modules/role/config_admin/install/user.role.farm_config_admin.yml
+++ b/modules/role/config_admin/install/user.role.farm_config_admin.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - farm_role
+  enforced:
+    module:
+      - farm_config_admin
+id: farm_config_admin
+label: 'Config Admin'
+weight: 1
+is_admin: false
+permissions: { }
+third_party_settings:
+  farm_role:
+    access:
+      config: true
+      manager: false
+      entity:
+        view all: false
+        create all: false
+        update all: false
+        delete all: false

--- a/modules/role/manager/config/install/user.role.farm_manager.yml
+++ b/modules/role/manager/config/install/user.role.farm_manager.yml
@@ -15,6 +15,7 @@ third_party_settings:
   farm_role:
     access:
       config: true
+      manager: true
       entity:
         view all: true
         create all: true

--- a/modules/role/manager/config/install/user.role.farm_manager.yml
+++ b/modules/role/manager/config/install/user.role.farm_manager.yml
@@ -14,7 +14,7 @@ permissions: { }
 third_party_settings:
   farm_role:
     access:
-      config: true
+      config: false
       manager: true
       entity:
         view all: true

--- a/modules/role/manager/farm_manager.post_update.php
+++ b/modules/role/manager/farm_manager.post_update.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for farm_manager module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Add manager permissions to manager role.
+ */
+function farm_manager_update_add_manager_permissions(&$sandbox) {
+  $role = \Drupal::configFactory()->getEditable('user.role.farm_manager');
+  $settings = $role->get('third_party_settings');
+  if (empty($settings['farm_role']['access']['manager'])) {
+    $settings['farm_role']['access']['manager'] = TRUE;
+    $role->set('third_party_settings', $settings);
+    $role->save();
+  }
+}

--- a/modules/role/manager/farm_manager.post_update.php
+++ b/modules/role/manager/farm_manager.post_update.php
@@ -19,3 +19,16 @@ function farm_manager_update_add_manager_permissions(&$sandbox) {
     $role->save();
   }
 }
+
+/**
+ * Remove config permissions from manager role.
+ */
+function farm_manager_update_remove_config_permissions(&$sandbox) {
+  $role = \Drupal::configFactory()->getEditable('user.role.farm_manager');
+  $settings = $role->get('third_party_settings');
+  if (!empty($settings['farm_role']['access']['config'])) {
+    $settings['farm_role']['access']['config'] = FALSE;
+    $role->set('third_party_settings', $settings);
+    $role->save();
+  }
+}


### PR DESCRIPTION
Originally proposed here: https://farmos.discourse.group/t/adding-a-settings-admin-role/2295

This adds a new "Config Admin" (`farm_config_admin`) role specifically for granting access to manage certain farmOS configuration settings.

The intention is similar to the existing "Account Admin" (`farm_account_admin`) - these roles are not enabled by default in farmOS, but a system administrator (with full Drupal user 1 access) can grant them to users in order to provide some higher-level permissions, without needing to grant full admin access.

Previously, we were starting to overload the "Account Admin" role with permissions to things unrelated to user accounts (like the `administer farm settings` permission).

This PR also shifts some of the "configuration" settings from the "Manager" role to the new "Config Admin" role. Therefore this is a breaking change because it removes some access from existing users.

It does this by splitting the `config_permissions` setting into `config_permissions` and `manager_permissions`. I took my best shot at splitting these in a way that makes sense, but curious to hear what others think.