### PR TITLE
Update drupal/simple_oauth to ^6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ requirements (inherited from Drupal 11):
 - [Workers cannot update or delete taxonomy terms #1033](https://github.com/farmOS/farmOS/pull/1033)
 - [Allow birth quick form to create up to 20 children #1030](https://github.com/farmOS/farmOS/pull/1030)
 - [Always consider revision translations affected #1041](https://github.com/farmOS/farmOS/pull/1041)
+- [Update drupal/simple_oauth to ^6.1 #1028](https://github.com/farmOS/farmOS/pull/1028)
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_tools": "^6.1.2",
         "drupal/role_delegation": "^1.3",
-        "drupal/simple_oauth": "6.0.9",
+        "drupal/simple_oauth": "^6.1",
         "drupal/simple_oauth_password_grant": "^2.1",
         "drupal/state_machine": "^1.12",
         "drupal/subrequests": "3.0.12",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_tools": "^6.1.2",
         "drupal/role_delegation": "^1.3",
-        "drupal/simple_oauth": "^6.1",
+        "drupal/simple_oauth": "6.1.0",
         "drupal/simple_oauth_password_grant": "^2.1",
         "drupal/state_machine": "^1.12",
         "drupal/subrequests": "3.0.12",
@@ -73,6 +73,9 @@
             },
             "drupal/gin": {
                 "Issue #3342164: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch"
+            },
+            "drupal/simple_oauth": {
+                "Issue #3572695: Use AccessPolicyInterface::calculatePermissions() instead of AccessPolicyInterface::alterPermissions()": "https://git.drupalcode.org/issue/simple_oauth-3572695/-/commit/53a2cecab69c98216ab8c4f154f9392ffc1959a2.patch"
             },
             "drupal/subrequests": {
                 "Issue #3524429: PHP 8.4 deprecation: Implicitly marking parameter as nullable": "https://git.drupalcode.org/issue/subrequests-3524429/-/commit/784ccfe8af7d803f392263d2dbf7dcd89f9566d5.patch"

--- a/modules/core/role/src/Plugin/ScopeGranularity/ManagedRole.php
+++ b/modules/core/role/src/Plugin/ScopeGranularity/ManagedRole.php
@@ -67,6 +67,16 @@ class ManagedRole extends Role implements ContainerFactoryPluginInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getPermissions(): array {
+    $permissions = parent::getPermissions();
+    $role_id = $this->getConfiguration()['role'];
+    $role = $this->entityTypeManager->getStorage('user_role')->load($role_id);
+    return array_unique(array_merge($permissions, $this->managedRolePermissionsManager->getManagedRolePermissions($role)));
+  }
+
+  /**
    * Gets the role options.
    *
    * @return \Drupal\Core\StringTranslation\TranslatableMarkup[]


### PR DESCRIPTION
Opening this draft PR as a follow-up to https://github.com/farmOS/farmOS/commit/735479980db72dd03bcc43bf81da48541197919b.

Todo: Investigate why `drupal/simple_oauth` `6.1.0` causes tests to fail.

See https://www.drupal.org/project/simple_oauth/issues/3507450