### PR TITLE
Fix exposed taxonomy term reference filters in Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix exposed log category filter in Views #1060](https://github.com/farmOS/farmOS/pull/1060)
+
 ## [4.0.0-beta3] 2026-02-21
 
 ### Added

--- a/modules/core/ui/views/config/install/views.view.farm_log.yml
+++ b/modules/core/ui/views/config/install/views.view.farm_log.yml
@@ -937,7 +937,7 @@ display:
           entity_field: category
           plugin_id: taxonomy_index_tid
           operator: or
-          value: {  }
+          value: null
           group: 1
           exposed: true
           expose:
@@ -973,6 +973,16 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+          sub_handler: 'default:taxonomy_term'
+          sub_handler_settings:
+            target_bundles:
+              log_category: log_category
+            sort:
+              field: name
+              direction: asc
+            auto_create: false
+            auto_create_bundle: ''
+          widget: select
         flag_value:
           id: flag_value
           table: log__flag

--- a/modules/core/ui/views/config/optional/views.view.farm_organization_log.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_organization_log.yml
@@ -975,7 +975,7 @@ display:
           entity_field: category
           plugin_id: taxonomy_index_tid
           operator: or
-          value: {  }
+          value: null
           group: 1
           exposed: true
           expose:
@@ -1011,6 +1011,16 @@ display:
           hierarchy: false
           limit: true
           error_message: true
+          sub_handler: 'default:taxonomy_term'
+          sub_handler_settings:
+            target_bundles:
+              log_category: log_category
+            sort:
+              field: name
+              direction: asc
+            auto_create: false
+            auto_create_bundle: ''
+          widget: select
         flag_value:
           id: flag_value
           table: log__flag


### PR DESCRIPTION
The plugin settings must have changed at some point, causing this to revert to an autocomplete that does not filter by taxonomy. This changes it back to a multi-select field that only shows log category terms.

**Before**:

<img width="1101" height="390" alt="Screenshot from 2026-03-07 08-22-57" src="https://github.com/user-attachments/assets/ec1069d4-3559-428b-9ebc-ea8a1a6d908e" />

<img width="1094" height="545" alt="Screenshot from 2026-03-07 08-22-43" src="https://github.com/user-attachments/assets/a6e4dd87-7ea2-4e00-bc64-9b2fd7a2bb0a" />

**After**:

<img width="1098" height="442" alt="Screenshot from 2026-03-07 08-24-38" src="https://github.com/user-attachments/assets/651804bd-d2b2-4413-a910-724a56092e98" />
