### PR TITLE
Sort user selection alphabetically by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ requirements (inherited from Drupal 11):
 - [Issue #3413263: Use Entity API query access handler to filter entity queries based on user permissions](https://www.drupal.org/project/farm/issues/3413263)
 - [Allow more granular access to views #965](https://github.com/farmOS/farmOS/pull/965)
 - [Do not set blank revision log messages #1029](https://github.com/farmOS/farmOS/pull/1029)
+- [Sort user selection alphabetically by name #1026](https://github.com/farmOS/farmOS/pull/1026)
 
 ### Deprecated
 

--- a/modules/core/field/src/FarmFieldFactory.php
+++ b/modules/core/field/src/FarmFieldFactory.php
@@ -449,7 +449,8 @@ class FarmFieldFactory implements FarmFieldFactoryInterface {
           ],
           'target_bundles' => NULL,
           'sort' => [
-            'field' => '_none',
+            'field' => 'name',
+            'direction' => 'asc',
           ],
           'auto_create' => FALSE,
         ];


### PR DESCRIPTION
The `farm_field` module provides a shortcut for adding user reference fields. This uses an `entity_reference` field with `default:user` handler. It does not currently specify how to sort the users. This results in the user names appearing in the order in which they were created. This makes it harder to find the user you are looking for if the list of users is long.

This PR changes the handler settings so that it sorts them alphabetically.

**Before:**

<img width="291" height="177" alt="Screenshot from 2025-12-09 11-42-26" src="https://github.com/user-attachments/assets/6359a425-2791-473e-af3d-0d207ba0eba7" />

**After:**

<img width="291" height="177" alt="Screenshot from 2025-12-09 11-43-34" src="https://github.com/user-attachments/assets/18e43754-0174-4fa0-a16f-54a8a7356789" />
