### PR TITLE
Route "entity.filter_format.edit_form" does not exist

### DIFF
--- a/modules/core/ui/theme/farm_ui_theme.info.yml
+++ b/modules/core/ui/theme/farm_ui_theme.info.yml
@@ -3,6 +3,7 @@ description: Install Gin theme and provide overrides for farmOS.
 type: module
 package: farmOS UI
 core_version_requirement: ^11
+container_rebuild_required: true
 dependencies:
   - drupal:block
   - drupal:layout_discovery

--- a/modules/core/ui/theme/tests/modules/farm_ui_theme_test/config/install/user.role.test.yml
+++ b/modules/core/ui/theme/tests/modules/farm_ui_theme_test/config/install/user.role.test.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {}
+id: test
+label: Test
+weight: 0
+is_admin: false
+permissions: {}

--- a/modules/core/ui/theme/tests/modules/farm_ui_theme_test/farm_ui_theme_test.info.yml
+++ b/modules/core/ui/theme/tests/modules/farm_ui_theme_test/farm_ui_theme_test.info.yml
@@ -1,0 +1,7 @@
+name: farmOS UI Theme Test
+description: 'Support module for farmOS UI Theme testing.'
+type: module
+package: Testing
+core_version_requirement: ^11
+dependencies:
+  - farm:farm_format

--- a/modules/core/ui/theme/tests/src/Functional/FarmUiThemeTest.php
+++ b/modules/core/ui/theme/tests/src/Functional/FarmUiThemeTest.php
@@ -7,11 +7,11 @@ namespace Drupal\Tests\farm_ui_theme\Functional;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 
 /**
- * Tests the "Powered by farmOS" block.
+ * Tests the farmOS UI Theme module.
  *
  * @group farm
  */
