### PR TITLE
Clear access_policy cache when modules are installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Fix missing action links on entity collection pages #1050](https://github.com/farmOS/farmOS/pull/1050)
 - [Fix asset and plan update hooks for prefixed database tables #1051](https://github.com/farmOS/farmOS/pull/1051)
 - [Validate entity bundle in asset/log/etc page_type display logic #1048](https://github.com/farmOS/farmOS/pull/1048)
+- [Clear access_policy cache when modules are installed #1049](https://github.com/farmOS/farmOS/pull/1049)
 
 ## [4.0.0-beta2] 2026-02-12
 

--- a/modules/core/role/src/Hook/ModuleHooks.php
+++ b/modules/core/role/src/Hook/ModuleHooks.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_role\Hook;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+/**
+ * Module hook implementations for farm_role.
+ */
+class ModuleHooks {
+
+  public function __construct(
+    #[Autowire(service: 'cache.access_policy')]
+    protected CacheBackendInterface $accessPolicyCache,
+  ) {}
+
+  /**
+   * Implements hook_modules_installed().
+   */
+  #[Hook('modules_installed')]
+  public function modulesInstalled($modules, $is_syncing) {
+
+    // Clear the access_policy cache when modules are installed, so that our
+    // managed role access policy rules get refreshed.
+    $this->accessPolicyCache->deleteAll();
+  }
+
+}


### PR DESCRIPTION
I noticed a bug with the farmOS module installation forms (both the original `/setup/modules` form and the new `/setup/wizard/modules` form). After installing a quick form module, the "Quick forms" menu item does not show, and going to `/quick` results in a 403 access denied.

Rebuilding the cache fixes the problem.

Steps to reproduce:

1. Install farmOS.
2. In the setup wizard modules installation step (or in `/setup/modules`) install the Planting quick form module.
3. Notice that "Quick forms" does not appear in the main menu.
4. Run `drush cr` and notice that "Quick forms" is added to the menu.

I'm not sure if this has been an issue all along in 3.x, and why it went unnoticed. Maybe it is related to the fact that we no longer install "default" modules (#1034) during initial farmOS installation, and now leave most modules to be installed by the user afterwards (#1035).

I'm also not sure if there is a more targeted fix (eg: only rebuilding the router information), or if rebuilding the entire cache is necessary (for this an other things).

I added a test that demonstrates the problem, and a simple `FarmModulesForm::finishInstallModulesBatch()` callback that runs `drupal_flush_all_caches()` after the module installation batch operations finish.

Worth noting: the only other place we run `drupal_flush_all_caches()` (outside of tests) is when the Mapbox / Google Maps settings forms are submitted (for saving API keys). We found that was necessary in order for the API keys to take effect. Maybe there is a more targeted fix for that as well, and digging deeper into both cases would be worthwhile as a follow-up step as a refinement.

Also worth noting: we might also want to follow-up on the relationship between `FarmSetupBlockForm::finishInstallModulesBatch()` and `FarmModulesForm::finishInstallModulesBatch()`. Before this PR, the former was only used to reset the setup wizard block plugin ID to ensure that newly installed modules have a chance to insert their setup wizard steps into the process. After this PR, the former also calls the latter, to ensure caches are rebuilt. Maybe there's a better way to organize these things, but I didn't want to get too bogged down in that, so this PR is focused on fixing the bug first.