### PR TITLE
Update drupal/simple_oauth patch for Issue #3573262

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0-beta2] 2026-02-12
+
+### Changed
+
+- Update `drupal/simple_oauth` patch for [Issue #3573262: Calculated permissions have a cache max age of 0](https://www.drupal.org/project/simple_oauth/issues/3573262) [#1044](https://github.com/farmOS/farmOS/pull/1044)
+
 ## [4.0.0-beta1] 2026-02-11
 
 This is the first release of the farmOS 4.x branch, following
@@ -156,5 +162,6 @@ farmOS 2.x release notes are available in the 2.x branch's
 farmOS 1.x release notes are available in the
 [farmOS releases on Drupal.org](https://www.drupal.org/project/farm/releases?version=7.x-1).
 
-[Unreleased]: https://github.com/farmOS/farmOS/compare/4.0.0-beta1...4.x
+[Unreleased]: https://github.com/farmOS/farmOS/compare/4.0.0-beta2...4.x
+[4.0.0-beta2]: https://github.com/farmOS/farmOS/releases/tag/4.0.0-beta2
 [4.0.0-beta1]: https://github.com/farmOS/farmOS/releases/tag/4.0.0-beta1

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
                 "Issue #3342164: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch"
             },
             "drupal/simple_oauth": {
-                "Issue #3572695: Use AccessPolicyInterface::calculatePermissions() instead of AccessPolicyInterface::alterPermissions()": "https://git.drupalcode.org/issue/simple_oauth-3572695/-/commit/53a2cecab69c98216ab8c4f154f9392ffc1959a2.patch"
+                "Issue #3573262: Calculated permissions have a cache max age of 0": "https://git.drupalcode.org/project/simple_oauth/-/commit/11081aa8e80cc1c6eb91dbfc03eb32c3e5622297.patch"
             },
             "drupal/subrequests": {
                 "Issue #3524429: PHP 8.4 deprecation: Implicitly marking parameter as nullable": "https://git.drupalcode.org/issue/subrequests-3524429/-/commit/784ccfe8af7d803f392263d2dbf7dcd89f9566d5.patch"


### PR DESCRIPTION
This is a follow-up to #1028, which introduced a patch to `drupal/simple_oauth` to fix [Issue #3572695: Use AccessPolicyInterface::calculatePermissions() instead of AccessPolicyInterface::alterPermissions()](https://www.drupal.org/node/3572695)(https://www.drupal.org/node/3572695).

In discussion with the maintainers of `drupal/simple_oauth`, it became clear that this patch is not the correct solution, and may cause other issues.

I discovered (what I think) is the deeper root cause, and opened a new upstream merge request for it in [Issue #3573262: Calculated permissions have a cache max age of 0](https://www.drupal.org/project/simple_oauth/issues/3573262), so this pull request updates farmOS to use that patch instead.