-class FarmBlockTest extends FarmBrowserTestBase {
+class FarmUiThemeTest extends FarmBrowserTestBase {
 
   /**
    * {@inheritdoc}

--- a/modules/core/ui/theme/tests/src/Functional/FarmUiThemeTest.php
+++ b/modules/core/ui/theme/tests/src/Functional/FarmUiThemeTest.php
@@ -18,6 +18,7 @@ class FarmUiThemeTest extends FarmBrowserTestBase {
    */
   protected static $modules = [
     'farm_ui_theme',
+    'farm_ui_theme_test',
   ];
 
   /**


### PR DESCRIPTION
I ran into a strange error in a contrib module's functional test after updating to Drupal 11.3. I'm still not 100% sure what the cause is, but I was able to replicate it in a new farmOS core functional test (included in this PR), so it is not specific to the contrib module. I found a very simple fix for it, but I'd like to understand the root cause better to make sure my solution makes sense...

Here is the full error that PHPUnit when the test fails:

```bash
There was 1 error:

1) Drupal\Tests\farm_ui_theme\Functional\FarmUiThemeTest::testFarmBlock
Symfony\Component\Routing\Exception\RouteNotFoundException: Route "entity.filter_format.edit_form" does not exist.

/opt/drupal/web/core/lib/Drupal/Core/Routing/RouteProvider.php:214
/opt/drupal/web/core/lib/Drupal/Core/Routing/UrlGenerator.php:450
/opt/drupal/web/core/lib/Drupal/Core/Routing/UrlGenerator.php:290
/opt/drupal/web/core/lib/Drupal/Core/Render/MetadataBubblingUrlGenerator.php:105
/opt/drupal/web/core/lib/Drupal/Core/Url.php:773
/opt/drupal/web/core/modules/filter/src/FilterPermissions.php:57
/opt/drupal/web/core/modules/user/src/PermissionHandler.php:157
/opt/drupal/web/core/modules/user/src/PermissionHandler.php:116
/opt/drupal/web/core/modules/user/src/Entity/Role.php:210
/opt/drupal/web/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php:331
/opt/drupal/web/core/modules/user/src/Entity/Role.php:187
/opt/drupal/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php:567
/opt/drupal/web/core/lib/Drupal/Core/Entity/EntityStorageBase.php:522
/opt/drupal/web/core/lib/Drupal/Core/Config/Entity/ConfigEntityStorage.php:239
/opt/drupal/web/core/lib/Drupal/Core/Entity/EntityBase.php:370
/opt/drupal/web/core/lib/Drupal/Core/Config/Entity/ConfigEntityBase.php:635
/opt/drupal/web/core/lib/Drupal/Core/Config/ConfigInstaller.php:429
/opt/drupal/web/core/lib/Drupal/Core/Config/ConfigInstaller.php:175
/opt/drupal/web/core/lib/Drupal/Core/ProxyClass/Config/ConfigInstaller.php:75
/opt/drupal/web/core/lib/Drupal/Core/Extension/ModuleInstaller.php:448
/opt/drupal/web/core/lib/Drupal/Core/Extension/ModuleInstaller.php:229
/opt/drupal/web/core/lib/Drupal/Core/ProxyClass/Extension/ModuleInstaller.php:83
/opt/drupal/web/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php:511
/opt/drupal/web/core/tests/Drupal/Tests/BrowserTestBase.php:557
/opt/drupal/web/core/tests/Drupal/Tests/BrowserTestBase.php:349
/opt/repos/farmOS/modules/core/test/tests/src/Functional/FarmBrowserTestBase.php:35

ERRORS!
Tests: 1, Assertions: 0, Errors: 1, Deprecations: 11, PHPUnit Deprecations: 2.
```

The error occurs during `setUp()` of the functional test, so it doesn't have anything to do with the actual tests that are performed.

The simple fix is to add `container_rebuild_required: true` to `farm_ui_theme.info.yml`. This is a new feature provided by Drupal 11.3, explained in this change record: https://www.drupal.org/node/3473563

It seems to require a very specific combination of things... I spent a fair bit of time narrowing it down to the following pieces:

1. Drupal 11.3+
2. Gin theme, installed via `hook_install()` in `farm_ui_theme` module
3. A module that depends on `farm_format` with a role in `config/install`

We do not currently have a functional test in farmOS core that has both 2 and 3, so it went unnoticed when we updated to 11.3 (in https://github.com/farmOS/farmOS/commit/9be87eb929414f388b539d8efd1fcf89671c064a).

Notably, we also updated Gin from 5.0.3 to 5.0.10 around the same time (in https://github.com/farmOS/farmOS/commit/f8a33e86ecb349ea7ae8fc3c48f9f431c99485e7) - but downgrading back to 5.0.3 does not fix it - so while it is related to Gin it does not seem to be caused by a recent change in those versions. Downgrading Drupal back to 11.2.8 *does* fix it, however.

I tried replicating without `farm_ui_theme` - using Gin as the `$defaultTheme` in the functional test, but that didn't cause the error, so it may have something to do with the way we are installing Gin via `hook_install()` - which may also relate to why `container_rebuild_required: true` fixes it.

I also focused some testing on our `farm_format` module, and found that if I delete the `config/install/filter.format.default.yml` file then the test passes.

It's also interesting that this only happens when a module that is installed during the functional test setup includes a role config entity. The role doesn't have to have any dependencies or permissions in it - just installing a simple empty role causes the issue.

As far as I can tell this is only an issue with functional tests... I haven't encountered any issues actually using farmOS. So it seems that it only happens during functional test `setUp()`.

I couldn't find any open issues in Gin or Drupal core issue queues, but I did find the same error in this 2022 issue in the https://github.com/localgovdrupal/localgov_microsites_group project which was fixed without much explanation: https://github.com/localgovdrupal/localgov_microsites_group/issues/159

(Note: this PR renames our `FarmBlockTest` class to `FarmUiThemeTest` because I didn't think this was worth introducing another functional test for, so I just generalized the one we already have in `farm_ui_theme`.)