### PR TITLE
Deprecate asset/organization/quantity entity events

### DIFF
--- a/modules/core/asset/src/Event/AssetEvent.php
+++ b/modules/core/asset/src/Event/AssetEvent.php
@@ -8,7 +8,11 @@ use Drupal\Component\EventDispatcher\Event;
 use Drupal\asset\Entity\AssetInterface;
 
 /**
- * Event that is fired by asset save, delete and clone operations.
+ * Event that is fired by asset entity operations.
+ *
+ * @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+ *   Use Drupal core entity hooks instead.
+ * @see https://www.drupal.org/node/3576637
  */
 class AssetEvent extends Event {
 

--- a/modules/core/asset/src/Hook/EntityHooks.php
+++ b/modules/core/asset/src/Hook/EntityHooks.php
@@ -27,8 +27,12 @@ class EntityHooks {
   public function assetPresave(AssetInterface $asset) {
 
     // Dispatch an event on asset presave.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new AssetEvent($asset);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, AssetEvent::PRESAVE);
   }
 
@@ -39,8 +43,12 @@ class EntityHooks {
   public function assetInsert(AssetInterface $asset) {
 
     // Dispatch an event on asset insert.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new AssetEvent($asset);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, AssetEvent::INSERT);
   }
 
@@ -51,8 +59,12 @@ class EntityHooks {
   public function assetUpdate(AssetInterface $asset) {
 
     // Dispatch an event on asset update.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new AssetEvent($asset);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, AssetEvent::UPDATE);
   }
 
@@ -63,8 +75,12 @@ class EntityHooks {
   public function assetDelete(AssetInterface $asset) {
 
     // Dispatch an event on asset delete.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new AssetEvent($asset);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, AssetEvent::DELETE);
   }
 

--- a/modules/core/organization/src/Event/OrganizationEvent.php
+++ b/modules/core/organization/src/Event/OrganizationEvent.php
@@ -8,7 +8,11 @@ use Drupal\Component\EventDispatcher\Event;
 use Drupal\organization\Entity\OrganizationInterface;
 
 /**
- * Event that is fired by organization save, delete and clone operations.
+ * Event that is fired by organization entity operations.
+ *
+ * @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+ *   Use Drupal core entity hooks instead.
+ * @see https://www.drupal.org/node/3576637
  */
 class OrganizationEvent extends Event {
 

--- a/modules/core/organization/src/Hook/EntityHooks.php
+++ b/modules/core/organization/src/Hook/EntityHooks.php
@@ -27,8 +27,12 @@ class EntityHooks {
   public function organizationPresave(OrganizationInterface $organization) {
 
     // Dispatch an event on organization presave.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new OrganizationEvent($organization);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, OrganizationEvent::PRESAVE);
   }
 
@@ -39,8 +43,12 @@ class EntityHooks {
   public function organizationInsert(OrganizationInterface $organization) {
 
     // Dispatch an event on organization insert.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new OrganizationEvent($organization);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, OrganizationEvent::INSERT);
   }
 
@@ -51,8 +59,12 @@ class EntityHooks {
   public function organizationUpdate(OrganizationInterface $organization) {
 
     // Dispatch an event on organization update.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new OrganizationEvent($organization);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, OrganizationEvent::UPDATE);
   }
 
@@ -63,8 +75,12 @@ class EntityHooks {
   public function organizationDelete(OrganizationInterface $organization) {
 
     // Dispatch an event on organization delete.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new OrganizationEvent($organization);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, OrganizationEvent::DELETE);
   }
 

--- a/modules/core/quantity/src/Event/QuantityEvent.php
+++ b/modules/core/quantity/src/Event/QuantityEvent.php
@@ -8,7 +8,11 @@ use Drupal\quantity\Entity\QuantityInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
- * Event that is fired by hook_quantity_OPERATION().
+ * Event that is fired by quantity entity operations.
+ *
+ * @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+ *   Use Drupal core entity hooks instead.
+ * @see https://www.drupal.org/node/3576637
  */
 class QuantityEvent extends Event {
 

--- a/modules/core/quantity/src/Hook/EntityHooks.php
+++ b/modules/core/quantity/src/Hook/EntityHooks.php
@@ -27,8 +27,12 @@ class EntityHooks {
   public function quantityPresave(QuantityInterface $quantity) {
 
     // Dispatch an event on quantity presave.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new QuantityEvent($quantity);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, QuantityEvent::PRESAVE);
   }
 
@@ -39,8 +43,12 @@ class EntityHooks {
   public function quantityDelete(QuantityInterface $quantity) {
 
     // Dispatch an event on quantity delete.
-    // @todo Replace this with core event via https://www.drupal.org/node/2551893.
+    // @deprecated in farm:4.1.0 and is removed from farm:5.0.0.
+    // Use Drupal core entity hooks instead.
+    // @see https://www.drupal.org/node/3576637
+    // @phpstan-ignore-next-line
     $event = new QuantityEvent($quantity);
+    // @phpstan-ignore-next-line
     $this->eventDispatcher->dispatch($event, QuantityEvent::DELETE);
   }
 


### PR DESCRIPTION
See [Issue #3576633: Deprecate and remove asset/organization/quantity entity events](https://www.drupal.org/project/farm/issues/3576633) for full description.