### PR TITLE
Fix asset parent/child farm validation when neither asset is in a farm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Allow importing taxonomy term CSVs without parent column #1054](https://github.com/farmOS/farmOS/pull/1054)
 - [Fix exposed taxonomy term reference filters in Views #1060](https://github.com/farmOS/farmOS/pull/1060)
+- [Fix asset parent/child farm validation when neither asset is in a farm #1061](https://github.com/farmOS/farmOS/pull/1061)
 
 ### Changed
 

--- a/modules/organization/farm/src/Plugin/Validation/Constraint/AssetParentFarmValidator.php
+++ b/modules/organization/farm/src/Plugin/Validation/Constraint/AssetParentFarmValidator.php
@@ -69,8 +69,8 @@ class AssetParentFarmValidator extends ConstraintValidator implements ContainerI
         }
       }
 
-      // Otherwise, add a violation because the relation isn't in a farm.
-      else {
+      // Or, if the relation isn't in a farm, but the asset is, add a violation.
+      elseif (!empty($farm_id)) {
         $violation = TRUE;
         break;
       }

--- a/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
+++ b/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
@@ -135,6 +135,22 @@ class FieldConstraintsTest extends KernelTestBase {
     // asset has a child in a different farm.
     $this->assertEquals(1, $violations->count());
     $this->assertInstanceOf(AssetParentFarm::class, $violations->get(0)->getConstraint());
+
+    // Reset the first asset to the first farm and confirm that it validates.
+    $asset1->set('farm', [$farm1]);
+    $violations = $asset1->validate();
+    $this->assertEquals(0, $violations->count());
+
+    // Remove farm assignment from both assets, save them, and confirm that they
+    // both validate.
+    $asset1->set('farm', []);
+    $asset1->save();
+    $asset2->set('farm', []);
+    $asset2->save();
+    $violations = $asset1->validate();
+    $this->assertEquals(0, $violations->count());
+    $violations = $asset2->validate();
+    $this->assertEquals(0, $violations->count());
   }
 
   /**


### PR DESCRIPTION
Fixes https://github.com/farmOS/farmOS/issues/1059