### PR TITLE
Allow importing taxonomy term CSVs without parent column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [Fix exposed log category filter in Views #1060](https://github.com/farmOS/farmOS/pull/1060)
+- [Allow importing taxonomy term CSVs without parent column #1054](https://github.com/farmOS/farmOS/pull/1054)
 
 ## [4.0.0-beta3] 2026-02-21
 

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationTerm.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationTerm.php
@@ -38,9 +38,15 @@ class CsvImportMigrationTerm extends CsvImportMigrationBase {
     // Add support for assigning term parent.
     // The parent term must already exist in the same vocabulary.
     $mapping['parent'] = [
-      'plugin' => 'term_lookup',
-      'bundle' => $bundle,
-      'source' => 'parent',
+      [
+        'plugin' => 'skip_on_empty',
+        'method' => 'process',
+        'source' => 'assets',
+      ],
+      [
+        'plugin' => 'term_lookup',
+        'bundle' => $bundle,
+      ],
     ];
   }
 


### PR DESCRIPTION
Discovered a minor bug with the default taxonomy term CSV importers. If you omit the `parent` column from the CSV, import fails with the following error:

`TypeError: trim(): Argument #1 ($string) must be of type string, null given in trim() (line 56 of /opt/repos/farmOS/modules/core/migrate/src/Plugin/migrate/process/TermLookup.php).`

This is the line that is throwing the error: https://github.com/farmOS/farmOS/blob/5f36bf6dd372868ea7fe9a6c95c928a33ba09304/modules/core/migrate/src/Plugin/migrate/process/TermLookup.php#L56

The problem is a `null` value is being passed into that process plugin, which is not designed to deal with `null` values. It should never get that far in the first place.

We fixed this same issue on asset and log entities in https://github.com/farmOS/farmOS/commit/9069e787603271eb62f26de2f60d4e1b332f2517

The fix is to run the migrated value through the `skip_on_empty` plugin before passing it to the `term_lookup` plugin.

This PR applies the same fix for the `parent` field on taxonomy terms.