### PR TITLE
Fix dashboard block access checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ requirements (inherited from Drupal 11):
 - [Fix CSV importer compatibility with migrate_source_ui v1.3+ #993](https://github.com/farmOS/farmOS/pull/993)
 - [Check that real path exists before loading exif data #1000](https://github.com/farmOS/farmOS/pull/1000)
 - [Do not allow entity revisions to be reverted #1004](https://github.com/farmOS/farmOS/pull/1004)
+- [Fix dashboard block access checking #1031](https://github.com/farmOS/farmOS/pull/1031)
 
 ## farmOS 3.x
 

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -48,7 +48,7 @@ class DashboardController extends ControllerBase {
 
       // Set default values.
       $args = [];
-      $output = '';
+      $output = [];
       $title = '';
       $region = 'first';
       $group = 'default';

--- a/modules/core/ui/dashboard/tests/modules/dashboard_test/farm_ui_dashboard_test.permissions.yml
+++ b/modules/core/ui/dashboard/tests/modules/dashboard_test/farm_ui_dashboard_test.permissions.yml
@@ -1,0 +1,2 @@
+access dashboard test block:
+  title: 'Access dashboard test block'

--- a/modules/core/ui/dashboard/tests/modules/dashboard_test/src/Plugin/Block/DashboardTestBlock.php
+++ b/modules/core/ui/dashboard/tests/modules/dashboard_test/src/Plugin/Block/DashboardTestBlock.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_dashboard_test\Plugin\Block;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 
 /**
@@ -16,6 +18,13 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
   admin_label: new TranslatableMarkup('Dashboard test block'),
 )]
 class DashboardTestBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockAccess(AccountInterface $account) {
+    return AccessResult::allowedIfHasPermission($account, 'access dashboard test block');
+  }
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
+++ b/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
@@ -54,7 +54,16 @@ class DashboardTest extends FarmBrowserTestBase {
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
 
-    // Assert that the test block was added.
+    // Assert that the test block was not added to the dashboard.
+    $this->assertSession()->pageTextNotContains('This is the dashboard test block.');
+
+    // Grant permission to view the block.
+    $user = $this->createUser(['access farm dashboard', 'access dashboard test block']);
+    $this->drupalLogin($user);
+
+    // Assert that the test block was added to the dashboard.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
     $this->assertSession()->pageTextContains('This is the dashboard test block.');
   }
 


### PR DESCRIPTION
Fixes the following error that occurs if access is denied to a dashboard block:

`InvalidArgumentException: "0" is an invalid render array key. Value should be an array but got a string. in Drupal\Core\Render\Element::children() (line 97 of core/lib/Drupal/Core/Render/Element.php).`

Dashboard panes should always return a render array, but the default $`output` value was a string. In the case of blocks that deny access, this string was not being overwritten.