### PR TITLE
Display warning when user attempts to navigate away from form with unsaved changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ requirements (inherited from Drupal 11):
 - [Add map layer for "Other Location" assets #966](https://github.com/farmOS/farmOS/pull/966)
 - [Add ability to assign plan ownership #1015](https://github.com/farmOS/farmOS/pull/1015)
 - [Show violation messages when validation fails in bulk action forms #1018](https://github.com/farmOS/farmOS/pull/1018)
+- [Add warning when navigating away from forms with unsaved changes #1025](https://github.com/farmOS/farmOS/pull/1025)
 - [Document how to use symfony/mailer for email SMTP relay #844](https://github.com/farmOS/farmOS/pull/844)
 - [Document setup of local Git repositories #1032](https://github.com/farmOS/farmOS/pull/1032)
 

--- a/modules/core/form/config/install/farm_form.settings.yml
+++ b/modules/core/form/config/install/farm_form.settings.yml
@@ -1,0 +1,1 @@
+enable_form_protection: true

--- a/modules/core/form/config/schema/farm_form.schema.yml
+++ b/modules/core/form/config/schema/farm_form.schema.yml
@@ -1,0 +1,7 @@
+farm_form.settings:
+  type: config_object
+  label: 'farmOS Form Settings'
+  mapping:
+    enable_form_protection:
+      type: boolean
+      label: 'Display warning when users attempt to navigate away from forms with unsaved changes.'

--- a/modules/core/form/farm_form.info.yml
+++ b/modules/core/form/farm_form.info.yml
@@ -1,0 +1,5 @@
+name: farmOS Forms
+description: Provides features for farmOS forms.
+type: module
+package: farmOS
+core_version_requirement: ^11

--- a/modules/core/form/farm_form.libraries.yml
+++ b/modules/core/form/farm_form.libraries.yml
@@ -1,0 +1,5 @@
+form_protection:
+  js:
+    js/form_protection.js: { }
+  dependencies:
+    - core/jquery

--- a/modules/core/form/farm_form.links.task.yml
+++ b/modules/core/form/farm_form.links.task.yml
@@ -1,0 +1,4 @@
+farm_form.settings:
+  base_route: farm.setup.settings
+  route_name: farm_form.settings
+  title: 'Forms'

--- a/modules/core/form/farm_form.managed_role_permissions.yml
+++ b/modules/core/form/farm_form.managed_role_permissions.yml
@@ -1,0 +1,3 @@
+farm_form:
+  config_permissions:
+    - administer farm forms

--- a/modules/core/form/farm_form.permissions.yml
+++ b/modules/core/form/farm_form.permissions.yml
@@ -1,0 +1,2 @@
+administer farm forms:
+  title: 'Administer farmOS form settings'

--- a/modules/core/form/farm_form.routing.yml
+++ b/modules/core/form/farm_form.routing.yml
@@ -1,0 +1,7 @@
+farm_form.settings:
+  path: 'farm/settings/forms'
+  defaults:
+    _form: '\Drupal\farm_form\Form\FormSettingsForm'
+    _title: 'Form settings'
+  requirements:
+    _permission: 'administer farm forms'

--- a/modules/core/form/js/form_protection.js
+++ b/modules/core/form/js/form_protection.js
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Show warning when a user is about to navigate away from an unsaved form.
+ */
+(function ($, Drupal) {
+
+  'use strict'
+
+  // Track the initial state of forms.
+  const initialFormState = {};
+
+  // Track whether a submit was clicked "globally" over all attached DOM, so we
+  // can ignore those "onbeforeunload" events and allow form submission.
+  let submitWasClicked = false;
+
+  // Check to see if a protected form input has changed.
+  const protectedFormInputHasChanged = function() {
+    return $('form.form-protected :input').is(function(index, element) {
+      if (!element.id || !Object.hasOwn(initialFormState, element.id)) {
+        return false;
+      }
+      return $(this).serialize() !== initialFormState[element.id];
+    });
+  };
+
+  // Define the Drupal form protection behavior.
+  Drupal.behaviors.form_protection = {
+    attach: function (context) {
+
+      // Save the initial form state of all input elements.
+      $('form.form-protected :input', context).each(function () {
+        if (this.id) {
+          initialFormState[this.id] = $(this).serialize();
+        }
+      });
+
+      // Tell onbeforeunload to allow the "submit" event through.
+      $('form.form-protected').on('submit', () => {
+        submitWasClicked = true;
+      });
+
+      // Handle navigation, back button, exit etc.
+      window.onbeforeunload = function () {
+
+        // If the form has been changed, and a form submission has not occurred,
+        // warn the user that they will lose unsaved changes.
+        if (protectedFormInputHasChanged() && !submitWasClicked) {
+
+          // For very old browsers show custom text (modern browsers will ignore
+          // this text).
+          return Drupal.t('You have unsaved changes.');
+        }
+      }
+    }
+  };
+})(jQuery, Drupal);

--- a/modules/core/form/src/Form/FormSettingsForm.php
+++ b/modules/core/form/src/Form/FormSettingsForm.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_form\Form;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Provides settings form for the farm_form module.
+ */
+class FormSettingsForm extends ConfigFormbase {
+
+  use AutowireTrait;
+
+  /**
+   * Config settings.
+   *
+   * @var string
+   */
+  const SETTINGS = 'farm_form.settings';
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_form_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      static::SETTINGS,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateinterface $form_state) {
+    $config = $this->config(static::SETTINGS);
+    $form['enable_form_protection'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable form protection'),
+      '#description' => $this->t('Display a warning when users attempt to navigate away from forms with unsaved changes.'),
+      '#default_value' => $config->get('enable_form_protection'),
+    ];
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->configFactory->getEditable(static::SETTINGS)
+      ->set('enable_form_protection', $form_state->getValue('enable_form_protection'))
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/core/form/src/Traits/FarmFormProtectionTrait.php
+++ b/modules/core/form/src/Traits/FarmFormProtectionTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_form\Traits;
+
+/**
+ * Provides a standard method for enabling form protection.
+ */
+trait FarmFormProtectionTrait {
+
+  /**
+   * This method is provided by \Drupal\Core\Form\FormBase.
+   *
+   * It is recommended that forms that use this trait inject
+   * ConfigFactoryInterface with autowiring and use $this->setConfigFactory()
+   * in their constructors. Otherwise, Drupal will use load it by name from
+   * the container.
+   *
+   * @see \Drupal\Core\Form\FormBase::config()
+   * @see \Drupal\Core\Form\FormBase::setConfigFactory()
+   * @see \Drupal\Core\Form\FormBase::getConfigFactory()
+   */
+  abstract public function config($name);
+
+  /**
+   * Enable form protection.
+   *
+   * @param array $form
+   *   The form build array.
+   */
+  protected function enableFormProtection(array &$form) {
+    if ($this->config('farm_form.settings')->get('enable_form_protection')) {
+      $form['#attributes']['class'][] = 'form-protected';
+      $form['#attached']['library'][] = 'farm_form/form_protection';
+    }
+  }
+
+}

--- a/modules/core/quick/farm_quick.info.yml
+++ b/modules/core/quick/farm_quick.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - drupal:taxonomy
   - farm:asset
   - farm:farm_entity
+  - farm:farm_form
   - farm:farm_log_quantity
   - farm:farm_setup
   - farm:quantity

--- a/modules/core/quick/farm_quick.post_update.php
+++ b/modules/core/quick/farm_quick.post_update.php
@@ -8,6 +8,15 @@
 declare(strict_types=1);
 
 /**
+ * Install the farm_form module.
+ */
+function farm_quick_post_update_install_farm_form(&$sandbox = NULL) {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_form')) {
+    \Drupal::service('module_installer')->install(['farm_form']);
+  }
+}
+
+/**
  * Implements hook_removed_post_updates().
  */
 function farm_quick_removed_post_updates() {

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -108,6 +108,10 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
       ];
     }
 
+    // Enable form protection.
+    $form['#attributes']['class'][] = 'form-protected';
+    $form['#attached']['library'][] = 'farm_form/form_protection';
+
     return $form;
   }
 

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick\Form;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityMalformedException;
 use Drupal\Core\Form\BaseFormIdInterface;
@@ -31,7 +32,10 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
 
   public function __construct(
     protected QuickFormInstanceManagerInterface $quickFormInstanceManager,
-  ) {}
+    ConfigFactoryInterface $config_factory,
+  ) {
+    $this->setConfigFactory($config_factory);
+  }
 
   /**
    * {@inheritdoc}
@@ -108,9 +112,11 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
       ];
     }
 
-    // Enable form protection.
-    $form['#attributes']['class'][] = 'form-protected';
-    $form['#attached']['library'][] = 'farm_form/form_protection';
+    // Enable form protection, if configured.
+    if ($this->config('farm_form.settings')->get('enable_form_protection')) {
+      $form['#attributes']['class'][] = 'form-protected';
+      $form['#attached']['library'][] = 'farm_form/form_protection';
+    }
 
     return $form;
   }

--- a/modules/core/quick/src/Form/QuickForm.php
+++ b/modules/core/quick/src/Form/QuickForm.php
@@ -11,6 +11,7 @@ use Drupal\Core\Form\BaseFormIdInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\farm_form\Traits\FarmFormProtectionTrait;
 use Drupal\farm_quick\QuickFormInstanceManagerInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 
@@ -22,6 +23,7 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 class QuickForm extends FormBase implements BaseFormIdInterface {
 
   use AutowireTrait;
+  use FarmFormProtectionTrait;
 
   /**
    * The quick form ID.
@@ -112,11 +114,8 @@ class QuickForm extends FormBase implements BaseFormIdInterface {
       ];
     }
 
-    // Enable form protection, if configured.
-    if ($this->config('farm_form.settings')->get('enable_form_protection')) {
-      $form['#attributes']['class'][] = 'form-protected';
-      $form['#attached']['library'][] = 'farm_form/form_protection';
-    }
+    // Enable form protection.
+    $this->enableFormProtection($form);
 
     return $form;
   }

--- a/modules/core/ui/theme/farm_ui_theme.info.yml
+++ b/modules/core/ui/theme/farm_ui_theme.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^11
 dependencies:
   - drupal:block
   - drupal:layout_discovery
+  - farm:farm_form

--- a/modules/core/ui/theme/farm_ui_theme.post_update.php
+++ b/modules/core/ui/theme/farm_ui_theme.post_update.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for farm_ui_theme module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Install the farm_form module.
+ */
+function farm_ui_theme_post_update_install_farm_form(&$sandbox = NULL) {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_form')) {
+    \Drupal::service('module_installer')->install(['farm_form']);
+  }
+}

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -176,6 +176,10 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
         '#theme' => 'item_list',
         '#items' => $revision_items,
       ];
+
+      // Enable form protection.
+      $form['#attributes']['class'][] = 'form-protected';
+      $form['#attached']['library'][] = 'farm_form/form_protection';
     }
 
     return $form;

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -16,6 +16,7 @@ use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element\RenderCallbackInterface;
+use Drupal\farm_form\Traits\FarmFormProtectionTrait;
 use Drupal\user\EntityOwnerInterface;
 
 /**
@@ -24,6 +25,7 @@ use Drupal\user\EntityOwnerInterface;
 class GinContentFormBase extends ContentEntityForm implements RenderCallbackInterface {
 
   use AutowireTrait;
+  use FarmFormProtectionTrait;
 
   public function __construct(
     EntityRepositoryInterface $entity_repository,
@@ -180,11 +182,8 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
         '#items' => $revision_items,
       ];
 
-      // Enable form protection, if configured.
-      if ($this->config('farm_form.settings')->get('enable_form_protection')) {
-        $form['#attributes']['class'][] = 'form-protected';
-        $form['#attached']['library'][] = 'farm_form/form_protection';
-      }
+      // Enable form protection.
+      $this->enableFormProtection($form);
     }
 
     return $form;

--- a/modules/core/ui/theme/src/Form/GinContentFormBase.php
+++ b/modules/core/ui/theme/src/Form/GinContentFormBase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_theme\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\ContentEntityForm;
@@ -30,9 +31,11 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
     TimeInterface $time,
     protected DateFormatterInterface $dateFormatter,
     ModuleHandlerInterface $module_handler,
+    ConfigFactoryInterface $config_factory,
   ) {
     parent::__construct($entity_repository, $entity_type_bundle_info, $time);
     $this->setModuleHandler($module_handler);
+    $this->setConfigFactory($config_factory);
   }
 
   /**
@@ -177,9 +180,11 @@ class GinContentFormBase extends ContentEntityForm implements RenderCallbackInte
         '#items' => $revision_items,
       ];
 
-      // Enable form protection.
-      $form['#attributes']['class'][] = 'form-protected';
-      $form['#attached']['library'][] = 'farm_form/form_protection';
+      // Enable form protection, if configured.
+      if ($this->config('farm_form.settings')->get('enable_form_protection')) {
+        $form['#attributes']['class'][] = 'form-protected';
+        $form['#attached']['library'][] = 'farm_form/form_protection';
+      }
     }
 
     return $form;


### PR DESCRIPTION
Adds a `farm_form` module that includes a JS library for displaying an alert whenever a user tries to leave a form with unsaved changes.

This approach is based on some of the elements used by the [node edit protection module](https://git.drupalcode.org/project/node_edit_protection) and combined with the addition of `farm_form` that @mstenta had already started. The discovery process involved a lot of ways of figuring out how _not_ to implement this. Ultimately, the trick here has been trying to create something that works only for a specific subset of forms of varying types (such as quick forms and entity forms, and ideally also forms within forms like the entity browser; this solution works for the first two, but not the latter), regardless of the impact of other JS libraries (such as the one added by `farmOS-map`) and Drupal's own form handling. In short, there were a lot of gotchas here that Mike and I discovered during implementation.

Anyway, there are some definite improvements that can be made, but it's in a good place to be put up as a PR for discussion.