### PR TITLE
Fix missing action links on entity collection pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Change comment form "Save" button to "Save comment" #1046](https://github.com/farmOS/farmOS/pull/1046)
 
+### Fixed
+
+- [Fix missing action links on entity collection pages #1050](https://github.com/farmOS/farmOS/pull/1050)
+
 ## [4.0.0-beta2] 2026-02-12
 
 ### Changed

--- a/modules/core/asset/asset.links.action.yml
+++ b/modules/core/asset/asset.links.action.yml
@@ -1,3 +1,9 @@
+entity.asset.add_page:
+  route_name: 'entity.asset.add_page'
+  title: 'Add Asset'
+  appears_on:
+    - entity.asset.collection
+
 entity.asset_type.add_form:
   route_name: 'entity.asset_type.add_form'
   title: 'Add asset type'

--- a/modules/core/organization/organization.links.action.yml
+++ b/modules/core/organization/organization.links.action.yml
@@ -1,3 +1,9 @@
+entity.organization.add_page:
+  route_name: 'entity.organization.add_page'
+  title: 'Add Organization'
+  appears_on:
+    - entity.organization.collection
+
 entity.organization_type.add_form:
   route_name: 'entity.organization_type.add_form'
   title: 'Add organization type'

--- a/modules/core/plan/plan.links.action.yml
+++ b/modules/core/plan/plan.links.action.yml
@@ -1,3 +1,9 @@
+entity.plan.add_page:
+  route_name: 'entity.plan.add_page'
+  title: 'Add Plan'
+  appears_on:
+    - entity.plan.collection
+
 entity.plan_type.add_form:
   route_name: 'entity.plan_type.add_form'
   title: 'Add plan type'

--- a/modules/core/ui/action/src/Hook/MenuHooks.php
+++ b/modules/core/ui/action/src/Hook/MenuHooks.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_action\Hook;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Menu hook implementations for farm_ui_action.
+ */
+class MenuHooks {
+
+  use AutowireTrait;
+
+  public function __construct(
+    protected ModuleHandlerInterface $moduleHandler,
+  ) {}
+
+  /**
+   * Implements hook_menu_local_actions_alter().
+   */
+  #[Hook('menu_local_actions_alter')]
+  public function menuLocalActionsAlter(array &$local_actions) {
+    $entity_types = [
+      'asset',
+      'log',
+      'organization',
+      'plan',
+    ];
+    foreach ($entity_types as $entity_type) {
+
+      // Alter the "Add [entity_type]" action links, if available.
+      // These are provided by their respective entity type modules.
+      $action_key = 'entity.' . $entity_type . '.add_page';
+      if (array_key_exists($action_key, $local_actions)) {
+
+        // Show the action link on the farmOS dashboard, if available.
+        if ($this->moduleHandler->moduleExists('farm_ui_dashboard')) {
+          $local_actions[$action_key]['appears_on'][] = 'farm.dashboard';
+        }
+
+        // Show the "Add Log" action link on /user/%/logs, if available.
+        if ($entity_type == 'log' && $this->moduleHandler->moduleExists('farm_ui_views')) {
+          $local_actions[$action_key]['appears_on'][] = 'view.farm_log.page_user';
+        }
+      }
+    }
+  }
+
+}

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -101,7 +101,7 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
         $this->derivatives[$name]['bundle_parameter'] = 'arg_0';
       }
 
