### PR TITLE
Sort "Active plans" by last updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ requirements (inherited from Drupal 11):
 - [Allow more granular access to views #965](https://github.com/farmOS/farmOS/pull/965)
 - [Do not set blank revision log messages #1029](https://github.com/farmOS/farmOS/pull/1029)
 - [Sort user selection alphabetically by name #1026](https://github.com/farmOS/farmOS/pull/1026)
+- [Sort "Active plans" by last updated #1027](https://github.com/farmOS/farmOS/pull/1027)
 
 ### Deprecated
 

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -1211,6 +1211,83 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        changed:
+          id: changed
+          table: plan_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: changed
+          plugin_id: field
+          label: Updated
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
       pager:
         type: none
         options:
@@ -1271,7 +1348,8 @@ display:
             id: id
             name: name
             type: type
-          default: name
+            changed: changed
+          default: changed
           info:
             plan_bulk_form:
               align: ''
@@ -1299,6 +1377,9 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
+            changed:
+              sortable: true
+              default_sort_order: desc
               align: ''
               separator: ''
               empty_column: false

--- a/modules/core/ui/views/config/optional/views.view.farm_plan.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_plan.yml
@@ -1268,20 +1268,12 @@ display:
           default_row_class: true
           columns:
             plan_bulk_form: plan_bulk_form
-            image_target_id: image_target_id
             id: id
             name: name
             type: type
-            flag_value: flag_value
-            status: status
           default: name
           info:
             plan_bulk_form:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            image_target_id:
               align: ''
               separator: ''
               empty_column: false
@@ -1307,14 +1299,6 @@ display:
               separator: ''
               empty_column: false
               responsive: ''
-            flag_value:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            status:
-              sortable: false
-              default_sort_order: asc
               align: ''
               separator: ''
               empty_column: false


### PR DESCRIPTION
This changes the default sort column of the "Active plans" block that is displayed on the dashboard (when the `plan` and `farm_ui_views` modules are installed).

Previously, the plans listed in this block were sorted by the "Name" column (alphabetically). This PR adds an additional "Updated" column, and makes it the default sort. They are sorted in a descending order so the most recently updated plans appear on top.

The motivation for doing this comes from a request that we have in a contrib module that adds its own plan types: https://github.com/farmier/farm_rcd/issues/48

I want to quote a specific section from that issue because it is relevant and might be of interest to other maintainers of modules that add plan types:

> The tricky part here is defining exactly (in code) what "most recently worked on" means. There is an existing Views filter plugin available for the `changed` property of `plan` entities, which is a timestamp that is updated whenever the plan is saved.
> 
> However, a lot of the actions performed in the RCP workflow forms do not actually save the plan entity. They save other related assets and logs. So the `changed` property does not get touched, and therefore sorting by it wouldn't accomplish the goal of this issue.

However, we have a related task that will solve this: https://github.com/farmier/farm_rcd/issues/87

> The RCP workflow form is used to update entities that are linked to the plan, and it saves new revisions whenever that happens. The plan entity itself is not updated in most of these cases, because nothing is changing on it.
> 
> It would be helpful, for traceability purposes, to save revisions of the plan, and to save revision log messages on both whenever they are updated. This will make it a lot easier to ascertain when changes were made and by whom.

With both of these changes, the "Active Plans" will be accurately sorted by "most recently updated". And we'll have better traceability. This feels like a good pattern that other modules can adopt as well: whenever they make changes to records through their plan type UI they can save a revision log message to the plan, thereby updating the plan's `changed` timestamp and raising it in the "Active Plans" default sort.

Of course, this won't be relevant to all types of plans, but I think this PR's change is still a good one regardless. Sorting by plan name alphabetically is not all that helpful, IMO. I don't think we gave it much thought when the block was added, and sorting by name was an easy place to start.

Note: this PR includes another commit (before the described change) with unrelated updates to the exported YML.