### PR TITLE
Do not set blank revision log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ requirements (inherited from Drupal 11):
 - [Change farmOS Update config revert logic from opt-out to opt-in #1011](https://github.com/farmOS/farmOS/pull/1011)
 - [Issue #3413263: Use Entity API query access handler to filter entity queries based on user permissions](https://www.drupal.org/project/farm/issues/3413263)
 - [Allow more granular access to views #965](https://github.com/farmOS/farmOS/pull/965)
+- [Do not set blank revision log messages #1029](https://github.com/farmOS/farmOS/pull/1029)
 
 ### Deprecated
 

--- a/modules/core/entity/src/Hook/EntityHooks.php
+++ b/modules/core/entity/src/Hook/EntityHooks.php
@@ -127,15 +127,6 @@ class EntityHooks {
       // Always create a new revision.
       $entity->setNewRevision(TRUE);
 
-      // If the new revision log message matches the original, then set a blank
-      // revision log message. We don't want the same message repeated across
-      // every revision created by the API.
-      if (!empty($entity->getOriginal())) {
-        if ($entity->getOriginal()->get('revision_log_message')->value == $entity->get('revision_log_message')->value) {
-          $entity->setRevisionLogMessage('');
-        }
-      }
-
       // Set the user ID and creation time.
       $entity->setRevisionUserId($this->currentUser->id());
       $entity->setRevisionCreationTime($this->time->getRequestTime());


### PR DESCRIPTION
We have some logic in the `farm_entity` module for automatically creating new revisions whenever an entity is saved. Inside this logic we also have the following:

https://github.com/farmOS/farmOS/blob/735479980db72dd03bcc43bf81da48541197919b/modules/core/entity/src/Hook/EntityHooks.php#L130-L137

This was added back in 2021, before the release of 2.0.0, in this commit: https://github.com/farmOS/farmOS/commit/b3be5b0755fb85fe80f2375ab6a11dc782127f7b

I *think* the reason that was added was because we were using JSON:API to make changes to location asset hierarchy via the `/locations` page, and I had noticed that that was resulting in a lot of duplicate revision log messages on assets. We eventually refactored that to not make updates via JSON:API, so it was no longer an issue, but this logic remained.

I forgot about all of this until today when I spent a frustrating amount of time trying to figure out why some custom module code was only able to save revision log messages every other time the asset was saved. It was intentionally saving the same revision log message, which was detected by this core logic and thus deleted. But then when it was saved again, the same logic determined that it was not the same anymore, so allowed it to be saved. :facepalm: :face_exhaling:

This logic is bad. It was flawed from the beginning. Let's remove it.