### PR TITLE
Add a farmOS setup wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ requirements (inherited from Drupal 11):
 
 ### Added
 
+- [Add a farmOS setup wizard #1035](https://github.com/farmOS/farmOS/pull/1035)
 - [Add an Organization entity type with a Farm bundle #849](https://github.com/farmOS/farmOS/pull/849)
 - [Allow API access to organizations #1010](https://github.com/farmOS/farmOS/pull/1010)
 - [Issue #3304608: Add an "abandoned" log status](https://www.drupal.org/project/farm/issues/3304608)

--- a/farm.install
+++ b/farm.install
@@ -86,4 +86,8 @@ function farm_install_base_modules(array $install_state): void {
     'farm_update',
   ];
   \Drupal::service('module_installer')->install($modules, TRUE);
+
+  // Initialize the setup wizard state so that the welcome form is displayed on
+  // the dashboard.
+  \Drupal::service('farm_setup.wizard')->setBlockPluginId('welcome');
 }

--- a/modules/asset/land/modules/types/farm_land_types.info.yml
+++ b/modules/asset/land/modules/types/farm_land_types.info.yml
@@ -1,4 +1,4 @@
-name: farmOS Default Land Types
+name: Default land types
 description: 'Provides default land types: Property, Field, Bed, Paddock, Landmark.'
 type: module
 package: farmOS Defaults

--- a/modules/asset/structure/modules/types/farm_structure_types.info.yml
+++ b/modules/asset/structure/modules/types/farm_structure_types.info.yml
@@ -1,4 +1,4 @@
-name: farmOS Default Structure Types
+name: Default structure types
 description: 'Provides default structure types: Building, Greenhouse.'
 type: module
 package: farmOS Defaults

--- a/modules/core/setup/farm_setup.links.menu.yml
+++ b/modules/core/setup/farm_setup.links.menu.yml
@@ -3,6 +3,12 @@ farm.setup:
   parent: system.admin
   route_name: farm.setup
 
+farm.setup.wizard:
+  title: Wizard
+  parent: farm.setup
+  route_name: farm.setup.wizard
+  weight: 100
+
 farm.setup.modules:
   title: Modules
   description: Select the core and community farmOS modules that you would like to be installed.

--- a/modules/core/setup/farm_setup.links.task.yml
+++ b/modules/core/setup/farm_setup.links.task.yml
@@ -3,3 +3,6 @@ farm_setup.settings:
   route_name: farm.setup.settings
   title: 'Farm Info'
   weight: -5
+
+farm_setup.wizard:
+  deriver: Drupal\farm_setup\Plugin\Derivative\SetupFormTaskLink

--- a/modules/core/setup/farm_setup.managed_role_permissions.yml
+++ b/modules/core/setup/farm_setup.managed_role_permissions.yml
@@ -1,6 +1,7 @@
 farm_setup:
   config_permissions:
     - access farm setup
+    - access farm setup wizard
     - administer farm settings
     - install farm modules
   manager_permissions:

--- a/modules/core/setup/farm_setup.managed_role_permissions.yml
+++ b/modules/core/setup/farm_setup.managed_role_permissions.yml
@@ -2,5 +2,6 @@ farm_setup:
   config_permissions:
     - access farm setup
     - administer farm settings
+    - install farm modules
   manager_permissions:
     - access farm setup

--- a/modules/core/setup/farm_setup.permissions.yml
+++ b/modules/core/setup/farm_setup.permissions.yml
@@ -1,6 +1,9 @@
 access farm setup:
   title: 'Access farmOS setup'
 
+access farm setup wizard:
+  title: 'Access farmOS setup wizard'
+
 administer farm settings:
   title: 'Administer farmOS settings'
 

--- a/modules/core/setup/farm_setup.permissions.yml
+++ b/modules/core/setup/farm_setup.permissions.yml
@@ -3,3 +3,6 @@ access farm setup:
 
 administer farm settings:
   title: 'Administer farmOS settings'
+
+install farm modules:
+  title: 'Install farmOS modules'

--- a/modules/core/setup/farm_setup.routing.yml
+++ b/modules/core/setup/farm_setup.routing.yml
@@ -21,3 +21,6 @@ farm.setup.modules:
     _form: \Drupal\farm_setup\Form\FarmModulesForm
   requirements:
     _permission: install farm modules
+
+route_callbacks:
+  - '\Drupal\farm_setup\Routing\SetupFormRoutes::routes'

--- a/modules/core/setup/farm_setup.routing.yml
+++ b/modules/core/setup/farm_setup.routing.yml
@@ -20,4 +20,4 @@ farm.setup.modules:
     _title: Modules
     _form: \Drupal\farm_setup\Form\FarmModulesForm
   requirements:
-    _permission: administer farm settings
+    _permission: install farm modules

--- a/modules/core/setup/farm_setup.services.yml
+++ b/modules/core/setup/farm_setup.services.yml
@@ -1,0 +1,4 @@
+services:
+  plugin.manager.setup_form:
+    class: Drupal\farm_setup\SetupFormPluginManager
+    parent: default_plugin_manager

--- a/modules/core/setup/farm_setup.services.yml
+++ b/modules/core/setup/farm_setup.services.yml
@@ -1,4 +1,9 @@
 services:
+  _defaults:
+    autowire: true
+  farm_setup.wizard:
+    class: Drupal\farm_setup\SetupWizard
+  Drupal\farm_setup\SetupWizardInterface: '@farm_setup.wizard'
   plugin.manager.setup_form:
     class: Drupal\farm_setup\SetupFormPluginManager
     parent: default_plugin_manager

--- a/modules/core/setup/src/Attribute/SetupForm.php
+++ b/modules/core/setup/src/Attribute/SetupForm.php
@@ -17,6 +17,7 @@ class SetupForm extends Plugin {
     public readonly string $id,
     public readonly TranslatableMarkup $title,
     public readonly ?TranslatableMarkup $description = NULL,
+    public readonly int $weight = 0,
   ) {}
 
 }

--- a/modules/core/setup/src/Attribute/SetupForm.php
+++ b/modules/core/setup/src/Attribute/SetupForm.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Attribute;
+
+use Drupal\Component\Plugin\Attribute\Plugin;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * The setup form plugin attribute.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class SetupForm extends Plugin {
+
+  public function __construct(
+    public readonly string $id,
+    public readonly TranslatableMarkup $title,
+    public readonly ?TranslatableMarkup $description = NULL,
+  ) {}
+
+}

--- a/modules/core/setup/src/Attribute/SetupForm.php
+++ b/modules/core/setup/src/Attribute/SetupForm.php
@@ -16,6 +16,7 @@ class SetupForm extends Plugin {
   public function __construct(
     public readonly string $id,
     public readonly TranslatableMarkup $title,
+    public readonly TranslatableMarkup $task_title,
     public readonly ?TranslatableMarkup $description = NULL,
     public readonly int $weight = 0,
   ) {}

--- a/modules/core/setup/src/Form/FarmSetupBlockForm.php
+++ b/modules/core/setup/src/Form/FarmSetupBlockForm.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_setup\Form;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\State\StateInterface;
-use Drupal\farm_setup\SetupFormPluginManager;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Setup block form.
@@ -16,16 +12,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * @ingroup farm
  */
 class FarmSetupBlockForm extends FarmSetupForm {
-
-  use AutowireTrait;
-
-  public function __construct(
-    #[Autowire(service: 'plugin.manager.setup_form')]
-    SetupFormPluginManager $setupFormPluginManager,
-    protected StateInterface $state,
-  ) {
-    parent::__construct($setupFormPluginManager);
-  }
 
   /**
    * {@inheritdoc}
@@ -42,9 +28,8 @@ class FarmSetupBlockForm extends FarmSetupForm {
     // This performs the same logic as the parent method, but does not perform
     // any redirections. Instead, it saves the next plugin to state so that it
     // is shown next time the block is loaded.
-    $plugin_id = $form_state->getValue('plugin_id');
-    $next_plugin_id = $this->getNextPluginId($plugin_id);
-    $this->state->set('farm_setup.block', $next_plugin_id);
+    $next_plugin_id = $this->setupWizard->getNextPluginId($form_state->getValue('plugin_id'));
+    $this->setupWizard->setBlockPluginId($next_plugin_id);
     if (is_null($next_plugin_id)) {
       $this->completeMessage();
     }

--- a/modules/core/setup/src/Form/FarmSetupBlockForm.php
+++ b/modules/core/setup/src/Form/FarmSetupBlockForm.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Form;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\farm_setup\SetupFormPluginManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Setup block form.
+ *
+ * @ingroup farm
+ */
+class FarmSetupBlockForm extends FarmSetupForm {
+
+  use AutowireTrait;
+
+  public function __construct(
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    SetupFormPluginManager $setupFormPluginManager,
+    protected StateInterface $state,
+  ) {
+    parent::__construct($setupFormPluginManager);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_setup_block_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function proceed(FormStateInterface $form_state): void {
+
+    // This performs the same logic as the parent method, but does not perform
+    // any redirections. Instead, it saves the next plugin to state so that it
+    // is shown next time the block is loaded.
+    $plugin_id = $form_state->getValue('plugin_id');
+    $next_plugin_id = $this->getNextPluginId($plugin_id);
+    $this->state->set('farm_setup.block', $next_plugin_id);
+    if (is_null($next_plugin_id)) {
+      $this->completeMessage();
+    }
+  }
+
+}

--- a/modules/core/setup/src/Form/FarmSetupBlockForm.php
+++ b/modules/core/setup/src/Form/FarmSetupBlockForm.php
@@ -35,4 +35,25 @@ class FarmSetupBlockForm extends FarmSetupForm {
     }
   }
 
+  /**
+   * Batch 'finished' callback that runs after module installation.
+   *
+   * We need a bit of special logic here to ensure that setup wizard forms from
+   * newly installed modules are shown next in the setup wizard block context.
+   * We only do this if the module installation batch operation was successful,
+   * and the current block plugin state is not NULL (which would indicate that
+   * the setup wizard process has already been completed).
+   */
+  public static function finishInstallModulesBatch($success, $results, $operations) {
+    /** @var \Drupal\farm_setup\SetupWizardInterface $wizard */
+    $wizard = \Drupal::service('farm_setup.wizard');
+    if (!$success || is_null($wizard->getBlockPluginId())) {
+      return;
+    }
+    $next_plugin_id = $wizard->getNextPluginId('modules');
+    if (!is_null($next_plugin_id)) {
+      $wizard->setBlockPluginId($next_plugin_id);
+    }
+  }
+
 }

--- a/modules/core/setup/src/Form/FarmSetupForm.php
+++ b/modules/core/setup/src/Form/FarmSetupForm.php
@@ -7,6 +7,7 @@ namespace Drupal\farm_setup\Form;
 use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\farm_setup\SetupFormPluginManager;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
@@ -29,6 +30,21 @@ class FarmSetupForm extends FormBase {
    */
   public function getFormId() {
     return 'farm_setup_form';
+  }
+
+  /**
+   * Checks access for a specific setup form.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   * @param string $plugin_id
+   *   The setup form plugin ID.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account, string $plugin_id) {
+    return $this->setupFormPluginManager->createInstance($plugin_id)->access($account);
   }
 
   /**

--- a/modules/core/setup/src/Form/FarmSetupForm.php
+++ b/modules/core/setup/src/Form/FarmSetupForm.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Form;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\farm_setup\SetupFormPluginManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Setup form.
+ *
+ * @ingroup farm
+ */
+class FarmSetupForm extends FormBase {
+
+  use AutowireTrait;
+
+  public function __construct(
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    protected SetupFormPluginManager $setupFormPluginManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_setup_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, ?string $plugin_id = NULL) {
+
+    // Build the setup form.
+    $form = $this->setupFormPluginManager->createInstance($plugin_id)->buildForm($form, $form_state);
+
+    // Save the plugin ID for validate/submit.
+    $form['plugin_id'] = [
+      '#type' => 'value',
+      '#value' => $plugin_id,
+    ];
+
+    // Submit buttons.
+    // If this is the welcome plugin, only show "Continue".
+    // Or, if this is the resources plugin, only show "Finish".
+    // Otherwise, show "Save and continue" (which submits the form), and "Skip"
+    // (which goes to the next form without submitting).
+    $form['setup']['actions'] = ['#type' => 'actions'];
+    if ($plugin_id == 'welcome') {
+      $form['setup']['actions']['submit'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Continue'),
+        '#submit' => [[$this, 'skipSubmit']],
+      ];
+    }
+    elseif ($plugin_id == 'resources') {
+      $form['setup']['actions']['submit'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Finish'),
+        '#submit' => [[$this, 'skipSubmit']],
+      ];
+    }
+    else {
+      $form['setup']['actions']['submit'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Save and continue'),
+      ];
+      $form['setup']['actions']['skip'] = [
+        '#type' => 'submit',
+        '#value' => $this->t('Skip'),
+        // Ignore all validation errors, but preserve the plugin_id value.
+        '#limit_validation_errors' => [['plugin_id']],
+        '#submit' => [[$this, 'skipSubmit']],
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    $plugin_id = $form_state->getValue('plugin_id');
+    $this->setupFormPluginManager->createInstance($plugin_id)->validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->setupFormPluginManager->createInstance($form_state->getValue('plugin_id'))->submitForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function skipSubmit(array &$form, FormStateInterface $form_state) {
+
+  }
+
+}

--- a/modules/core/setup/src/Form/FarmSetupForm.php
+++ b/modules/core/setup/src/Form/FarmSetupForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\farm_setup\SetupFormPluginManager;
+use Drupal\farm_setup\SetupWizardInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
@@ -23,6 +24,7 @@ class FarmSetupForm extends FormBase {
   public function __construct(
     #[Autowire(service: 'plugin.manager.setup_form')]
     protected SetupFormPluginManager $setupFormPluginManager,
+    protected SetupWizardInterface $setupWizard,
   ) {}
 
   /**
@@ -135,33 +137,13 @@ class FarmSetupForm extends FormBase {
   }
 
   /**
-   * Get the next setup form plugin ID.
-   *
-   * @param string $plugin_id
-   *   The current setup form plugin ID.
-   *
-   * @return string|null
-   *   The next setup form plugin ID, or NULL if there is none.
-   */
-  protected function getNextPluginId(string $plugin_id): ?string {
-    $plugins = $this->setupFormPluginManager->getDefinitions();
-    $keys = array_keys($plugins);
-    $index = array_search($plugin_id, $keys);
-    if ($index !== FALSE && isset($keys[$index + 1])) {
-      return $keys[$index + 1];
-    }
-    return NULL;
-  }
-
-  /**
    * Proceed to the next setup form.
    *
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   The current state of the form.
    */
   protected function proceed(FormStateInterface $form_state): void {
-    $plugin_id = $form_state->getValue('plugin_id');
-    $next_plugin_id = $this->getNextPluginId($plugin_id);
+    $next_plugin_id = $this->setupWizard->getNextPluginId($form_state->getValue('plugin_id'));
     if (!is_null($next_plugin_id)) {
       $form_state->setRedirect('farm.setup.wizard.' . $next_plugin_id);
     }

--- a/modules/core/setup/src/Form/FarmSetupForm.php
+++ b/modules/core/setup/src/Form/FarmSetupForm.php
@@ -167,7 +167,15 @@ class FarmSetupForm extends FormBase {
     }
     else {
       $form_state->setRedirect('<front>');
+      $this->completeMessage();
     }
+  }
+
+  /**
+   * Show a setup completion message.
+   */
+  protected function completeMessage() {
+    $this->messenger()->addStatus($this->t('farmOS setup is complete! Happy record keeping!'));
   }
 
 }

--- a/modules/core/setup/src/Form/FarmSetupForm.php
+++ b/modules/core/setup/src/Form/FarmSetupForm.php
@@ -48,6 +48,19 @@ class FarmSetupForm extends FormBase {
   }
 
   /**
+   * Get the title of the setup form.
+   *
+   * @param string $plugin_id
+   *   The setup form plugin ID.
+   *
+   * @return string
+   *   Quick form title.
+   */
+  public function getTitle(string $plugin_id) {
+    return $this->setupFormPluginManager->createInstance($plugin_id)->getTitle();
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, ?string $plugin_id = NULL) {

--- a/modules/core/setup/src/Form/FarmSetupForm.php
+++ b/modules/core/setup/src/Form/FarmSetupForm.php
@@ -124,13 +124,50 @@ class FarmSetupForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->setupFormPluginManager->createInstance($form_state->getValue('plugin_id'))->submitForm($form, $form_state);
+    $this->proceed($form_state);
   }
 
   /**
    * {@inheritdoc}
    */
   public function skipSubmit(array &$form, FormStateInterface $form_state) {
+    $this->proceed($form_state);
+  }
 
+  /**
+   * Get the next setup form plugin ID.
+   *
+   * @param string $plugin_id
+   *   The current setup form plugin ID.
+   *
+   * @return string|null
+   *   The next setup form plugin ID, or NULL if there is none.
+   */
+  protected function getNextPluginId(string $plugin_id): ?string {
+    $plugins = $this->setupFormPluginManager->getDefinitions();
+    $keys = array_keys($plugins);
+    $index = array_search($plugin_id, $keys);
+    if ($index !== FALSE && isset($keys[$index + 1])) {
+      return $keys[$index + 1];
+    }
+    return NULL;
+  }
+
+  /**
+   * Proceed to the next setup form.
+   *
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  protected function proceed(FormStateInterface $form_state): void {
+    $plugin_id = $form_state->getValue('plugin_id');
+    $next_plugin_id = $this->getNextPluginId($plugin_id);
+    if (!is_null($next_plugin_id)) {
+      $form_state->setRedirect('farm.setup.wizard.' . $next_plugin_id);
+    }
+    else {
+      $form_state->setRedirect('<front>');
+    }
   }
 
 }

--- a/modules/core/setup/src/Hook/HelpHooks.php
+++ b/modules/core/setup/src/Hook/HelpHooks.php
@@ -4,16 +4,25 @@ declare(strict_types=1);
 
 namespace Drupal\farm_setup\Hook;
 
+use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\farm_setup\SetupFormPluginManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Help hook implementations for farm_setup.
  */
 class HelpHooks {
 
+  use AutowireTrait;
   use StringTranslationTrait;
+
+  public function __construct(
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    protected SetupFormPluginManager $setupFormPluginManager,
+  ) {}
 
   /**
    * Implements hook_help().
@@ -21,6 +30,13 @@ class HelpHooks {
   #[Hook('help')]
   public function help($route_name, RouteMatchInterface $route_match) {
     $output = '';
+
+    // Setup wizard forms.
+    if (str_starts_with($route_name, 'farm.setup.wizard')) {
+      $plugin_id = $route_match->getParameter('plugin_id');
+      $plugin = $this->setupFormPluginManager->createInstance($plugin_id);
+      $output = $plugin->getDescription();
+    }
 
     // Modules form.
     if ($route_name == 'farm_setup.modules') {

--- a/modules/core/setup/src/Hook/ThemeHooks.php
+++ b/modules/core/setup/src/Hook/ThemeHooks.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Theme hook implementations for farm_setup.
+ */
+class ThemeHooks {
+
+  /**
+   * Implements hook_farm_dashboard_panes().
+   */
+  #[Hook('farm_dashboard_panes')]
+  public function farmDashboardPanes() {
+    return [
+      'setup' => [
+        'block' => 'farm_setup',
+        'region' => 'top',
+      ],
+    ];
+  }
+
+}

--- a/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
+++ b/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
@@ -75,6 +75,20 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
     /** @var \Drupal\farm_setup\Plugin\SetupForm\SetupFormInterface $plugin */
     $plugin = $this->setupFormPluginManager->createInstance($plugin_id);
 
+    // Show a progress bar (only include plugins the user has access to).
+    $accessible_plugins = array_filter($plugins, function ($plugin) {
+      return $this->setupFormPluginManager->createInstance($plugin['id'])->access($this->account)->isAllowed();
+    });
+    $step_count = count($accessible_plugins) - 1;
+    $step_number = array_search($plugin_id, array_keys($accessible_plugins));
+    $step_progress = round(($step_number / $step_count) * 100);
+    $build['progress'] = [
+      '#theme' => 'progress_bar',
+      '#label' => $this->t('Setup progress'),
+      '#percent' => $step_progress,
+      '#message' => $this->t('Step @step_number: @step_label', ['@step_number' => $step_number + 1, '@step_label' => $plugin->getTaskTitle()]),
+    ];
+
     // Build the setup form.
     $build['form'] = [
       '#type' => 'details',

--- a/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
+++ b/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_setup\Form\FarmSetupBlockForm;
 use Drupal\farm_setup\SetupFormPluginManager;
@@ -32,6 +33,7 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
     protected SetupFormPluginManager $setupFormPluginManager,
     protected SetupWizardInterface $setupWizard,
     protected FormBuilderInterface $formBuilder,
+    protected AccountInterface $account,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -47,6 +49,7 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $container->get('plugin.manager.setup_form'),
       $container->get('farm_setup.wizard'),
       $container->get('form_builder'),
+      $container->get('current_user'),
     );
   }
 
@@ -59,8 +62,8 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
     // Get all setup form plugins.
     $plugins = $this->setupFormPluginManager->getDefinitions();
 
-    // Get the current form plugin ID from state.
-    $plugin_id = $this->state->get('farm_setup.block');
+    // Get the next accessible plugin ID.
+    $plugin_id = $this->getAccessiblePluginId();
 
     // If the current setup form plugin ID is NULL, or if it does not exist,
     // then consider the setup process to be complete and show nothing.
@@ -82,6 +85,32 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
     ];
 
     return $build;
+  }
+
+  /**
+   * Get the next accessible plugin ID.
+   *
+   * @param string|null $plugin_id
+   *   Optionally provide the current plugin ID. If this is omitted, it will be
+   *   loaded from state.
+   *
+   * @return string|null
+   *   A plugin ID.
+   */
+  protected function getAccessiblePluginId(?string $plugin_id = NULL): ?string {
+
+    // Get the current plugin ID from state, if necessary.
+    if (is_null($plugin_id)) {
+      $plugin_id = $this->setupWizard->getBlockPluginId();
+    }
+
+    // If the user does not have access to the plugin, look up the next one that
+    // they do have access to.
+    $plugins = $this->setupFormPluginManager->getDefinitions();
+    if (!is_null($plugin_id) && array_key_exists($plugin_id, $plugins) && !$this->setupFormPluginManager->createInstance($plugin_id)->access($this->account)->isAllowed()) {
+      $plugin_id = $this->getAccessiblePluginId($this->setupWizard->getNextPluginId($plugin_id));
+    }
+    return $plugin_id;
   }
 
 }

--- a/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
+++ b/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_setup\Plugin\Block;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormBuilderInterface;
@@ -51,6 +52,13 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $container->get('form_builder'),
       $container->get('current_user'),
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockAccess(AccountInterface $account) {
+    return AccessResult::allowedIfHasPermission($account, 'access farm setup wizard');
   }
 
   /**

--- a/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
+++ b/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\Block;
+
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_setup\Form\FarmSetupBlockForm;
+use Drupal\farm_setup\SetupFormPluginManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a farmOS setup block.
+ */
+#[Block(
+  id: 'farm_setup',
+  admin_label: new TranslatableMarkup('farmOS setup wizard'),
+)]
+class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    protected SetupFormPluginManager $setupFormPluginManager,
+    protected StateInterface $state,
+    protected FormBuilderInterface $formBuilder,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('plugin.manager.setup_form'),
+      $container->get('state'),
+      $container->get('form_builder'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build = [];
+
+    // Get all setup form plugins.
+    $plugins = $this->setupFormPluginManager->getDefinitions();
+
+    // Get the current form plugin ID from state.
+    $plugin_id = $this->state->get('farm_setup.block');
+
+    // If the current setup form plugin ID is NULL, or if it does not exist,
+    // then consider the setup process to be complete and show nothing.
+    if (is_null($plugin_id) || !array_key_exists($plugin_id, $plugins)) {
+      return [];
+    }
+
+    // Instantiate the plugin.
+    /** @var \Drupal\farm_setup\Plugin\SetupForm\SetupFormInterface $plugin */
+    $plugin = $this->setupFormPluginManager->createInstance($plugin_id);
+
+    // Build the setup form.
+    $build['form'] = [
+      '#type' => 'details',
+      '#title' => $plugin->getTitle(),
+      '#description' => $plugin->getDescription(),
+      '#open' => TRUE,
+      'form' => $this->formBuilder->getForm(FarmSetupBlockForm::class, $plugin_id),
+    ];
+
+    return $build;
+  }
+
+}

--- a/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
+++ b/modules/core/setup/src/Plugin/Block/FarmSetupBlock.php
@@ -8,10 +8,10 @@ use Drupal\Core\Block\Attribute\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\farm_setup\Form\FarmSetupBlockForm;
 use Drupal\farm_setup\SetupFormPluginManager;
+use Drupal\farm_setup\SetupWizardInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -30,7 +30,7 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
     $plugin_definition,
     #[Autowire(service: 'plugin.manager.setup_form')]
     protected SetupFormPluginManager $setupFormPluginManager,
-    protected StateInterface $state,
+    protected SetupWizardInterface $setupWizard,
     protected FormBuilderInterface $formBuilder,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
@@ -45,7 +45,7 @@ class FarmSetupBlock extends BlockBase implements ContainerFactoryPluginInterfac
       $plugin_id,
       $plugin_definition,
       $container->get('plugin.manager.setup_form'),
-      $container->get('state'),
+      $container->get('farm_setup.wizard'),
       $container->get('form_builder'),
     );
   }

