### PR TITLE
Change comment form "Save" button to "Save comment"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Change comment form "Save" button to "Save comment" #1046](https://github.com/farmOS/farmOS/pull/1046)
+
 ## [4.0.0-beta2] 2026-02-12
 
 ### Changed

--- a/modules/core/comment/src/Hook/FormHooks.php
+++ b/modules/core/comment/src/Hook/FormHooks.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_comment\Hook;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Form hook implementations for farm_comment.
+ */
+class FormHooks {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_form_BASE_FORM_ID_alter().
+   */
+  #[Hook('form_comment_form_alter')]
+  public function formCommentFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+
+    // Change "Save" button to "Save comment".
+    if (!empty($form['actions']['submit']['#value'])) {
+      $form['actions']['submit']['#value'] = $this->t('Save comment');
+    }
+  }
+
+}


### PR DESCRIPTION
This is a simple change to a button name to prevent confusion. This originated in the `farm_rcd` add-on module here: See: https://github.com/farmier/farm_rcd/issues/140

Rght now we provide modules for enabling comments on `asset`, `log`, and `plan` entities. These add the Drupal core comment form at the bottom of the entity view display. For example:

<img width="832" height="508" alt="Screenshot from 2026-02-14 16-06-16" src="https://github.com/user-attachments/assets/31bfa627-4046-42cc-b479-070214443557" />

The submit button is labeled "Save" by default. This is a bit confusing/misleading, when this form appears at the bottom of an entity that has other forms embedded in it, which is sometimes the case with plans. The user may think that they are saving the plan itself, and that a comment is required, when in reality it's a separate form that is only for adding comments.

It was proposed in https://github.com/farmier/farm_rcd/issues/140 that we simply change "Save" to "Save comment" to make that explicit. For example:

<img width="787" height="494" alt="Screenshot from 2026-02-14 16-06-29" src="https://github.com/user-attachments/assets/90df780e-85f5-4bdf-9298-38dc572f4c4f" />