-      // Generate links to [entity-type]/add/[bundle]?asset=[id] on asset pages.
+      // Generate links to /log/add/[bundle]?asset=[id] on asset pages.
       if ($type == 'log') {
         $bundles = $this->entityTypeBundleInfo->getBundleInfo('log');
         foreach ($bundles as $bundle => $bundle_info) {

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\farm_ui_action\Plugin\Menu\LocalAction\AddEntity;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -88,7 +89,7 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
       $name = 'farm.add.' . $type . '.bundle';
       $this->derivatives[$name] = $base_plugin_definition;
       $this->derivatives[$name]['route_name'] = 'entity.' . $type . '.add_form';
-      $this->derivatives[$name]['class'] = 'Drupal\farm_ui_action\Plugin\Menu\LocalAction\AddEntity';
+      $this->derivatives[$name]['class'] = AddEntity::class;
       $this->derivatives[$name]['entity_type'] = $type;
 
       // Add the entity_bundles cache tag so action links are recreated after
@@ -108,7 +109,7 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
           $name = 'farm.asset.add.' . $type . '.' . $bundle;
           $this->derivatives[$name] = $base_plugin_definition;
           $this->derivatives[$name]['route_name'] = 'entity.' . $type . '.add_form';
-          $this->derivatives[$name]['class'] = 'Drupal\farm_ui_action\Plugin\Menu\LocalAction\AddEntity';
+          $this->derivatives[$name]['class'] = AddEntity::class;
           $this->derivatives[$name]['entity_type'] = $type;
           $this->derivatives[$name]['bundle'] = $bundle;
           $this->derivatives[$name]['appears_on'][] = 'entity.asset.canonical';

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -63,27 +63,6 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
         continue;
       }
 
-      // Generate a link to [entity-type]/add.
-      $name = 'farm.add.' . $type;
-      $entity_type_label = $this->entityTypeManager->getStorage($type)->getEntityType()->getLabel();
-      $this->derivatives[$name] = $base_plugin_definition;
-      $this->derivatives[$name]['title'] = $this->t('Add :entity_type', [':entity_type' => $entity_type_label]);
-      $this->derivatives[$name]['route_name'] = 'entity.' . $type . '.add_page';
-
-      // Add it to entity Views, if the farm_ui_views module is enabled.
-      if ($this->moduleHandler->moduleExists('farm_ui_views')) {
-
-        // If this is a log, also add it to view.farm_log.page_user.
-        if ($type == 'log') {
-          $this->derivatives[$name]['appears_on'][] = 'view.farm_log.page_user';
-        }
-      }
-
-      // Add it to farm.dashboard, if the farm_ui_dashboard module is enabled.
-      if ($this->moduleHandler->moduleExists('farm_ui_dashboard')) {
-        $this->derivatives[$name]['appears_on'][] = 'farm.dashboard';
-      }
-
       // Generate a link to [entity-type]/add/[bundle].
       $name = 'farm.add.' . $type . '.bundle';
       $this->derivatives[$name] = $base_plugin_definition;

--- a/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
+++ b/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php
@@ -72,7 +72,6 @@ class FarmActions extends DeriverBase implements ContainerDeriverInterface {
 
       // Add it to entity Views, if the farm_ui_views module is enabled.
       if ($this->moduleHandler->moduleExists('farm_ui_views')) {
-        $this->derivatives[$name]['appears_on'][] = 'view.farm_' . $type . '.page';
 
         // If this is a log, also add it to view.farm_log.page_user.
         if ($type == 'log') {

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/asset.type.test.yml
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/asset.type.test.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: test
+label: Test
+description: ''
+new_revision: true

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/log.type.test.yml
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/log.type.test.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: test
+label: Test
+description: ''
+name_pattern: 'Test log [log:id]'
+workflow: log_default
+new_revision: true

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/organization.type.test.yml
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/organization.type.test.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: test
+label: Test
+description: ''
+new_revision: true

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/plan.type.test.yml
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/config/install/plan.type.test.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: test
+label: Test
+description: ''
+name_pattern: 'Test plan [plan:id]'
+workflow: plan_default
+new_revision: true

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/farm_ui_action_test.info.yml
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/farm_ui_action_test.info.yml
@@ -1,0 +1,10 @@
+name: farmOS UI Action Test
+description: Module for testing farmOS UI Action.
+type: module
+package: Testing
+core_version_requirement: ^11
+dependencies:
+  - farm:asset
+  - farm:organization
+  - farm:plan
+  - log:log

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Asset/AssetType/TestAsset.php
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Asset/AssetType/TestAsset.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_action_test\Plugin\Asset\AssetType;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\AssetType;
+use Drupal\farm_entity\Plugin\Asset\AssetType\FarmAssetType;
+
+/**
+ * Provides the test asset type.
+ */
+#[AssetType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
+class TestAsset extends FarmAssetType {
+
+}

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Log/LogType/TestLog.php
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Log/LogType/TestLog.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_action_test\Plugin\Log\LogType;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\LogType;
+use Drupal\farm_entity\Plugin\Log\LogType\FarmLogType;
+
+/**
+ * Provides the test log type.
+ */
+#[LogType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
+class TestLog extends FarmLogType {
+
+}

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Organization/OrganizationType/TestOrganization.php
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Organization/OrganizationType/TestOrganization.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_action_test\Plugin\Organization\OrganizationType;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\OrganizationType;
+use Drupal\farm_entity\Plugin\Organization\OrganizationType\FarmOrganizationType;
+
+/**
+ * Provides the test organization type.
+ */
+#[OrganizationType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
+class TestOrganization extends FarmOrganizationType {
+
+}

--- a/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Plan/PlanType/TestPlan.php
+++ b/modules/core/ui/action/tests/modules/farm_ui_action_test/src/Plugin/Plan/PlanType/TestPlan.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_action_test\Plugin\Plan\PlanType;
+
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\farm_entity\Attribute\PlanType;
+use Drupal\farm_entity\Plugin\Plan\PlanType\FarmPlanType;
+
+/**
+ * Provides the test plan type.
+ */
+#[PlanType(
+  id: 'test',
+  label: new TranslatableMarkup('Test'),
+)]
+class TestPlan extends FarmPlanType {
+
+}

--- a/modules/core/ui/action/tests/src/Functional/ActionsTest.php
+++ b/modules/core/ui/action/tests/src/Functional/ActionsTest.php
@@ -68,43 +68,43 @@ class ActionsTest extends FarmBrowserTestBase {
     // Test dashboard buttons.
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Asset');
-    $this->assertSession()->linkExists('Add Log');
-    $this->assertSession()->linkExists('Add Organization');
-    $this->assertSession()->linkExists('Add Plan');
+    $this->assertActionLinkExists('Add Asset', '/asset/add');
+    $this->assertActionLinkExists('Add Log', '/log/add');
+    $this->assertActionLinkExists('Add Organization', '/organization/add');
+    $this->assertActionLinkExists('Add Plan', '/plan/add');
 
     // Test entity lists.
     $this->drupalGet('/assets');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Asset');
+    $this->assertActionLinkExists('Add Asset', '/asset/add');
     $this->drupalGet('/logs');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Log');
+    $this->assertActionLinkExists('Add Log', '/log/add');
     $this->drupalGet('/organizations');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Organization');
+    $this->assertActionLinkExists('Add Organization', '/organization/add');
     $this->drupalGet('/plans');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Plan');
+    $this->assertActionLinkExists('Add Plan', '/plan/add');
 
     // Test per-bundle entity lists.
     $this->drupalGet('/assets/test');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Asset: Test');
+    $this->assertActionLinkExists('Add Asset: Test', '/asset/add/test');
     $this->drupalGet('/logs/test');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Log: Test');
+    $this->assertActionLinkExists('Add Log: Test', '/log/add/test');
     $this->drupalGet('/organizations/test');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Organization: Test');
+    $this->assertActionLinkExists('Add Organization: Test', '/organization/add/test');
     $this->drupalGet('/plans/test');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Plan: Test');
+    $this->assertActionLinkExists('Add Plan: Test', '/plan/add/test');
 
     // Test /user/%uid/logs.
     $this->drupalGet('/user/' . $this->user->id() . '/logs');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Log');
+    $this->assertActionLinkExists('Add Log', '/log/add');
 
     // Test links to /log/add/[bundle]?asset=[id] on asset pages.
     /** @var \Drupal\asset\Entity\AssetInterface $asset */
@@ -121,13 +121,26 @@ class ActionsTest extends FarmBrowserTestBase {
     $log->save();
     $this->drupalGet('/asset/' . $asset->id());
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Log: Test');
+    $this->assertActionLinkExists('Add Log: Test', '/log/add/test?asset=' . $asset->id());
     $this->drupalGet('/asset/' . $asset->id() . '/logs');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Log: Test');
+    $this->assertActionLinkExists('Add Log: Test', '/log/add/test?asset=' . $asset->id());
     $this->drupalGet('/asset/' . $asset->id() . '/logs/test');
     $this->assertSession()->statusCodeEquals(200);
-    $this->assertSession()->linkExists('Add Log: Test');
+    $this->assertActionLinkExists('Add Log: Test', '/log/add/test?asset=' . $asset->id());
+  }
+
+  /**
+   * Helper method to test that an action link exists.
+   *
+   * @param string $label
+   *   The action link label.
+   * @param string $href
+   *   The action link href.
+   */
+  protected function assertActionLinkExists(string $label, string $href): void {
+    $this->assertSession()->linkExists($label);
+    $this->assertSession()->linkByHrefExists($href);
   }
 
 }

--- a/modules/core/ui/action/tests/src/Functional/ActionsTest.php
+++ b/modules/core/ui/action/tests/src/Functional/ActionsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_ui_action\Functional;
+
+use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use Drupal\asset\Entity\Asset;
+use Drupal\log\Entity\Log;
+
+/**
+ * Tests the farmOS action functionality.
+ *
+ * @group farm
+ */
+class ActionsTest extends FarmBrowserTestBase {
+
+  /**
+   * Test user.
+   *
+   * @var \Drupal\user\Entity\User|bool
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_ui_action',
+    'farm_ui_action_test',
+    'farm_ui_dashboard',
+    'farm_ui_views',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Add the local actions block.
+    $this->drupalPlaceBlock('local_actions_block');
+
+    // Create and login a user with necessary permissions.
+    $this->user = $this->createUser([
+      'access asset collection',
+      'access farm dashboard',
+      'access log collection',
+      'access organization collection',
+      'access plan collection',
+      'create test asset',
+      'create test log',
+      'create test organization',
+      'create test plan',
+      'view any asset',
+      'view any log',
+      'view any organization',
+      'view any plan',
+    ]);
+    $this->drupalLogin($this->user);
+  }
+
+  /**
+   * Test that action buttons are added.
+   */
+  public function testActionButtons() {
+
+    // Test dashboard buttons.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Asset');
+    $this->assertSession()->linkExists('Add Log');
+    $this->assertSession()->linkExists('Add Organization');
+    $this->assertSession()->linkExists('Add Plan');
+
+    // Test entity lists.
+    $this->drupalGet('/assets');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Asset');
+    $this->drupalGet('/logs');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Log');
+    $this->drupalGet('/organizations');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Organization');
+    $this->drupalGet('/plans');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Plan');
+
+    // Test per-bundle entity lists.
+    $this->drupalGet('/assets/test');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Asset: Test');
+    $this->drupalGet('/logs/test');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Log: Test');
+    $this->drupalGet('/organizations/test');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Organization: Test');
+    $this->drupalGet('/plans/test');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Plan: Test');
+
+    // Test /user/%uid/logs.
+    $this->drupalGet('/user/' . $this->user->id() . '/logs');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Log');
+
+    // Test links to /log/add/[bundle]?asset=[id] on asset pages.
+    /** @var \Drupal\asset\Entity\AssetInterface $asset */
+    $asset = Asset::create([
+      'type' => 'test',
+      'name' => $this->randomMachineName(),
+    ]);
+    $asset->save();
+    /** @var \Drupal\log\Entity\LogInterface $log */
+    $log = Log::create([
+      'type' => 'test',
+      'asset' => [$asset],
+    ]);
+    $log->save();
+    $this->drupalGet('/asset/' . $asset->id());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Log: Test');
+    $this->drupalGet('/asset/' . $asset->id() . '/logs');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Log: Test');
+    $this->drupalGet('/asset/' . $asset->id() . '/logs/test');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->linkExists('Add Log: Test');
+  }
+
+}

--- a/modules/core/ui/views/src/Hook/EntityHooks.php
+++ b/modules/core/ui/views/src/Hook/EntityHooks.php
@@ -18,11 +18,12 @@ class EntityHooks {
   public function entityTypeBuild(array &$entity_types) {
     /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entity_types */
 
-    // Override the "collection" link path for assets, logs, and plans to use
-    // the Views provided by this module.
+    // Override the "collection" link path for assets, logs, organizations,
+    // and plans to use the Views provided by this module.
     $collection_paths = [
       'asset' => '/assets',
       'log' => '/logs',
+      'organization' => '/organizations',
       'plan' => '/plans',
     ];
     foreach ($collection_paths as $entity_type => $path) {


### PR DESCRIPTION
I noticed that the "Add Asset" action link was missing from the /assets collection page in 4.x (but works in 3.x). As far as I can recall, nothing changed in the way we generate these links between 3.x and 4.x. This led me down a rabbit hole...

Tl;dr: I'm still not sure exactly what changed, but I've refactored the way we generate these action links, and added automated tests so we'll know if they break in the future.

### Observations:

I installed a fresh 4.x instance with the `asset`, `log`, `organization`, and `plan` modules turned on:

```bash
$ drush site-install -y --db-url=pgsql://farm:farm@db/farm --account-pass=admin
$ drush en asset plan log organization
```

The dashboard shows all expected action links:

<img width="1366" height="442" alt="Screenshot from 2026-02-20 07-26-02" src="https://github.com/user-attachments/assets/afd64e40-9903-4f6f-abce-0adaf255a720" />

However, the same action link should also be appearing on entity collection pages (`/assets`, `/logs`, `/organizations`, `/plans`), but in practice they are inconsistent. "Add Log" and "Add Organization" are present, but "Add Asset" and "Add Plan" are missing.

<img width="1366" height="442" alt="Screenshot from 2026-02-20 07-28-19" src="https://github.com/user-attachments/assets/ea15b31c-be07-4037-988a-e4ae7cecba24" />

<img width="1366" height="442" alt="Screenshot from 2026-02-20 07-28-32" src="https://github.com/user-attachments/assets/4f46fe0f-5395-44da-a8de-4ca2560f7deb" />

<img width="1366" height="442" alt="Screenshot from 2026-02-20 07-28-42" src="https://github.com/user-attachments/assets/2d303414-bba0-4b7f-a8c5-78731735eb6c" />

<img width="1366" height="442" alt="Screenshot from 2026-02-20 07-28-55" src="https://github.com/user-attachments/assets/c4f5a8ee-3449-42e5-a44f-1dc0d49289e8" />

_Notably, all the other actions links derived by our `FarmActions` class (see below) appear to be working as expected._

### Investigation:

This is where those action links are currently built in the `farm_ui_action` module's `FarmActions` deriver class:

https://github.com/farmOS/farmOS/blob/6012587ab9221c6ff101db13f29c693f84dcc0dc/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php#L65-L85

And specifically, this is where they are added to the dashboard:

https://github.com/farmOS/farmOS/blob/6012587ab9221c6ff101db13f29c693f84dcc0dc/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php#L84

And this is where they are added to the collection pages (built by Views):

https://github.com/farmOS/farmOS/blob/6012587ab9221c6ff101db13f29c693f84dcc0dc/modules/core/ui/action/src/Plugin/Derivative/FarmActions.php#L74

So, what's going on? And why are they working for `log` and `organization`, but not for `asset` and `plan`? :thinking: 

Well... I discovered that I could fix `/assets` and `/plans` by changing line 74 in `FarmActions` (linked above) from:

`$this->derivatives[$name]['appears_on'][] = 'view.farm_' . $type . '.page';`

to:

`$this->derivatives[$name]['appears_on'][] = 'entity.' . $type . '.collection';`

This restores the "Add Asset" and "Add Plan" action links! But it removes the "Add Organization" link, and causes TWO "Add Log" links to appear. :face_with_spiral_eyes: 

<img width="1366" height="442" alt="Screenshot from 2026-02-20 08-01-07" src="https://github.com/user-attachments/assets/b3fae693-749c-42bf-af26-6b83cb94c9c5" />

<img width="1366" height="442" alt="Screenshot from 2026-02-20 08-01-24" src="https://github.com/user-attachments/assets/0276e50c-9c15-4d9a-b81d-002248e67766" />

<img width="1366" height="442" alt="Screenshot from 2026-02-20 08-01-35" src="https://github.com/user-attachments/assets/7ae54f7e-0036-4eea-9427-86f0d1f4dfba" />

<img width="1366" height="442" alt="Screenshot from 2026-02-20 08-01-47" src="https://github.com/user-attachments/assets/f2dc7a23-7991-467b-bafd-595b902da858" />

After much head scratching, I figured out why...

The Log module implements its own "Add Log" action link in `log.links.action.yml`, which appears on the `entity.log.collection`: https://git.drupalcode.org/project/log/-/blob/2bbb45e9c97dca0af0d07efd219733392327d3ad/log.links.action.yml#L1-5 

So, by changing line 74 in `FarmActions`, we are essentially adding our own action link to the `entity.log.collection` route alongside the `log` module's own action link.

As for the missing "Add Organization" action link, I realized that was because we didn't include `organization` in the `farm_ui_view` module's implementation of `hook_entity_type_build()`:

https://github.com/farmOS/farmOS/blob/6012587ab9221c6ff101db13f29c693f84dcc0dc/modules/core/ui/views/src/Hook/EntityHooks.php#L14-L33

That hook alters the entity type definitions to override the "collection" links, so that they point to the pages we generate via Views provided by `farm_ui_views`. We should have added `organization` to that hook during #849, but that was overlooked.

The part that I don't understand, which is at the crux of all this, is: why does Drupal interpret the route name of `/assets` (and others) as `entity.asset.collection` in farmOS 4.x, while it is interpreted as `view.farm_asset.page` in farmOS 3.x? :thinking: 

Ultimately, this is better! Our desire is to add action links to the "collection" pages, and in 3.x we had to reference the Views route names explicitly, but that logic would break if anyone wanted to override those paths with their own routes. So it's better to add action links to the generic `entity.[entity-type].collection` routes, if possible.

It's possible that this was a bug in Drupal 10, which was fixed in Drupal 11... and this "fix" broke our code, which was technically a workaround.

I wish I could pinpoint exactly what changed, but I wasn't able to find a related Drupal core issue or change record. Although to be fair, this is a bit of a tricky one to search for...

### Proposed Solution:

I've reworked the way that these action links are generated. Instead of deriving our own generic "Add [entity-type]" action links in the `FarmActions` deriver class, I added them via `[entity-type].links.action.yml` definitions in the `asset`, `organization`, and `plan` modules, following the same pattern that the `log` module already employs. This fixes the duplicate "Add Log" action link, and restores the "Add Asset" and "Add Plan" links.

This only adds them to the entity collection pages. So then I also implemented `hook_menu_local_actions_alter()` to alter these default action links to add additional routes that they should appear on, including the dashboard and `/user/%/logs`, and removed the related logic from the `FarmAction` deriver class.

To fix the "Add Organization" link, I added `organization` to the `farm_ui_view` module's implementation of `hook_entity_type_build()`.

Lastly, I added automated test coverage for all these links, so we'll know if this breaks in the future.