--- a/modules/core/setup/src/Plugin/Derivative/SetupFormTaskLink.php
+++ b/modules/core/setup/src/Plugin/Derivative/SetupFormTaskLink.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\Derivative;
+
+use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\farm_setup\SetupFormPluginManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides task links for setup forms.
+ */
+class SetupFormTaskLink extends DeriverBase implements ContainerDeriverInterface {
+
+  use StringTranslationTrait;
+
+  public function __construct(
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    protected SetupFormPluginManager $setupFormPluginManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, $base_plugin_id) {
+    return new static(
+      $container->get('plugin.manager.setup_form'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition) {
+    $links = [];
+
+    // Add a link for each setup form plugin.
+    // The first one will be farm.setup.wizard.
+    $plugins = $this->setupFormPluginManager->getDefinitions();
+    foreach ($plugins as $id => $plugin) {
+      $route_name = 'farm.setup.wizard';
+      $base_route = 'farm.setup.wizard';
+      if ($id != array_key_first($plugins)) {
+        $route_name .= '.' . $id;
+      }
+      $links[$route_name] = [
+        'title' => $plugin['task_title'],
+        'route_name' => $route_name,
+        'base_route' => $base_route,
+        'weight' => $plugin['weight'],
+      ] + $base_plugin_definition;
+    }
+
+    return $links;
+  }
+
+}

--- a/modules/core/setup/src/Plugin/SetupForm/SetupFormBase.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupFormBase.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Drupal\farm_setup\Plugin\SetupForm;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerTrait;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Psr\Container\ContainerInterface;
 
@@ -70,6 +72,13 @@ class SetupFormBase extends PluginBase implements SetupFormInterface, ContainerF
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Submit is optional, but presumably this will be overridden.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(AccountInterface $account) {
+    return AccessResult::allowed();
   }
 
 }

--- a/modules/core/setup/src/Plugin/SetupForm/SetupFormBase.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupFormBase.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\SetupForm;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Plugin\PluginBase;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Base class for setup forms.
+ */
+class SetupFormBase extends PluginBase implements SetupFormInterface, ContainerFactoryPluginInterface {
+
+  use MessengerTrait;
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_setup_' . $this->getPluginId() . '_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getTitle() {
+    return (string) ($this->pluginDefinition['title'] ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return (string) ($this->pluginDefinition['description'] ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Validation is optional.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Submit is optional, but presumably this will be overridden.
+  }
+
+}

--- a/modules/core/setup/src/Plugin/SetupForm/SetupFormBase.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupFormBase.php
@@ -49,6 +49,13 @@ class SetupFormBase extends PluginBase implements SetupFormInterface, ContainerF
   /**
    * {@inheritdoc}
    */
+  public function getTaskTitle() {
+    return (string) ($this->pluginDefinition['task_title'] ?? '');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getDescription() {
     return (string) ($this->pluginDefinition['description'] ?? '');
   }

--- a/modules/core/setup/src/Plugin/SetupForm/SetupFormInterface.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupFormInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_setup\Plugin\SetupForm;
 
 use Drupal\Core\Form\FormInterface;
+use Drupal\Core\Session\AccountInterface;
 
 /**
  * Interface for setup forms.
@@ -26,5 +27,16 @@ interface SetupFormInterface extends FormInterface {
    *   The setup form description.
    */
   public function getDescription();
+
+  /**
+   * Checks access for the setup form.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(AccountInterface $account);
 
 }

--- a/modules/core/setup/src/Plugin/SetupForm/SetupFormInterface.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupFormInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\SetupForm;
+
+use Drupal\Core\Form\FormInterface;
+
+/**
+ * Interface for setup forms.
+ */
+interface SetupFormInterface extends FormInterface {
+
+  /**
+   * Returns the setup form title.
+   *
+   * @return string
+   *   The setup form title.
+   */
+  public function getTitle();
+
+  /**
+   * Returns the setup form description.
+   *
+   * @return string
+   *   The setup form description.
+   */
+  public function getDescription();
+
+}

--- a/modules/core/setup/src/Plugin/SetupForm/SetupFormInterface.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupFormInterface.php
@@ -21,6 +21,14 @@ interface SetupFormInterface extends FormInterface {
   public function getTitle();
 
   /**
+   * Returns the setup form task title.
+   *
+   * @return string
+   *   The setup form task title.
+   */
+  public function getTaskTitle();
+
+  /**
    * Returns the setup form description.
    *
    * @return string

--- a/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Drupal\farm_setup\Plugin\SetupForm;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\farm_setup\Attribute\SetupForm;
@@ -45,6 +47,13 @@ class SetupModulesForm extends SetupFormBase {
       $container->get('module_handler'),
       $container->get('extension.list.module'),
     );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access(AccountInterface $account) {
+    return AccessResult::allowedIfHasPermission($account, 'install farm modules');
   }
 
   /**

--- a/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
@@ -1,0 +1,462 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\SetupForm;
+
+use Drupal\Core\Extension\ModuleExtensionList;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\farm_setup\Attribute\SetupForm;
+use Drupal\farm_setup\Form\FarmModulesForm;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Module installation setup form.
+ */
+#[SetupForm(
+  id: 'modules',
+  title: new TranslatableMarkup('What are your record keeping needs?'),
+  description: new TranslatableMarkup('farmOS allows you to choose which features are relevant to your operation. These are packaged into "modules" that can be turned on/off. The questions below will help to determine what you need.'),
+  weight: -95,
+)]
+class SetupModulesForm extends SetupFormBase {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected ModuleHandlerInterface $moduleHandler,
+    protected ModuleExtensionList $moduleExtensionList,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('module_handler'),
+      $container->get('extension.list.module'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('farmOS allows you to choose which features are relevant to your operation. These are packaged into "modules" that can be turned on/off. The questions below will help to determine what you need. Modules can also be installed individually via the <a href=":module-form-uri">farmOS modules form</a>.', [':module-form-uri' => Url::fromRoute('farm.setup.modules')->toString()])->render();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $modules = [];
+
+    // Operation questions.
+    $operation_questions = [
+      'plant' => [
+        'title' => $this->t('Do you work with plants?'),
+        'description' => $this->t('Installs the plant asset type.'),
+        'modules' => [
+          'farm_plant',
+        ],
+        'questions' => [
+          'seeding' => [
+            'title' => $this->t('Do you grow plants from seed?'),
+            'description' => $this->t('Installs the seeding log type and a quick form for recording plantings.'),
+            'modules' => [
+              'farm_seeding',
+              'farm_quick_planting',
+            ],
+          ],
+          'transplanting' => [
+            'title' => $this->t('Do you transplant?'),
+            'description' => $this->t('Installs the transplanting log type and a quick form for recording plantings.'),
+            'modules' => [
+              'farm_transplanting',
+              'farm_quick_planting',
+            ],
+          ],
+        ],
+      ],
+      'animal' => [
+        'title' => $this->t('Do you work with animals?'),
+        'description' => $this->t('Installs the animal asset type.'),
+        'modules' => [
+          'farm_animal',
+        ],
+        'questions' => [
+          'birth' => [
+            'title' => $this->t('Do you track animal births?'),
+            'description' => $this->t('Installs the birth log type and a quick form for recording births.'),
+            'modules' => [
+              'farm_birth',
+              'farm_quick_birth',
+            ],
+          ],
+          'medical' => [
+            'title' => $this->t('Do you track animal medical records?'),
+            'description' => $this->t('Installs the medical log type.'),
+            'modules' => [
+              'farm_medical',
+            ],
+          ],
+          'movement' => [
+            'title' => $this->t('Do you track animal movements?'),
+            'description' => $this->t('Installs the activity log type and a quick form for recording movements.'),
+            'modules' => [
+              'farm_activity',
+              'farm_quick_movement',
+            ],
+          ],
+          'group' => [
+            'title' => $this->t('Do you track some animals individually, and group them into herds/flocks/etc?'),
+            'description' => $this->t('Installs the group asset type and a quick form for recording group assignment.'),
+            'modules' => [
+              'farm_group',
+              'farm_observation',
+              'farm_quick_group',
+            ],
+          ],
+          'inventory' => [
+            'title' => $this->t('Do you track some animals together as a single head-count, instead of as individual animals (eg: a flock of birds)?'),
+            'description' => $this->t('Installs a quick form for recording inventory adjustments.'),
+            'modules' => [
+              'farm_observation',
+              'farm_quick_inventory',
+            ],
+          ],
+        ],
+      ],
+      'equipment' => [
+        'title' => $this->t('Do you keep equipment records?'),
+        'description' => $this->t('Installs the equipment asset type.'),
+        'modules' => [
+          'farm_equipment',
+        ],
+        'questions' => [
+          'maintenance' => [
+            'title' => $this->t('Do you track equipment maintenance?'),
+            'description' => $this->t('Installs the maintenance log type.'),
+            'modules' => [
+              'farm_maintenance',
+            ],
+          ],
+          'movement' => [
+            'title' => $this->t('Do you track equipment location?'),
+            'description' => $this->t('Installs the activity log type and a quick form for recording movements.'),
+            'modules' => [
+              'farm_activity',
+              'farm_quick_movement',
+            ],
+          ],
+        ],
+      ],
+      'compost' => [
+        'title' => $this->t('Do you work with compost?'),
+        'description' => $this->t('Installs the compost asset type.'),
+        'modules' => [
+          'farm_compost',
+        ],
+      ],
+      'inventory' => [
+        'title' => $this->t('Do you track inventory?'),
+        'description' => $this->t('Installs a quick form for recording inventory adjustments.'),
+        'modules' => [
+          'farm_observation',
+          'farm_quick_inventory',
+        ],
+        'questions' => [
+          'material' => [
+            'title' => $this->t('Do you track inventory of materials?'),
+            'description' => $this->t('Installs the material asset type.'),
+            'modules' => [
+              'farm_material',
+            ],
+          ],
+          'product' => [
+            'title' => $this->t('Do you track inventory of products?'),
+            'description' => $this->t('Installs the product asset type.'),
+            'modules' => [
+              'farm_product',
+            ],
+          ],
+          'seed' => [
+            'title' => $this->t('Do you track inventory of seed?'),
+            'description' => $this->t('Installs the seed asset type.'),
+            'modules' => [
+              'farm_seed',
+            ],
+          ],
+        ],
+      ],
+    ];
+    $form['operation'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('What do you do?'),
+    ];
+    $form['operation'] += $this->buildQuestionsForm($operation_questions);
+    $modules = array_merge($modules, $this->buildModules($operation_questions, $form_state));
+
+    // Location questions.
+    $location_questions = [
+      'land' => [
+        'title' => $this->t('Land (eg: fields, paddocks, etc)?'),
+        'description' => $this->t('Installs the land asset type and default land types.'),
+        'modules' => [
+          'farm_land',
+          'farm_land_types',
+        ],
+        'questions' => [
+          'lab_test' => [
+            'title' => $this->t('Do you track soil lab test results?'),
+            'description' => $this->t('Installs the lab test log type.'),
+            'modules' => [
+              'farm_lab_test',
+            ],
+          ],
+        ],
+      ],
+      'structure' => [
+        'title' => $this->t('Structures (buildings, greenhouses, etc.)'),
+        'description' => $this->t('Installs the structure asset type and default structure types.'),
+        'modules' => [
+          'farm_structure',
+          'farm_structure_types',
+        ],
+      ],
+      'water' => [
+        'title' => $this->t('Water (wells, ponds, etc.)'),
+        'description' => $this->t('Installs the water asset type.'),
+        'modules' => [
+          'farm_water',
+        ],
+        'questions' => [
+          'lab_test' => [
+            'title' => $this->t('Do you track water lab test results?'),
+            'description' => $this->t('Installs the lab test log type.'),
+            'modules' => [
+              'farm_lab_test',
+            ],
+          ],
+        ],
+      ],
+    ];
+    $form['locations'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Where do you do it?'),
+      '#description' => $this->t('Land, structure, and water assets are used to represent locations that other records can reference.'),
+    ];
+    $form['locations'] += $this->buildQuestionsForm($location_questions);
+    $modules = array_merge($modules, $this->buildModules($location_questions, $form_state));
+
+    // Basic log types.
+    $log_questions = [
+      'activity' => [
+        'title' => $this->t('General activities'),
+        'description' => $this->t('Installs the activity log type.'),
+        'modules' => [
+          'farm_activity',
+        ],
+      ],
+      'observation' => [
+        'title' => $this->t('General observations'),
+        'description' => $this->t('Installs the observation log type.'),
+        'modules' => [
+          'farm_observation',
+        ],
+      ],
+      'input' => [
+        'title' => $this->t('Inputs'),
+        'description' => $this->t('Installs the input log type.'),
+        'modules' => [
+          'farm_input',
+        ],
+      ],
+      'harvest' => [
+        'title' => $this->t('Harvests'),
+        'description' => $this->t('Installs the harvest log type.'),
+        'modules' => [
+          'farm_harvest',
+        ],
+      ],
+    ];
+    $form['logs'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('What events do you record?'),
+      '#description' => $this->t('Events are recorded as logs that reference locations or other assets.'),
+    ];
+    $form['logs'] += $this->buildQuestionsForm($log_questions);
+    $modules = array_merge($modules, $this->buildModules($log_questions, $form_state));
+
+    // Filter out duplicates and sort modules alphabetically.
+    $modules = array_unique($modules);
+    sort($modules);
+
+    // Build a summary of modules that will be installed.
+    // This will be replaced by Ajax as the user makes selections.
+    // Include all modules in the value that gets passed to form state, but
+    // filter out modules that are already installed for the summary.
+    $form['summary'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'id' => 'module-summary',
+      ],
+    ];
+    $form['summary']['modules'] = [
+      '#type' => 'value',
+      '#value' => $modules,
+    ];
+    $install_modules = array_map(function ($module) {
+      return $this->moduleExtensionList->getName($module);
+    }, $this->filterModules($modules));
+    if (!empty($install_modules)) {
+      $form['summary']['summary'] = [
+        '#type' => 'fieldset',
+        '#description' => $this->t('The following modules will be installed: %modules', ['%modules' => implode(', ', $install_modules)]),
+      ];
+    }
+
+    return $form;
+  }
+
+  /**
+   * Recursively build form elements from a nested array of questions.
+   *
+   * @param array $questions
+   *   An array of question and module information.
+   * @param array $parents
+   *   An array of parent keys, if this is a nested question set.
+   *
+   * @return array
+   *   Returns a form build array.
+   */
+  protected function buildQuestionsForm(array $questions, array $parents = []) {
+    $form = [];
+    foreach ($questions as $key => $info) {
+      $key = implode('_', array_merge($parents, [$key]));
+      $form[$key] = [
+        '#type' => 'checkbox',
+        '#title' => $info['title'],
+        '#ajax' => [
+          'callback' => [$this, 'summaryCallback'],
+          'wrapper' => 'module-summary',
+        ],
+      ];
+      if (!empty($info['modules'])) {
+        $form[$key]['#default_value'] = array_reduce($info['modules'], function ($carry, $module) {
+          if (!$carry) {
+            return FALSE;
+          }
+          return $this->moduleHandler->moduleExists($module);
+        }, TRUE);
+        $form[$key]['#disabled'] = $form[$key]['#default_value'];
+      }
+      if (!empty($info['description'])) {
+        $form[$key]['#description'] = $info['description'];
+      }
+      foreach ($parents as $parent) {
+        $form[$key]['#states']['visible'] = [':input[name="' . $parent . '"]' => ['checked' => TRUE]];
+      }
+      if (!empty($info['questions'])) {
+        $form[$key . '_questions'] = [
+          '#type' => 'fieldset',
+        ];
+        $form[$key . '_questions'] += $this->buildQuestionsForm($info['questions'], array_merge($parents, [$key]));
+        $form[$key . '_questions']['#states']['visible'] = [':input[name="' . $key . '"]' => ['checked' => TRUE]];
+      }
+    }
+    return $form;
+  }
+
+  /**
+   * Recursively build a list of modules from a questions list and form state.
+   *
+   * @param array $questions
+   *   An array of question and module information.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state object.
+   * @param array $parents
+   *   An array of parent keys, if this is a nested question set.
+   *
+   * @return array
+   *   Returns a form build array.
+   */
+  protected function buildModules(array $questions, FormStateInterface $form_state, array $parents = []) {
+    $modules = [];
+    foreach ($questions as $key => $info) {
+      $key = implode('_', array_merge($parents, [$key]));
+      if (!empty($info['modules'])) {
+        $selected = !empty($form_state->getValue($key));
+        $modules = array_merge($modules, array_filter($info['modules'], function ($module) use ($selected) {
+          return $selected || $this->moduleHandler->moduleExists($module);
+        }));
+      }
+      if (!empty($info['questions'])) {
+        $modules = array_merge($modules, $this->buildModules($info['questions'], $form_state, array_merge($parents, [$key])));
+      }
+    }
+    return $modules;
+  }
+
+  /**
+   * Filters a list of modules to only include ones that are not installed.
+   *
+   * @param array $modules
+   *   A list of modules.
+   *
+   * @return array
+   *   Returns the filtered list of modules.
+   */
+  protected function filterModules(array $modules) {
+    return array_filter($modules, function ($module) {
+      return !$this->moduleHandler->moduleExists($module);
+    });
+  }
+
+  /**
+   * Ajax callback for the modules summary.
+   */
+  public function summaryCallback(array $form, FormStateInterface $form_state) {
+    return $form['summary'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Get list of modules to install from form state and filter out ones that
+    // are already installed.
+    $to_install = $this->filterModules($form_state->getValue('modules'));
+
+    // Bail if no modules need to be installed.
+    if (empty($to_install)) {
+      return;
+    }
+
+    // Assemble the batch operation for installing modules.
+    $operations = [];
+    foreach ($to_install as $module) {
+      $operations[] = [
+        [FarmModulesForm::class, 'farmInstallModuleBatch'],
+        [$module, $this->moduleExtensionList->getName($module)],
+      ];
+    }
+    $batch = [
+      'operations' => $operations,
+      'title' => $this->t('Installing farmOS modules'),
+      'error_message' => $this->t('The installation has encountered an error.'),
+    ];
+    batch_set($batch);
+  }
+
+}

--- a/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
@@ -335,6 +335,46 @@ class SetupModulesForm extends SetupFormBase {
       ];
     }
 
+    // Recommend that at least one location asset type and one basic log type
+    // modules are installed, but allow the user to ignore this recommendation.
+    $recommended_modules = [
+      'asset' => [
+        'farm_land',
+        'farm_structure',
+        'farm_water',
+      ],
+      'log' => [
+        'farm_activity',
+        'farm_harvest',
+        'farm_input',
+        'farm_observation',
+      ],
+    ];
+    if (
+      empty(array_intersect($recommended_modules['asset'], $modules))
+      ||
+      empty(array_intersect($recommended_modules['log'], $modules))
+    ) {
+      $form['summary']['recommended'] = [
+        '#theme' => 'status_messages',
+        '#message_list' => [
+          'warning' => [
+            $this->t('It is recommended that at least one location asset type and one basic log type is installed. To proceed anyway, use the "Ignore recommendations" checkbox below.'),
+          ],
+        ],
+        '#status_headings' => [
+          'warning' => $this->t('Recommendations'),
+        ],
+      ];
+      $form['summary']['ignore_recommended'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Ignore recommendations'),
+        '#description' => $this->t('This allows you to proceed without installing any recommended modules.'),
+        '#default_value' => FALSE,
+        '#required' => TRUE,
+      ];
+    }
+
     return $form;
   }
 

--- a/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
@@ -308,8 +308,20 @@ class SetupModulesForm extends SetupFormBase {
     $form['logs'] += $this->buildQuestionsForm($log_questions);
     $modules = array_merge($modules, $this->buildModules($log_questions, $form_state));
 
-    // Filter out duplicates and sort modules alphabetically.
+    // Filter out duplicates.
     $modules = array_unique($modules);
+
+    // If any log modules are installed, add the standard quantity type module.
+    // We do this to ensure that at least one quantity type is available, since
+    // log type modules do not explicitly depend on any specific type.
+    $log_modules = array_keys(array_filter($this->moduleExtensionList->getAllAvailableInfo(), function ($module_info) {
+      return isset($module_info['package']) && $module_info['package'] == 'farmOS Logs';
+    }));
+    if (!empty(array_intersect($modules, $log_modules))) {
+      $modules[] = 'farm_quantity_standard';
+    }
+
+    // Sort modules alphabetically.
     sort($modules);
 
     // Build a summary of modules that will be installed.

--- a/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
@@ -21,6 +21,7 @@ use Psr\Container\ContainerInterface;
 #[SetupForm(
   id: 'modules',
   title: new TranslatableMarkup('What are your record keeping needs?'),
+  task_title: new TranslatableMarkup('Install modules'),
   description: new TranslatableMarkup('farmOS allows you to choose which features are relevant to your operation. These are packaged into "modules" that can be turned on/off. The questions below will help to determine what you need.'),
   weight: -95,
 )]

