### PR TITLE
Always consider revision translations affected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ requirements (inherited from Drupal 11):
 - [Workers can only delete their own records #1033](https://github.com/farmOS/farmOS/pull/1033)
 - [Workers cannot update or delete taxonomy terms #1033](https://github.com/farmOS/farmOS/pull/1033)
 - [Allow birth quick form to create up to 20 children #1030](https://github.com/farmOS/farmOS/pull/1030)
+- [Always consider revision translations affected #1041](https://github.com/farmOS/farmOS/pull/1041)
 
 ### Deprecated
 

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -37,3 +37,22 @@ function farm_entity_post_update_install_farm_entity_access(&$sandbox) {
     \Drupal::service('module_installer')->install(['farm_entity_access']);
   }
 }
+
+/**
+ * Consider all existing revision translations affected.
+ */
+function farm_entity_post_update_revision_translations_affected(&$sandbox) {
+  $entity_types = [
+    'asset',
+    'log',
+    'organization',
+    'plan',
+    'quantity',
+  ];
+  foreach ($entity_types as $entity_type) {
+    if (\Drupal::moduleHandler()->moduleExists($entity_type)) {
+      \Drupal::database()->query('UPDATE {' . $entity_type . '_field_data} SET revision_translation_affected = 1');
+      \Drupal::database()->query('UPDATE {' . $entity_type . '_field_revision} SET revision_translation_affected = 1');
+    }
+  }
+}

--- a/modules/core/entity/src/Hook/EntityHooks.php
+++ b/modules/core/entity/src/Hook/EntityHooks.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Entity\RevisionableEntityBundleInterface;
+use Drupal\Core\Entity\TranslatableRevisionableInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Hook\Order\OrderBefore;
 use Drupal\Core\Session\AccountInterface;
@@ -126,6 +127,18 @@ class EntityHooks {
 
       // Always create a new revision.
       $entity->setNewRevision(TRUE);
+
+      // Always consider revision translations affected. Without this, if an
+      // entity is saved with a revision log message, but without any changes to
+      // the entity itself, then Drupal core will hide this revision from the
+      // list of revisions in the UI.
+      // @see \Drupal\Core\Entity\ContentEntityStorageBase::populateAffectedRevisionTranslations()
+      // @see \Drupal\Core\Entity\ContentEntityBase::hasTranslationChanges()
+      // @see https://www.drupal.org/project/drupal/issues/2722307
+      // @see https://www.drupal.org/project/drupal/issues/2933518
+      if ($entity instanceof TranslatableRevisionableInterface) {
+        $entity->setRevisionTranslationAffected(TRUE);
+      }
 
       // Set the user ID and creation time.
       $entity->setRevisionUserId($this->currentUser->id());

--- a/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
@@ -7,7 +7,7 @@ namespace Drupal\Tests\farm_entity\Functional;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 
 /**
- * Tests that entity revisions cannot be reverted.
+ * Test expected farmOS entity revision behavior.
  *
  * @group farm
  */
@@ -40,7 +40,7 @@ class FarmEntityRevisionsTest extends FarmBrowserTestBase {
   }
 
   /**
-   * Test that entity revisions cannot be reverted.
+   * Test expected farmOS entity revision behavior.
    */
   public function testFarmEntityRevisions() {
     $entity_types = [
@@ -50,19 +50,27 @@ class FarmEntityRevisionsTest extends FarmBrowserTestBase {
     ];
     foreach ($entity_types as $entity_type) {
       $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
+
+      // Create a test entity.
       /** @var \Drupal\Core\Entity\RevisionableInterface $entity */
       $entity = $storage->create([
         'name' => $this->randomMachineName(),
         'type' => 'test',
       ]);
       $entity->save();
+
+      // Create a second revision and remember both revision IDs.
       $first_revision_id = $entity->getRevisionId();
       $entity->setNewRevision();
       $entity->save();
       $second_revision_id = $entity->getRevisionId();
       $this->assertNotEquals($first_revision_id, $second_revision_id);
+
+      // Confirm that a /revisions tab is available.
       $this->drupalGet($entity_type . '/' . $entity->id() . '/revisions');
       $this->assertSession()->statusCodeEquals(200);
+
+      // Test that entity revisions cannot be reverted.
       $this->assertSession()->responseNotContains('Revert');
       $this->drupalGet($entity_type . '/' . $entity->id() . '/revisions/' . $first_revision_id . '/revert');
       $this->assertSession()->statusCodeEquals(404);

--- a/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
@@ -52,16 +52,18 @@ class FarmEntityRevisionsTest extends FarmBrowserTestBase {
       $storage = \Drupal::entityTypeManager()->getStorage($entity_type);
 
       // Create a test entity.
-      /** @var \Drupal\Core\Entity\RevisionableInterface $entity */
+      /** @var \Drupal\Core\Entity\RevisionLogInterface $entity */
       $entity = $storage->create([
         'name' => $this->randomMachineName(),
         'type' => 'test',
       ]);
+      $entity->setRevisionLogMessage('First revision log.');
       $entity->save();
 
       // Create a second revision and remember both revision IDs.
       $first_revision_id = $entity->getRevisionId();
       $entity->setNewRevision();
+      $entity->setRevisionLogMessage('Second revision log.');
       $entity->save();
       $second_revision_id = $entity->getRevisionId();
       $this->assertNotEquals($first_revision_id, $second_revision_id);
@@ -69,6 +71,10 @@ class FarmEntityRevisionsTest extends FarmBrowserTestBase {
       // Confirm that a /revisions tab is available.
       $this->drupalGet($entity_type . '/' . $entity->id() . '/revisions');
       $this->assertSession()->statusCodeEquals(200);
+
+      // Confirm that both revisions are shown in the /revisions tab.
+      $this->assertSession()->pageTextContains('First revision log');
+      $this->assertSession()->pageTextContains('Second revision log');
 
       // Test that entity revisions cannot be reverted.
       $this->assertSession()->responseNotContains('Revert');


### PR DESCRIPTION
I discovered a strange "bug" yesterday that I traced to some interesting Drupal core behavior that I was unaware of.

## Symptom

I was testing out some code in a custom module for saving revision log messages to a `plan` entity, and I noticed that they were not being displayed in the `/plan/%/revisions` tab. But they _were_ being saved to the database.

In this case, nothing else was changing on the `plan` entity. Instead, my custom module was performing an action related to the plan, and I wanted to save a revision log to the `plan` entity for traceability purposes. Specifically, I have a button for sending an email with documents attached to the plan, and I wanted to log that the email was sent. This revision log was properly saved to the `plan_revision` database table, but the revision was not showing up in the `/plan/%/revisions` UI tab.

## Root Cause

I traced this to the following condition in the [Entity API](https://www.drupal.org/project/entity) module's `RevisionControllerTrait`:

```php
if (!$translatable || ($revision->hasTranslation($langcode) && $revision->getTranslation($langcode)->isRevisionTranslationAffected())) {
```

https://git.drupalcode.org/project/entity/-/blob/276e51fc92ba8159b5e0783d07f671dfd75956b6/src/Controller/RevisionControllerTrait.php#L131

And specifically, it is because `$revision->getTranslation($langcode)->isRevisionTranslationAffected()` is returning `FALSE`. To put this into words, it thinks that the "translation of the entity that is being viewed is not affected by this revision", and therefore it does not show this revision in the UI.

As an aside, I want to note: we currently use the [Entity API](https://www.drupal.org/project/entity) contrib module to generate this UI tab, because originally Drupal core only added this to `node` entities. Recently a generic revisions UI was added to Drupal core (see change record: [Revision UI available to revisionable entities](https://www.drupal.org/node/3160443)), but we decided to hide that and continue using the Entity API version (see #772 and #773 for more details and reasoning). That is somewhat unrelated to the issue this PR is aiming to solve, though, because both Entity API and Drupal core have the same condition that leads to this issue. So regardless of whether we are using Entity API or Drupal core's revisions UI, this issue will occur.

In an effort to understand this "revision translation affected" logic/reasoning better, I found these two Drupal core issues:

- https://www.drupal.org/project/drupal/issues/2722307
- https://www.drupal.org/project/drupal/issues/2933518

The first actually describes the same issue we're having pretty closely:

> Revision overview screens (both Node and the generic revision UI) load revisions via a database query and then contain additional conditions to only show revisions where `isRevisionTranslationAffected` returns TRUE.
> 
> This presents a number of issues such as hiding the real "current" revision when that flag is NULL, or in some cases showing a completely empty revisions page because the database query returns 50 revisions that are all marked as un-affected (see related issues).

And the second provided some insight into the "internal" `revision_translation_affected` field that is at the core of the issue:

> The case of `revision_translation_affected` is slightly different: it is populated automatically by the system, but only if a value is not explicitly set by the API consumer. Hence it's a regular field, which users may find it useful to read and write: for this reason I'm not sure it's correct to mark it as internal. I was hoping that the [documentation](http://cgit.drupalcode.org/drupal/tree/core/lib/Drupal/Core/Entity/entity.api.php#n102) we added lately was enough to clarify the meaning of this field.

(from comment: https://www.drupal.org/project/drupal/issues/2933518#comment-12420954)

Here is the bit of documentation linked to from that comment:

> ```
>  * An entity that is both revisionable and translatable has all the features
>  * described above: every revision can contain one or more translations. The
>  * canonical variant of the entity is the default translation of the default
>  * revision. Any revision will be initially loaded as the default translation,
>  * the other revision translations can be instantiated from this one. If a
>  * translation has changes in a certain revision, the translation is considered
>  * "affected" by that revision, and will be flagged as such via the
>  * "revision_translation_affected" field. With the built-in UI, every time a new
>  * revision is saved, the changes for the edited translations will be stored,
>  * while all field values for the other translations will be copied as-is.
>  * However, if multiple translations of the default revision are being
>  * subsequently modified without creating a new revision when saving, they will
>  * all be affected by the default revision. Additionally, all revision
>  * translations will be affected when saving a revision containing changes for
>  * untranslatable fields. On the other hand, pending revisions are not supposed
>  * to contain multiple affected translations, even when they are being
>  * manipulated via the API.
>  * @see \Drupal\Core\Entity\TranslatableRevisionableInterface
>  * @see \Drupal\Core\Entity\TranslatableRevisionableStorageInterface
> ```

(permalink: https://git.drupalcode.org/project/drupal/-/blob/ab5a470b20f019119c512023e61da013507e4df7/core/lib/Drupal/Core/Entity/entity.api.php#L102-120)

This led me to find the `revision_translated_affected` column of the `plan_field_revision` and `plan_field_data` tables (as well as the equivalent tables for `asset` and `log` entity types).

And sure enough... the value of that column is `null` for all of the revisions that are missing from the `/plan/%/revisions` ta in the UI. Revisions that do appear in the UI have a value of `1`.

This value gets set internally by Drupal core in `\Drupal\Core\Entity\ContentEntityStorageBase::populateAffectedRevisionTranslations()`, which calls `\Drupal\Core\Entity\ContentEntityBase::hasTranslationChanges()`:

https://git.drupalcode.org/project/drupal/-/blob/9644cf01c909d95394d6bdc0e2d00c2c1334c69a/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php#L1176-1177

`ContentEntityBase::hasTranslationChanges()` essentially checks each field against the original (pre-save) value, and any of the translatable fields have changed, then it considers the "revision translation to be affected", and saves `1` to the database column.

https://git.drupalcode.org/project/drupal/-/blob/9644cf01c909d95394d6bdc0e2d00c2c1334c69a/core/lib/Drupal/Core/Entity/ContentEntityBase.php#L1507

In the case of my plan entities, no fields were changing, so they ended up with a `null` value in the `revision_translated_affected` column.

## Proposed Solution

I propose we explicitly set `$entity->setRevisionTranslationAffected(TRUE);` in our implementation of `hook_entity_presave()`, where we are already explicitly setting `$entity->setNewRevision(TRUE);` to enforce the creation of new revisions whenever an entity is saved. This will ensure that the `revision_translated_affected` field is always set to `1` in the database.

I also propose that we run an `UPDATE` SQL query to change all existing values that are `null` to `1`. This will reveal any hidden revisions that were affected by this in the past.

## Reasoning

In farmOS, we want good (complete) records, and revisions are an important piece of that. This is why we enforce creation of revisions whenever an entity is saved. This provides visibility into who made changes and when, optionally with a revision log message. And in some cases (like `plan` entities) revisions can be used to create a record of actions taken that update _related_ entities, or don't update _any_ entities, including the original `plan` entity.

In parallel to this, we support _interface_ and _config_ translation (via the `farm_l10n` module), but we do not have plans to support _content_ translations. Content translation is relevant to other Drupal use-cases, like managing a website with content (eg: pages) that is translated into multiple languages, and changes over time (revisions).

My understanding of the motivation behind the `revision_translated_affected` field in Drupal core is that it is used to selectively show revisions that only pertain to specific _content_ translations in the UI. However, it seems that this logic is both irrelevant and broken in our use case.

So, I think it's safe for us to "always consider revision translations affected".