### PR TITLE
Limit permissions of worker role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ requirements (inherited from Drupal 11):
 - [Do not use birth log label in child revision log message #1019](https://github.com/farmOS/farmOS/pull/1019)
 - [Soften farm_field module dependencies #1020](https://github.com/farmOS/farmOS/pull/1020)
 - [Workers can only delete their own records #1033](https://github.com/farmOS/farmOS/pull/1033)
+- [Workers cannot update or delete taxonomy terms #1033](https://github.com/farmOS/farmOS/pull/1033)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ requirements (inherited from Drupal 11):
 - [Sort "Active plans" by last updated #1027](https://github.com/farmOS/farmOS/pull/1027)
 - [Do not use birth log label in child revision log message #1019](https://github.com/farmOS/farmOS/pull/1019)
 - [Soften farm_field module dependencies #1020](https://github.com/farmOS/farmOS/pull/1020)
+- [Workers can only delete their own records #1033](https://github.com/farmOS/farmOS/pull/1033)
 
 ### Deprecated
 

--- a/docs/guide/people.md
+++ b/docs/guide/people.md
@@ -13,7 +13,8 @@ Three default managed roles are provided with farmOS:
 - **Manager** - Has access to everything in farmOS. They can create, edit, and
   delete records, and they can change configuration settings.
 - **Worker** - Has most of the same permissions as Managers, but cannot change
-  configuration.
+  configuration, and can only delete records that they created. They cannot
+  delete records created by others, even if they are assigned to them.
 - **Viewer** - Limited to viewing farmOS records - but they cannot edit, delete
   or change configuration. This role is useful if you want to share your farm's
   activities with someone, but you don't want to give them the ability to make

--- a/docs/guide/people.md
+++ b/docs/guide/people.md
@@ -14,7 +14,8 @@ Three default managed roles are provided with farmOS:
   delete records, and they can change configuration settings.
 - **Worker** - Has most of the same permissions as Managers, but cannot change
   configuration, and can only delete records that they created. They cannot
-  delete records created by others, even if they are assigned to them.
+  delete records created by others, even if they are assigned to them. They also
+  cannot update or delete taxonomy terms.
 - **Viewer** - Limited to viewing farmOS records - but they cannot edit, delete
   or change configuration. This role is useful if you want to share your farm's
   activities with someone, but you don't want to give them the ability to make

--- a/modules/role/worker/config/install/user.role.farm_worker.yml
+++ b/modules/role/worker/config/install/user.role.farm_worker.yml
@@ -62,7 +62,3 @@ third_party_settings:
           taxonomy_term:
             create:
               - all
-            update:
-              - all
-            delete:
-              - all

--- a/modules/role/worker/config/install/user.role.farm_worker.yml
+++ b/modules/role/worker/config/install/user.role.farm_worker.yml
@@ -25,8 +25,6 @@ third_party_settings:
               - all
             update own:
               - all
-            delete any:
-              - all
             delete own:
               - all
           data_stream:
@@ -34,16 +32,12 @@ third_party_settings:
               - all
             update:
               - all
-            delete:
-              - all
           log:
             create:
               - all
             update any:
               - all
             update own:
-              - all
-            delete any:
               - all
             delete own:
               - all
@@ -54,8 +48,6 @@ third_party_settings:
               - all
             update own:
               - all
-            delete any:
-              - all
             delete own:
               - all
           quantity:
@@ -64,8 +56,6 @@ third_party_settings:
             update any:
               - all
             update own:
-              - all
-            delete any:
               - all
             delete own:
               - all


### PR DESCRIPTION
I propose that remove some of the permissions currently assigned to the `farm_worker` role.

Specifically:

- Remove the ability to delete records that were created by others.
- Remove the ability to update or delete taxonomy terms.

The motivations for doing this include:

- Limit potential damage by malicious users. Generally speaking, a user with the `farm_worker` role doesn't need to be able to delete data that is not relevant to them. An exception is made here for records that the user has created themselves. So not all risk is removed, but it's a step in the right direction (perhaps the idea of "soft deletion" will be implemented, removing the need for any `delete` permissions).
- Only roles with `config: true` (eg: `farm_manager`) have `access taxonomy overview`, under the assumption that they are in charge of taxonomies. Users with the `farm_worker` role will still have the ability to create new terms (eg: via autocomplete textfields) but this removes the ability to update or delete terms. Terms don't have the same granularity of permissions as other records, so we can't differentiate between `any` and `own`, so this takes a conservative approach and further solidifies the responsibility of taxonomy maintenance to managers (and limiting workers).
- Further differentiate the `farm_worker` and `farm_manager` roles.