--- a/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupModulesForm.php
@@ -13,6 +13,7 @@ use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\farm_setup\Attribute\SetupForm;
 use Drupal\farm_setup\Form\FarmModulesForm;
+use Drupal\farm_setup\Form\FarmSetupBlockForm;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -503,6 +504,7 @@ class SetupModulesForm extends SetupFormBase {
     }
     $batch = [
       'operations' => $operations,
+      'finished' => [FarmSetupBlockForm::class, 'finishInstallModulesBatch'],
       'title' => $this->t('Installing farmOS modules'),
       'error_message' => $this->t('The installation has encountered an error.'),
     ];

--- a/modules/core/setup/src/Plugin/SetupForm/SetupResourcesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupResourcesForm.php
@@ -14,6 +14,7 @@ use Drupal\farm_setup\Attribute\SetupForm;
 #[SetupForm(
   id: 'resources',
   title: new TranslatableMarkup('Next steps'),
+  task_title: new TranslatableMarkup('Resources'),
   weight: 100,
 )]
 class SetupResourcesForm extends SetupFormBase {

--- a/modules/core/setup/src/Plugin/SetupForm/SetupResourcesForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupResourcesForm.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\SetupForm;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_setup\Attribute\SetupForm;
+
+/**
+ * Resources step for the farmOS setup wizard.
+ */
+#[SetupForm(
+  id: 'resources',
+  title: new TranslatableMarkup('Next steps'),
+  weight: 100,
+)]
+class SetupResourcesForm extends SetupFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // Documentation links.
+    $form['docs'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Documentation'),
+    ];
+    $form['docs']['links'] = [
+      '#theme' => 'item_list',
+      '#items' => [
+        $this->t('User guide: <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.org/guide/']),
+        $this->t('Data model <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.org/model/']),
+      ],
+    ];
+
+    // Community links.
+    $form['community'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Community Resources'),
+    ];
+    $form['community']['links'] = [
+      '#theme' => 'item_list',
+      '#items' => [
+        $this->t('Community blog: <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.org/blog/']),
+        $this->t('Forum: <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.discourse.org/']),
+        $this->t('Chat room: <a href=":matrix-uri">#farmOS:matrix.org</a> / <a href=":irc-uri">#farmOS IRC</a>', [':matrix-uri' => 'https://app.element.io/#/room/#farmOS:matrix.org', ':irc-uri' => 'https://webchat.oftc.net/?channels=#farmOS']),
+        $this->t('Monthly call: <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.org/community/monthly-call/']),
+      ],
+    ];
+
+    // Contributing links.
+    $form['contributing'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Contributing'),
+    ];
+    $form['contributing']['links'] = [
+      '#theme' => 'item_list',
+      '#items' => [
+        $this->t('Support requests: <a href=":uri">:uri</a>', [':uri' => 'https://farmos.discourse.group/new-topic?tags=support-request']),
+        $this->t('Feature requests: <a href=":uri">:uri</a>', [':uri' => 'https://farmos.discourse.group/new-topic?category=development&tags=feature-request']),
+        $this->t('Development guide: <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.org/development/module/']),
+        $this->t('Donate: <a href=":uri">:uri</a>', [':uri' => 'https://farmOS.org/donate/']),
+      ],
+    ];
+
+    return $form;
+  }
+
+}

