### PR TITLE
Fix asset and plan update hooks for prefixed database tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix missing action links on entity collection pages #1050](https://github.com/farmOS/farmOS/pull/1050)
+- [Fix asset and plan update hooks for prefixed database tables #1051](https://github.com/farmOS/farmOS/pull/1051)
 
 ## [4.0.0-beta2] 2026-02-12
 

--- a/modules/core/asset/asset.post_update.php
+++ b/modules/core/asset/asset.post_update.php
@@ -27,8 +27,8 @@ function asset_post_update_remove_status(&$sandbox) {
   $update_manager->installFieldStorageDefinition('last_archived', 'asset', 'asset', $field_definition);
 
   // Populate last_archived field values from the old archived field.
-  \Drupal::database()->query("UPDATE asset_field_data SET last_archived = archived");
-  \Drupal::database()->query("UPDATE asset_field_revision SET last_archived = archived");
+  \Drupal::database()->query("UPDATE {asset_field_data} SET last_archived = archived");
+  \Drupal::database()->query("UPDATE {asset_field_revision} SET last_archived = archived");
 
   // Delete the old archived field.
   $storage_definition = $update_manager->getFieldStorageDefinition('archived', 'asset');
@@ -61,10 +61,10 @@ function asset_post_update_remove_status(&$sandbox) {
   $update_manager->installFieldStorageDefinition('archived', 'asset', 'asset', $field_definition);
 
   // Archive assets with a status of archived.
-  \Drupal::database()->query("UPDATE asset_field_data SET archived = 0 WHERE status != 'archived'");
-  \Drupal::database()->query("UPDATE asset_field_data SET archived = 1 WHERE status = 'archived'");
-  \Drupal::database()->query("UPDATE asset_field_revision SET archived = 0 WHERE status != 'archived'");
-  \Drupal::database()->query("UPDATE asset_field_revision SET archived = 1 WHERE status = 'archived'");
+  \Drupal::database()->query("UPDATE {asset_field_data} SET archived = 0 WHERE status != 'archived'");
+  \Drupal::database()->query("UPDATE {asset_field_data} SET archived = 1 WHERE status = 'archived'");
+  \Drupal::database()->query("UPDATE {asset_field_revision} SET archived = 0 WHERE status != 'archived'");
+  \Drupal::database()->query("UPDATE {asset_field_revision} SET archived = 1 WHERE status = 'archived'");
 
   // Rename asset_activate_action action configuration entity to
   // asset_unarchive_action.

--- a/modules/core/plan/plan.post_update.php
+++ b/modules/core/plan/plan.post_update.php
@@ -50,14 +50,14 @@ function plan_post_update_move_archived_status(&$sandbox) {
   $update_manager->installFieldStorageDefinition('archived', 'plan', 'plan', $field_definition);
 
   // Archive plans with a status of archived.
-  \Drupal::database()->query("UPDATE plan_field_data SET archived = 0 WHERE status != 'archived'");
-  \Drupal::database()->query("UPDATE plan_field_data SET archived = 1 WHERE status = 'archived'");
-  \Drupal::database()->query("UPDATE plan_field_revision SET archived = 0 WHERE status != 'archived'");
-  \Drupal::database()->query("UPDATE plan_field_revision SET archived = 1 WHERE status = 'archived'");
+  \Drupal::database()->query("UPDATE {plan_field_data} SET archived = 0 WHERE status != 'archived'");
+  \Drupal::database()->query("UPDATE {plan_field_data} SET archived = 1 WHERE status = 'archived'");
+  \Drupal::database()->query("UPDATE {plan_field_revision} SET archived = 0 WHERE status != 'archived'");
+  \Drupal::database()->query("UPDATE {plan_field_revision} SET archived = 1 WHERE status = 'archived'");
 
   // Change the status of archived plans to active.
-  \Drupal::database()->query("UPDATE plan_field_data SET status = 'active' WHERE status = 'archived'");
-  \Drupal::database()->query("UPDATE plan_field_revision SET status = 'active' WHERE status = 'archived'");
+  \Drupal::database()->query("UPDATE {plan_field_data} SET status = 'active' WHERE status = 'archived'");
+  \Drupal::database()->query("UPDATE {plan_field_revision} SET status = 'active' WHERE status = 'archived'");
 
   // Rename plan_activate_action action configuration entity to
   // plan_unarchive_action.


### PR DESCRIPTION
A user reported issues updating to farmOS v4 due to the fact that they are prefixing their database tables. Reported here: https://farmos.discourse.group/t/farmos-3-5-1-has-been-released/2465/12

This issue was introduced in #986, which added update hooks that use raw SQL queries. These SQL queries did not properly wrap database table names in curly brackets per https://www.drupal.org/docs/develop/drupal-apis/database-api/static-queries#s-table-name-prefixing

This PR adds curly brackets around those table names to fix these update hooks in sites that use table prefixing.