### PR TITLE
Fix errors during update from 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ requirements (inherited from Drupal 11):
 - [Do not allow entity revisions to be reverted #1004](https://github.com/farmOS/farmOS/pull/1004)
 - [Fix dashboard block access checking #1031](https://github.com/farmOS/farmOS/pull/1031)
 - [Fix page for adding quick form instances #1017](https://github.com/farmOS/farmOS/pull/1017)
+- [Fix errors during update from 3.x #1042](https://github.com/farmOS/farmOS/pull/1042)
 
 ## farmOS 3.x
 

--- a/modules/core/entity/farm_entity.install
+++ b/modules/core/entity/farm_entity.install
@@ -26,3 +26,12 @@ function farm_entity_install() {
   ];
   \Drupal::configFactory()->getEditable('entity_reference_integrity_enforce.settings')->set('enabled_entity_type_ids', array_combine($enforced_entity_types, $enforced_entity_types))->save();
 }
+
+/**
+ * Install the farm_entity_access module.
+ */
+function farm_entity_update_11400() {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_entity_access')) {
+    \Drupal::service('module_installer')->install(['farm_entity_access']);
+  }
+}

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -30,15 +30,6 @@ function farm_entity_post_update_enforce_organization_eri(&$sandbox) {
 }
 
 /**
- * Install the farm_entity_access module.
- */
-function farm_entity_post_update_install_farm_entity_access(&$sandbox) {
-  if (!\Drupal::service('module_handler')->moduleExists('farm_entity_access')) {
-    \Drupal::service('module_installer')->install(['farm_entity_access']);
-  }
-}
-
-/**
  * Consider all existing revision translations affected.
  */
 function farm_entity_post_update_revision_translations_affected(&$sandbox) {

--- a/modules/core/quick/farm_quick.install
+++ b/modules/core/quick/farm_quick.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Post update functions for farm_ui_theme module.
+ * Install, update and uninstall functions for the farm_quick module.
  */
 
 declare(strict_types=1);
@@ -10,7 +10,7 @@ declare(strict_types=1);
 /**
  * Install the farm_form module.
  */
-function farm_ui_theme_post_update_install_farm_form(&$sandbox = NULL) {
+function farm_quick_update_11400() {
   if (!\Drupal::service('module_handler')->moduleExists('farm_form')) {
     \Drupal::service('module_installer')->install(['farm_form']);
   }

--- a/modules/core/quick/farm_quick.post_update.php
+++ b/modules/core/quick/farm_quick.post_update.php
@@ -8,15 +8,6 @@
 declare(strict_types=1);
 
 /**
- * Install the farm_form module.
- */
-function farm_quick_post_update_install_farm_form(&$sandbox = NULL) {
-  if (!\Drupal::service('module_handler')->moduleExists('farm_form')) {
-    \Drupal::service('module_installer')->install(['farm_form']);
-  }
-}
-
-/**
  * Implements hook_removed_post_updates().
  */
 function farm_quick_removed_post_updates() {

--- a/modules/core/ui/theme/farm_ui_theme.install
+++ b/modules/core/ui/theme/farm_ui_theme.install
@@ -69,6 +69,15 @@ function farm_ui_theme_install() {
 }
 
 /**
+ * Install the farm_form module.
+ */
+function farm_ui_theme_update_11400() {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_form')) {
+    \Drupal::service('module_installer')->install(['farm_form']);
+  }
+}
+
+/**
  * Implements hook_update_last_removed().
  */
 function farm_ui_theme_update_last_removed() {


### PR DESCRIPTION
I ran into two errors while I was testing the update path from farmOS 3.5.1 to 4.x:

```bash
$ ./drush updb
 -------- ----------- --------------- ---------------------------------------------- 
  Module   Update ID   Type            Description                                   
 -------- ----------- --------------- ---------------------------------------------- 
  sys      11001       hook_update_n   11001 - Update length of menu_tree fields     
  tem                                  url and route_param_key from 255 to 2048.     
  sys      11100       hook_update_n   11100 - Invalidate container because the      
  tem                                  module handler has changed.                   
  sys      11102       hook_update_n   11102 - Equivalent update to 10400.           
  tem                                                                                
  sys      11200       hook_update_n   11200 - Add a [time] column to the            
  tem                                  {simpletest} table, if existing.              
  sys      11201       hook_update_n   11201 - Add the [alias] field to the          
  tem                                  {router} table.                               
  sys      11202       hook_update_n   11202 - Add an [exit_code] column to the      
  tem                                  {simpletest} table, if existing.              
  sys      11300       hook_update_n   11300 - Equivalent update to 10600.           
  tem                                                                                
  con      8112        hook_update_n   8112 - Fix Consumer entity definition         
  sum                                  mismatch.                                     
  ers                                                                                
  vie      11201       hook_update_n   11201 - Removes the ui.show.advanced_column   
  ws                                   setting.                                      
  ass      remove_     post-update     Remove the asset_admin View.                  
  et       admin_v                                                                   
           iew                                                                       
  ass      remove_     post-update     Remove the asset status field.                
  et       status                                                                    
  blo      make_we     post-update     Ensures that all block weights are integers.  
  ck       ight_in                                                                   
           teger                                                                     
  blo      set_men     post-update     Updates the `depth` setting to NULL if it is  
  ck       u_block                     0 in any menu blocks.                         
           _depth_                                                                   
           to_null                                                                   
           _if_zer                                                                   
           o                                                                         
  far      rename_     post-update     Rename is_castrated to is_sterile on Animal   
  m_a      is_cast                     assets.                                       
  nim      rated_i                                                                   
  al       s_steri                                                                   
           le                                                                        
  far      split_o     post-update     Install the farm_api_oauth module.            
  m_a      auth_mo                                                                   
  pi       dule                                                                      
  far      enforce     post-update     Enforce entity reference integrity on         
  m_e      _organi                     organization reference fields.                
  nti      zation_                                                                   
  ty       eri                                                                       
  far      install     post-update     Install the farm_entity_access module.        
  m_e      _farm_e                                                                   
  nti      ntity_a                                                                   
  ty       ccess                                                                     
  far      revisio     post-update     Consider all existing revision translations   
  m_e      n_trans                     affected.                                     
  nti      lations                                                                   
  ty       _affect                                                                   
           ed                                                                        
  far      add_pla     post-update     Add owner field to plans.                     
  m_o      n_owner                                                                   
  wne                                                                                
  r                                                                                  
  far      install     post-update     Install the farm_form module.                 
  m_q      _farm_f                                                                   
  uic      orm                                                                       
  k                                                                                  
  far      move_mo     post-update     Move farm_account_admin role module and       
  m_r      dule                        grant farm_config_admin role.                 
  ole                                                                                
  _ac                                                                                
  cou                                                                                
  nt_                                                                                
  adm                                                                                
  in                                                                                 
  far      split_m     post-update     Split farm_role_roles module into             
  m_r      odule                       farm_manager, farm_worker, farm_viewer.       
  ole                                                                                
  _ro                                                                                
  les                                                                                
  far      install     post-update     Install the farm_ui_term module.              
  m_u      _farm_u                                                                   
  i        i_term                                                                    
  far      install     post-update     Install the farm_form module.                 
  m_u      _farm_f                                                                   
  i_t      orm                                                                       
  hem                                                                                
  e                                                                                  
  far      remove_     post-update     Remove farm_update.settings.excluded_config.  
  m_u      exclude                                                                   
  pda      d_confi                                                                   
  te       g                                                                         
  fil      add_pla     post-update     Adds a value for the 'playsinline' setting    
  e        ysinlin                     of the 'file_video' formatter.   @deprecated  
           e                           in drupal:12.3.0 and is removed from          
                                       drupal:13.0.0. This was    rolled back due    
                                       to a bug in the implementation and is now a   
                                       no-op function    and is kept only to         
                                       prevent errors when updating.   @see          
                                       https:www.drupal.orgprojectdrupalissues35332  
                                       91                                            
  pat      update_     post-update     Update the path_alias_revision indices.       
  h_a      path_al                                                                   
  lia      ias_rev                                                                   
  s        ision_i                                                                   
           ndexes                                                                    
  pla      move_ar     post-update     Move archived plan status to boolean field.   
  n        chived_                                                                   
           status                                                                    
  pla      remove_     post-update     Remove the plan_admin View.                   
  n        admin_v                                                                   
           iew                                                                       
  sys      convert     post-update     Updates entity_form_mode descriptions from    
  tem      _empty_                     empty string to null.                         
           descrip                                                                   
           tion_en                                                                   
           tity_fo                                                                   
           rm_mode                                                                   
           s_to_nu                                                                   
           ll                                                                        
  sys      delete_     post-update     Delete obsolete system.rss configuration.     
  tem      rss_con                                                                   
           fig                                                                       
  sys      remove_     post-update     Remove path key in system.file.               
  tem      path_ke                                                                   
           y                                                                         
  sys      remove_     post-update     Rebuild the container to fix HTML in RSS      
  tem      rss_cda                     feeds.                                        
           ta_subs                                                                   
           criber                                                                    
  sys      sdc_uni     post-update     Uninstall the sdc module if installed.        
  tem      nstall                                                                    
  upd      clear_d     post-update     Removes the legacy 'Update Manager' disk      
  ate      isk_cac                     cache.                                        
           he                                                                        
  upd      fix_upd     post-update     Remove empty email addresses from             
  ate      ate_ema                     update.settings configuration.                
           ils                                                                       
  vie      add_dat     post-update     Clear cache to add new date default           
  ws       e_defau                     arguments.                                    
           lt_argu                                                                   
           ments                                                                     
  vie      block_i     post-update     Defaults `items_per_page` to NULL in Views    
  ws       tems_pe                     blocks.                                       
           r_page                                                                    
  vie      format_     post-update     Updates the format plural option for those    
  ws       plural                      views using aggregation.                      
  vie      table_c     post-update     Adds a default table CSS class.               
  ws       ss_clas                                                                   
           s                                                                         
  vie      update_     post-update     Clean-up empty remember_roles display         
  ws       remembe                     settings for views filters.                   
           r_role_                                                                   
           empty                                                                     
 -------- ----------- --------------- ---------------------------------------------- 


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ Yes                                                          │
 └──────────────────────────────────────────────────────────────┘

>  [notice] Update started: system_update_11001
>  [notice] Update completed: system_update_11001
>  [notice] Update started: system_update_11100
>  [notice] Update completed: system_update_11100
>  [notice] Update 11102 for the system module has been skipped because the equivalent change was already made in update 10400.
>  [notice] Update completed: system_update_11102
>  [notice] Update started: system_update_11200
>  [notice] Update completed: system_update_11200
>  [notice] Update started: system_update_11201
>  [notice] Update completed: system_update_11201
>  [notice] Update started: system_update_11202
>  [notice] Update completed: system_update_11202
>  [notice] Update 11300 for the system module has been skipped because the equivalent change was already made in update 10600.
>  [notice] Update completed: system_update_11300
>  [notice] Update started: consumers_update_8112
>  [notice] Consumer entity definition refreshed and status field synchronized.
>  [notice] Update completed: consumers_update_8112
>  [notice] Update started: views_update_11201
>  [notice] Update completed: views_update_11201
>  [notice] Reverted config: views.view.data_stream_basic_data
> 
> In DiscoveryTrait.php line 53:
>                                                                                
>   The "farm_entity_collection" plugin does not exist. Valid plugin IDs for Dr  
>   upal\views\Plugin\ViewsPluginManager are: perm, role, none                   
>                                                                                
> 

In ProcessBase.php line 171:
                                                                                                                                                     
  Unable to decode output into JSON: Syntax error                                                                                                    
                                                                                                                                                     
  Fatal error: Trait "Drupal\farm_form\Traits\FarmFormProtectionTrait" not found in /opt/repos/farmOS/modules/core/ui/theme/src/Form/GinContentForm  
  Base.php on line 25
```

In both of these errors, the issue is that some new `farm_*` modules have not been installed yet (specifically `farm_entity_access` and `farm_form`).

We have implementations of `hook_post_update_NAME()` to install the modules, but the problem is that the caches are being rebuilt after `hook_update_N()` implementations are run, and before `hook_post_update_NAME()` implementations are run. So it ends up looking for the new module code before it's available.

The solution is pretty simple: we can just convert our relevant `hook_post_update_NAME()` implementations to `hook_update_N()`.

I think it's safe to just remove the `hook_post_update_NAME()` implementations - even if there are 4.x deployments who have run them. The logic checks to see if the modules are already installed before trying to install them.

This wasn't caught in testing because the updates were being added incrementally in my development environment, and the issue only occurs during a full update from 3.x, which has `hook_update_N()` implementations from Drupal core and contrib modules.