--- a/modules/core/setup/src/Plugin/SetupForm/SetupWelcomeForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupWelcomeForm.php
@@ -13,6 +13,7 @@ use Drupal\farm_setup\Attribute\SetupForm;
 #[SetupForm(
   id: 'welcome',
   title: new TranslatableMarkup('Welcome to farmOS'),
+  task_title: new TranslatableMarkup('Welcome'),
   description: new TranslatableMarkup('This will guide you through the process of setting up your farmOS system.'),
   weight: -100,
 )]

--- a/modules/core/setup/src/Plugin/SetupForm/SetupWelcomeForm.php
+++ b/modules/core/setup/src/Plugin/SetupForm/SetupWelcomeForm.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Plugin\SetupForm;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_setup\Attribute\SetupForm;
+
+/**
+ * Welcome step for the farmOS setup wizard.
+ */
+#[SetupForm(
+  id: 'welcome',
+  title: new TranslatableMarkup('Welcome to farmOS'),
+  description: new TranslatableMarkup('This will guide you through the process of setting up your farmOS system.'),
+  weight: -100,
+)]
+class SetupWelcomeForm extends SetupFormBase {
+
+}

--- a/modules/core/setup/src/Routing/SetupFormRoutes.php
+++ b/modules/core/setup/src/Routing/SetupFormRoutes.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup\Routing;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\farm_setup\Form\FarmSetupForm;
+use Drupal\farm_setup\SetupFormPluginManager;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Defines setup form routes.
+ */
+class SetupFormRoutes implements ContainerInjectionInterface {
+
+  use AutowireTrait;
+
+  public function __construct(
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    protected SetupFormPluginManager $setupFormPluginManager,
+  ) {}
+
+  /**
+   * Provides routes for setup forms.
+   *
+   * @return \Symfony\Component\Routing\RouteCollection
+   *   Returns a route collection.
+   */
+  public function routes(): RouteCollection {
+    $route_collection = new RouteCollection();
+
+    // Create a /setup/wizard/[plugin_id] route for each plugin.
+    // The first one will be /setup/wizard (farm.setup.wizard).
+    $plugins = $this->setupFormPluginManager->getDefinitions();
+    foreach ($plugins as $id => $plugin) {
+      $path = '/setup/wizard';
+      $route_name = 'farm.setup.wizard';
+      if ($id != array_key_first($plugins)) {
+        $path .= '/' . $id;
+        $route_name .= '.' . $id;
+      }
+      $route = new Route(
+        $path,
+        [
+          '_form' => FarmSetupForm::class,
+          '_title_callback' => FarmSetupForm::class . '::getTitle',
+          'plugin_id' => $id,
+        ],
+        [
+          '_permission' => 'access farm setup wizard',
+          '_custom_access' => FarmSetupForm::class . '::access',
+        ],
+      );
+      $route_collection->add($route_name, $route);
+    }
+
+    return $route_collection;
+  }
+
+}

--- a/modules/core/setup/src/SetupFormPluginManager.php
+++ b/modules/core/setup/src/SetupFormPluginManager.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\farm_setup\Attribute\SetupForm;
+use Drupal\farm_setup\Plugin\SetupForm\SetupFormInterface;
+
+/**
+ * Setup form plugin manager.
+ */
+class SetupFormPluginManager extends DefaultPluginManager {
+
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+  ) {
+    parent::__construct(
+      'Plugin/SetupForm',
+      $namespaces,
+      $module_handler,
+      SetupFormInterface::class,
+      SetupForm::class,
+    );
+    $this->alterInfo('farm_setup_form_info');
+    $this->setCacheBackend($cache_backend, 'farm_setup_forms');
+  }
+
+}

--- a/modules/core/setup/src/SetupFormPluginManager.php
+++ b/modules/core/setup/src/SetupFormPluginManager.php
@@ -31,4 +31,17 @@ class SetupFormPluginManager extends DefaultPluginManager {
     $this->setCacheBackend($cache_backend, 'farm_setup_forms');
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefinitions() {
+
+    // Sort definitions by weight.
+    $definitions = parent::getDefinitions();
+    uasort($definitions, function ($a, $b) {
+      return $a['weight'] <=> $b['weight'];
+    });
+    return $definitions;
+  }
+
 }

--- a/modules/core/setup/src/SetupWizard.php
+++ b/modules/core/setup/src/SetupWizard.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Setup wizard logic.
+ */
+class SetupWizard implements SetupWizardInterface {
+
+  use AutowireTrait;
+
+  public function __construct(
+    #[Autowire(service: 'plugin.manager.setup_form')]
+    protected SetupFormPluginManager $setupFormPluginManager,
+    protected StateInterface $state,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getNextPluginId(string $plugin_id): ?string {
+    $plugins = $this->setupFormPluginManager->getDefinitions();
+    $keys = array_keys($plugins);
+    $index = array_search($plugin_id, $keys);
+    if ($index !== FALSE && isset($keys[$index + 1])) {
+      return $keys[$index + 1];
+    }
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getBlockPluginId(): ?string {
+    return $this->state->get('farm_setup.block');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setBlockPluginId(?string $plugin_id): void {
+    $this->state->set('farm_setup.block', $plugin_id);
+  }
+
+}

--- a/modules/core/setup/src/SetupWizardInterface.php
+++ b/modules/core/setup/src/SetupWizardInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup;
+
+/**
+ * Setup wizard logic.
+ */
+interface SetupWizardInterface {
+
+  /**
+   * Get the next setup form plugin ID.
+   *
+   * @param string $plugin_id
+   *   The current setup form plugin ID.
+   *
+   * @return string|null
+   *   The next setup form plugin ID, or NULL if there is none.
+   */
+  public function getNextPluginId(string $plugin_id): ?string;
+
+  /**
+   * Get the current block setup form plugin ID.
+   *
+   * @return string|null
+   *   A setup form plugin ID, or NULL if setup has been completed.
+   */
+  public function getBlockPluginId(): ?string;
+
+  /**
+   * Set the current block setup form plugin ID.
+   *
+   * @param string|null $plugin_id
+   *   A setup form plugin ID, or NULL to indicate setup has been completed.
+   */
+  public function setBlockPluginId(?string $plugin_id): void;
+
+}

--- a/modules/core/setup/tests/modules/farm_setup_test/src/Plugin/SetupForm/SetupTestForm.php
+++ b/modules/core/setup/tests/modules/farm_setup_test/src/Plugin/SetupForm/SetupTestForm.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup_test\Plugin\SetupForm;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_setup\Attribute\SetupForm;
+use Drupal\farm_setup\Plugin\SetupForm\SetupFormBase;
+
+/**
+ * Test setup form.
+ */
+#[SetupForm(
+  id: 'test',
+  title: new TranslatableMarkup('This is just a test'),
+  task_title: new TranslatableMarkup('Test'),
+  description: new TranslatableMarkup('Pay no attention.'),
+  weight: 0,
+)]
+class SetupTestForm extends SetupFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['test'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Test'),
+    ];
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(&$form, FormStateInterface $form_state) {
+    if ($form_state->getValue('test') == 'validate') {
+      $form_state->setError($form['test'], 'Validation test passed.');
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(&$form, FormStateInterface $form_state) {
+    $this->messenger()->addStatus('Submission test passed.');
+  }
+
+}

--- a/modules/core/setup/tests/modules/farm_setup_test_modules/farm_setup_test_modules.info.yml
+++ b/modules/core/setup/tests/modules/farm_setup_test_modules/farm_setup_test_modules.info.yml
@@ -1,0 +1,5 @@
+name: farmOS Setup Test Modules
+description: 'Support module for farmOS setup modules form testing.'
+type: module
+package: farmOS Contrib
+core_version_requirement: ^11

--- a/modules/core/setup/tests/modules/farm_setup_test_modules/src/Hook/FormHooks.php
+++ b/modules/core/setup/tests/modules/farm_setup_test_modules/src/Hook/FormHooks.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_setup_test_modules\Hook;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Form hook implementations for farm_setup_test_modules.
+ */
+class FormHooks {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_form_FORM_ID_alter().
+   */
+  #[Hook('form_farm_setup_block_form_alter')]
+  public function formFarmSetupBlockFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+
+    // Add checkbox and form validation method to the module setup form so that
+    // we can test installing the farm_setup_test module, which adds another
+    // setup form that should appear after the modules form.
+    if (isset($form['plugin_id']['#value']) && $form['plugin_id']['#value'] == 'modules') {
+      $form['install_farm_setup_test'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Install farm_setup_test module'),
+      ];
+      $form['#validate'][] = [self::class, 'validateFarmSetupBlockForm'];
+    }
+  }
+
+  /**
+   * Additional validation function for the farm_setup_block_form.
+   */
+  public static function validateFarmSetupBlockForm($form, FormStateInterface $form_state) {
+
+    // If the install_farm_setup_test box is checked, add farm_setup_test to the
+    // list of modules to install.
+    if (!empty($form_state->getValue('install_farm_setup_test'))) {
+      $modules = $form_state->getValue('modules');
+      $modules[] = 'farm_setup_test';
+      $form_state->setValue('modules', $modules);
+    }
+  }
+
+}

--- a/modules/core/setup/tests/src/Functional/SetupWizardTest.php
+++ b/modules/core/setup/tests/src/Functional/SetupWizardTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_setup\Functional;
+
+use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+
+/**
+ * Tests for the farmOS setup wizard.
+ *
+ * @group farm
+ */
+class SetupWizardTest extends FarmBrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_setup',
+    'farm_ui_dashboard',
+  ];
+
+  /**
+   * Tests the farmOS setup wizard functionality.
+   */
+  public function testSetupWizard() {
+
+    /** @var \Drupal\farm_setup\SetupWizardInterface $wizard */
+    $wizard = \Drupal::service('farm_setup.wizard');
+
+    // Initialize the setup wizard state so that the welcome form is displayed
+    // on the dashboard.
+    $wizard->setBlockPluginId('welcome');
+
+    // Login a user with access to the dashboard.
+    $permissions = ['access farm dashboard'];
+    $user = $this->createUser($permissions);
+    $this->drupalLogin($user);
+
+    // Go to the dashboard and confirm that the setup block is not visible.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextNotContains('Setup progress');
+    $this->assertSession()->pageTextNotContains('Step 1: Welcome');
+    $this->assertSession()->pageTextNotContains('Welcome to farmOS');
+
+    // Login a user with additional access to the setup wizard.
+    $permissions[] = 'access farm setup wizard';
+    $user = $this->createUser($permissions);
+    $this->drupalLogin($user);
+
+    // Go to the dashboard and confirm that the setup block is visible.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Setup progress');
+    $this->assertSession()->pageTextContains('Step 1: Welcome');
+    $this->assertSession()->pageTextContains('0%');
+    $this->assertSession()->pageTextContains('Welcome to farmOS');
+    $this->assertSession()->responseContains('value="Continue"');
+    $this->assertSession()->responseNotContains('value="Save and continue"');
+    $this->assertSession()->responseNotContains('value="Skip"');
+
+    // Press the "Continue" button and confirm that the resources form is shown
+    // (because the user does not have permission to install modules).
+    $this->getSession()->getPage()->pressButton('Continue');
+    $this->assertSession()->pageTextContains('Setup progress');
+    $this->assertSession()->pageTextContains('Step 2: Resources');
+    $this->assertSession()->pageTextContains('100%');
+    $this->assertSession()->pageTextContains('Next steps');
+
+    // Since this is now the last step, confirm there is only a "Finish" button.
+    $this->assertSession()->responseContains('value="Finish"');
+    $this->assertSession()->responseNotContains('value="Continue"');
+    $this->assertSession()->responseNotContains('value="Save and continue"');
+    $this->assertSession()->responseNotContains('value="Skip"');
+
+    // Refresh the page and confirm that the resources form is still shown.
+    // This tests that the progress is saved to Drupal state.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Step 2: Resources');
+
+    // Login a user with additional access to install modules.
+    $permissions[] = 'install farm modules';
+    $user = $this->createUser($permissions);
+    $this->drupalLogin($user);
+
+    // Refresh the page and confirm that the modules form is now shown, and that
+    // both "Save and continue" and "Skip" buttons are visible, but "Continue"
+    // and "Finish" are not.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Step 2: Install modules');
+    $this->assertSession()->pageTextContains('50%');
+    $this->assertSession()->pageTextContains('What are your record keeping needs?');
+    $this->assertSession()->responseContains('value="Save and continue"');
+    $this->assertSession()->responseContains('value="Skip"');
+    $this->assertSession()->responseNotContains('value="Continue"');
+    $this->assertSession()->responseNotContains('value="Finish"');
+
+    // Skip submission of the modules form. This will be tested separately.
+    $this->getSession()->getPage()->pressButton('Skip');
+
+    // Confirm that we are on the resources step again.
+    $this->assertSession()->pageTextContains('Step 3: Resources');
+    $this->assertSession()->pageTextContains('100%');
+
+    // Install the farm_setup_test module, reset the current plugin to modules,
+    // reload the page, press the "Skip" button, and confirm that we see the
+    // test form.
+    $wizard->setBlockPluginId('modules');
+    \Drupal::service('module_installer')->install(['farm_setup_test']);
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Step 2: Install modules');
+    $this->assertSession()->pageTextContains('33%');
+    $this->getSession()->getPage()->pressButton('Skip');
+    $this->assertSession()->pageTextContains('Step 3: Test');
+    $this->assertSession()->pageTextContains('67%');
+    $this->assertSession()->pageTextContains('This is just a test');
+    $this->assertSession()->pageTextContains('Pay no attention.');
+
+    // Test form validation.
+    $this->getSession()->getPage()->fillField('test', 'validate');
+    $this->getSession()->getPage()->pressButton('Save and continue');
+    $this->assertSession()->pageTextContains('Step 3: Test');
+    $this->assertSession()->pageTextContains('Validation test passed.');
+
+    // Test skipping the test form.
+    $this->getSession()->getPage()->pressButton('Skip');
+    $this->assertSession()->pageTextNotContains('Validation test passed.');
+    $this->assertSession()->pageTextContains('Step 4: Resources');
+
+    // Reset the state, reload the page, and confirm that we see the test form.
+    $wizard->setBlockPluginId('test');
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Step 3: Test');
+
+    // Test form submission.
+    $this->getSession()->getPage()->pressButton('Save and continue');
+    $this->assertSession()->pageTextContains('Submission test passed.');
+
+    // Confirm that we are on the resources step again, then press the "Finish"
+    // button and confirm that the block is no longer visible, and a message is
+    // displayed to the user.
+    $this->assertSession()->pageTextContains('Step 4: Resources');
+    $this->assertSession()->pageTextContains('100%');
+    $this->getSession()->getPage()->pressButton('Finish');
+    $this->assertSession()->pageTextNotContains('Setup progress');
+    $this->assertSession()->pageTextContains('farmOS setup is complete! Happy record keeping!');
+
+    // Confirm that we can also go through the setup process via /setup/wizard,
+    // and that it redirects back to the dashboard with a message at the end.
+    $this->drupalGet('/setup/wizard');
+    $this->assertSession()->statusCodeEquals(200);
+    $base_url = 'http://www/';
+    $this->getSession()->getPage()->pressButton('Continue');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertEquals($base_url . 'setup/wizard/modules', $this->getSession()->getCurrentUrl());
+    $this->getSession()->getPage()->pressButton('Skip');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertEquals($base_url . 'setup/wizard/test', $this->getSession()->getCurrentUrl());
+    $this->getSession()->getPage()->pressButton('Skip');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertEquals($base_url . 'setup/wizard/resources', $this->getSession()->getCurrentUrl());
+    $this->getSession()->getPage()->pressButton('Finish');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertEquals($base_url, $this->getSession()->getCurrentUrl());
+    $this->assertSession()->pageTextContains('farmOS setup is complete! Happy record keeping!');
+
+    // Remove the user's "install farm modules" permission and confirm that
+    // /setup/wizard/modules is no longer accessible.
+    $user = $this->createUser(array_filter($permissions, function ($perm) {
+      return $perm != 'install farm modules';
+    }));
+    $this->drupalLogin($user);
+    $this->drupalGet('/setup/wizard/modules');
+    $this->assertSession()->statusCodeEquals(403);
+  }
+
+}

--- a/modules/core/setup/tests/src/FunctionalJavascript/ModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/ModulesFormTest.php
@@ -31,8 +31,8 @@ class ModulesFormTest extends FarmWebDriverTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    // Login a user with administer farm settings permission.
-    $user = $this->createUser(['administer farm settings']);
+    // Login a user with permission to install farmOS modules.
+    $user = $this->createUser(['install farm modules']);
     $this->drupalLogin($user);
   }
 

--- a/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
@@ -110,7 +110,7 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
     $this->getSession()->getPage()->checkField('land');
     $this->assertTrue($this->assertSession()->waitForText('The following modules will be installed: Land asset, Default land types'));
     $this->getSession()->getPage()->checkField('activity');
-    $this->assertTrue($this->assertSession()->waitForText('The following modules will be installed: Activity log, Land asset, Default land types'));
+    $this->assertTrue($this->assertSession()->waitForText('Activity log, Land asset, Default land types, Standard quantity'));
 
     // Confirm that the recommended modules warning and ignore_recommended
     // checkbox is not visible.
@@ -130,7 +130,8 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
 
     // Confirm that the modules form is visible, the plant, land, and activity
     // checkboxes are checked, and the farm_activity, farm_land,
-    // farm_land_types, and farm_plant modules are installed.
+    // farm_land_types, farm_plant, and farm_quantity_standard modules are
+    // installed.
     $this->assertSession()->pageTextContains('Step 2: Install modules');
     $this->assertCheckboxState('plant', TRUE, TRUE);
     $this->assertCheckboxState('land', TRUE, TRUE);
@@ -139,6 +140,7 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
     $this->assertModuleInstalled('farm_land', TRUE);
     $this->assertModuleInstalled('farm_land_types', TRUE);
     $this->assertModuleInstalled('farm_plant', TRUE);
+    $this->assertModuleInstalled('farm_quantity_standard', TRUE);
 
     // Confirm that the recommended modules warning and ignore_recommended
     // checkbox is not visible.

--- a/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_setup\FunctionalJavascript;
+
+use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
+
+/**
+ * Tests installing modules via the setup wizard modules form.
+ *
+ * @group farm
+ *
+ * @see \Drupal\farm_setup\Plugin\SetupForm\SetupModulesForm
+ */
+class SetupModulesFormTest extends FarmWebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_setup',
+    'farm_ui_dashboard',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Set the initial setup wizard block plugin state to show the modules form.
+    \Drupal::service('farm_setup.wizard')->setBlockPluginId('modules');
+
+    // Login a user with access to the dashboard, setup wizard, and module
+    // installation setup form.
+    $user = $this->createUser([
+      'access farm dashboard',
+      'access farm setup wizard',
+      'install farm modules',
+    ]);
+    $this->drupalLogin($user);
+  }
+
+  /**
+   * Tests the setup wizard modules form.
+   */
+  public function testModulesSetupForm() {
+
+    // Request the dashboard.
+    $this->drupalGet('<front>');
+
+    // Confirm that checkboxes are unchecked, and modules are not installed.
+    $this->assertCheckboxState('plant', FALSE, FALSE);
+    $this->assertCheckboxState('land', FALSE, FALSE);
+    $this->assertCheckboxState('activity', FALSE, FALSE);
+    $this->assertModuleInstalled('farm_plant', FALSE);
+    $this->assertModuleInstalled('farm_land', FALSE);
+    $this->assertModuleInstalled('farm_land_types', FALSE);
+    $this->assertModuleInstalled('farm_activity', FALSE);
+
+    // Check the plant checkbox and confirm that a summary message is displayed.
+    $this->getSession()->getPage()->checkField('plant');
+    $this->assertTrue($this->assertSession()->waitForText('The following modules will be installed: Plant asset'));
+
+    // Submit the form.
+    $this->getSession()->getPage()->pressButton('Save and continue');
+
+    // Wait for the batch process to complete.
+    $this->assertTrue($this->assertSession()->waitForText('Step 3: Resources', 30000));
+
+    // Rebuild the container.
+    $this->rebuildContainer();
+
+    // Reset state so that we can see the modules form and reload the dashboard.
+    \Drupal::service('farm_setup.wizard')->setBlockPluginId('modules');
+    $this->drupalGet('<front>');
+
+    // Confirm that the modules form is visible, the plant checkbox is checked,
+    // and the farm_plant module is installed.
+    $this->assertSession()->pageTextContains('Step 2: Install modules');
+    $this->assertCheckboxState('plant', TRUE, TRUE);
+    $this->assertModuleInstalled('farm_plant', TRUE);
+  }
+
+  /**
+   * Helper function to assert the state of checkboxes.
+   *
+   * @param string $field_name
+   *   The checkbox input field name.
+   * @param bool $checked
+   *   Boolean if the checkbox should be checked. Defaults to FALSE.
+   * @param bool $disabled
+   *   Boolean if the checkbox should be disabled. Defaults to FALSE.
+   */
+  protected function assertCheckboxState(string $field_name, bool $checked = FALSE, bool $disabled = FALSE) {
+    $checkbox = $this->getSession()->getPage()->findField($field_name);
+    $this->assertNotEmpty($checkbox);
+    $this->assertEquals($checked, $checkbox->isChecked());
+    $this->assertEquals($disabled, $checkbox->hasAttribute('disabled'));
+  }
+
+  /**
+   * Helper function to assert the state of a module.
+   *
+   * @param string $module
+   *   The module name.
+   * @param bool $installed
+   *   Boolean if the module should be installed. Defaults to TRUE.
+   */
+  protected function assertModuleInstalled(string $module, bool $installed = TRUE) {
+    $this->assertEquals($installed, \Drupal::moduleHandler()->moduleExists($module));
+  }
+
+}

--- a/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
@@ -20,6 +20,7 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
    */
   protected static $modules = [
     'farm_setup',
+    'farm_setup_test_modules',
     'farm_ui_dashboard',
   ];
 
@@ -144,6 +145,15 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
     $this->assertSession()->pageTextNotContains($recommended_title);
     $this->assertSession()->pageTextNotContains($recommended_message);
     $this->assertEmpty($this->getSession()->getPage()->findField('ignore_recommended'));
+
+    // Test installing a module that provides a setup form, and confirm that it
+    // appears after the modules form.
+    $this->assertSession()->pageTextContains('Install farm_setup_test module');
+    $this->getSession()->getPage()->checkField('install_farm_setup_test');
+    $this->getSession()->getPage()->pressButton('Save and continue');
+    $this->assertTrue($this->assertSession()->waitForText('Step 3: Test', 30000));
+    $this->assertSession()->pageTextContains('This is just a test');
+    $this->assertSession()->pageTextContains('Pay no attention.');
   }
 
   /**

--- a/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
@@ -63,7 +63,20 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
     $this->getSession()->getPage()->checkField('plant');
     $this->assertTrue($this->assertSession()->waitForText('The following modules will be installed: Plant asset'));
 
-    // Submit the form.
+    // Confirm that the recommended modules warning is displayed.
+    $recommended_title = 'Recommendations';
+    $recommended_message = 'It is recommended that at least one location asset type and one basic log type is installed. To proceed anyway, use the "Ignore recommendations" checkbox below.';
+    $this->assertSession()->pageTextContains($recommended_title);
+    $this->assertSession()->pageTextContains($recommended_message);
+
+    // Confirm that the ignore_recommended checkbox is visible and required.
+    $ignore_recommended = $this->getSession()->getPage()->findField('ignore_recommended');
+    $this->assertNotEmpty($ignore_recommended);
+    $this->assertTrue($ignore_recommended->hasClass('required'));
+    $this->assertFalse($ignore_recommended->isChecked());
+
+    // Check the ignore_recommended checkbox and submit the form.
+    $ignore_recommended->check();
     $this->getSession()->getPage()->pressButton('Save and continue');
 
     // Wait for the batch process to complete.
@@ -81,6 +94,56 @@ class SetupModulesFormTest extends FarmWebDriverTestBase {
     $this->assertSession()->pageTextContains('Step 2: Install modules');
     $this->assertCheckboxState('plant', TRUE, TRUE);
     $this->assertModuleInstalled('farm_plant', TRUE);
+
+    // Confirm that the recommended modules warning and ignore_recommended
+    // checkbox is still visible and required.
+    $this->assertSession()->pageTextContains($recommended_title);
+    $this->assertSession()->pageTextContains($recommended_message);
+    $ignore_recommended = $this->getSession()->getPage()->findField('ignore_recommended');
+    $this->assertNotEmpty($ignore_recommended);
+    $this->assertTrue($ignore_recommended->hasClass('required'));
+    $this->assertFalse($ignore_recommended->isChecked());
+
+    // Check the land and activity checkboxes and confirm that the summary
+    // message is updated.
+    $this->getSession()->getPage()->checkField('land');
+    $this->assertTrue($this->assertSession()->waitForText('The following modules will be installed: Land asset, Default land types'));
+    $this->getSession()->getPage()->checkField('activity');
+    $this->assertTrue($this->assertSession()->waitForText('The following modules will be installed: Activity log, Land asset, Default land types'));
+
+    // Confirm that the recommended modules warning and ignore_recommended
+    // checkbox is not visible.
+    $this->assertSession()->pageTextNotContains($recommended_title);
+    $this->assertSession()->pageTextNotContains($recommended_message);
+    $this->assertEmpty($this->getSession()->getPage()->findField('ignore_recommended'));
+
+    // Submit the form, wait for the batch process to complete, and rebuild the
+    // container.
+    $this->getSession()->getPage()->pressButton('Save and continue');
+    $this->assertTrue($this->assertSession()->waitForText('Step 3: Resources', 30000));
+    $this->rebuildContainer();
+
+    // Reset state so that we can see the modules form and reload the dashboard.
+    \Drupal::service('farm_setup.wizard')->setBlockPluginId('modules');
+    $this->drupalGet('<front>');
+
+    // Confirm that the modules form is visible, the plant, land, and activity
+    // checkboxes are checked, and the farm_activity, farm_land,
+    // farm_land_types, and farm_plant modules are installed.
+    $this->assertSession()->pageTextContains('Step 2: Install modules');
+    $this->assertCheckboxState('plant', TRUE, TRUE);
+    $this->assertCheckboxState('land', TRUE, TRUE);
+    $this->assertCheckboxState('activity', TRUE, TRUE);
+    $this->assertModuleInstalled('farm_activity', TRUE);
+    $this->assertModuleInstalled('farm_land', TRUE);
+    $this->assertModuleInstalled('farm_land_types', TRUE);
+    $this->assertModuleInstalled('farm_plant', TRUE);
+
+    // Confirm that the recommended modules warning and ignore_recommended
+    // checkbox is not visible.
+    $this->assertSession()->pageTextNotContains($recommended_title);
+    $this->assertSession()->pageTextNotContains($recommended_message);
+    $this->assertEmpty($this->getSession()->getPage()->findField('ignore_recommended'));
   }
 
   /**


### PR DESCRIPTION
This adds a new "farmOS Setup Wizard" framework, which provides the ability for farmOS modules to add forms to a multi-step setup process. This is shown in a block on the dashboard after a fresh install, visible to admin (user 1) and users with the `farm_config_admin` role (from #1022). The forms are also available directly via routes in the `/setup/wizard/*` path.

This is intended to replace the module installation step that was removed in #1034, as well as to provide a new place to put setup wizard forms moving forward.

Setup wizard forms are plugins provided by modules, so it is possible for modules to provide their own steps. In the future, we can add more steps to core for things like initial farm mapping, setting up taxonomies, importing records, etc (these are all ideas that have come up during discussion).

This branch starts with three steps:

- Welcome - simply welcomes the new user to farmOS and introduces them to the setup process.
- Modules - guides the user through installing modules based on their need, by asking questions and installing relevant modules
- Resources - shows a bunch of links to the user guide, forum, etc as the last step

The commit history should describe each step of the development clearly, but happy to answer any questions!