### PR TITLE
Add #[RunTestsInSeparateProcesses] attribute to all Kernel, Functional, and FunctionalJavascript tests

### DIFF
--- a/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
+++ b/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_equipment\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the equipment used field.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class EquipmentFieldTest extends FarmBrowserTestBase {
 
   use StringTranslationTrait;

--- a/modules/asset/group/tests/src/FunctionalJavascript/GroupTest.php
+++ b/modules/asset/group/tests/src/FunctionalJavascript/GroupTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_group\FunctionalJavascript;
 
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS group membership logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class GroupTest extends FarmWebDriverTestBase {
 
   /**

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -12,12 +12,14 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS group membership logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class GroupTest extends KernelTestBase {
 
   use StringTranslationTrait;

--- a/modules/asset/sensor/modules/listener/tests/src/Functional/SensorListenerApiTest.php
+++ b/modules/asset/sensor/modules/listener/tests/src/Functional/SensorListenerApiTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_sensor_listener\Functional;
 
 use Drupal\Tests\farm_sensor\Functional\SensorDataApiTest;
 use Drupal\asset\Entity\AssetInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test the sensor listener (legacy) API.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class SensorListenerApiTest extends SensorDataApiTest {
 
   /**

--- a/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
+++ b/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
@@ -10,12 +10,14 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\asset\Entity\AssetInterface;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test the Sensor data API.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class SensorDataApiTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/api/modules/farm_api_oauth/tests/src/Functional/CorsResponseEventSubscriberTest.php
+++ b/modules/core/api/modules/farm_api_oauth/tests/src/Functional/CorsResponseEventSubscriberTest.php
@@ -9,6 +9,7 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\consumers\Entity\Consumer;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -16,6 +17,7 @@ use Psr\Http\Message\ResponseInterface;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class CorsResponseEventSubscriberTest extends FarmBrowserTestBase {
 
   use JsonApiRequestTestTrait;

--- a/modules/core/api/modules/farm_api_oauth/tests/src/Functional/OauthTestBase.php
+++ b/modules/core/api/modules/farm_api_oauth/tests/src/Functional/OauthTestBase.php
@@ -11,7 +11,7 @@ use Drupal\Tests\simple_oauth\Functional\TokenBearerFunctionalTestBase;
  *
  * @group farm
  */
-class OauthTestBase extends TokenBearerFunctionalTestBase {
+abstract class OauthTestBase extends TokenBearerFunctionalTestBase {
 
   /**
    * {@inheritdoc}

--- a/modules/core/api/tests/src/Functional/EntryPointTest.php
+++ b/modules/core/api/tests/src/Functional/EntryPointTest.php
@@ -9,12 +9,14 @@ use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the API entry point functionality.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class EntryPointTest extends FarmBrowserTestBase {
 
   use JsonApiRequestTestTrait;

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\AssetInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmApiTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
+++ b/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\asset\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the asset CRUD.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class AssetCRUDTest extends AssetTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/EmailDeliveryTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/EmailDeliveryTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Test\AssertMailTrait;
 use Drupal\Tests\data_stream\Kernel\DataStreamTestBase;
 use Drupal\Tests\data_stream\Traits\DataStreamCreationTrait;
 use Drupal\data_stream_notification\Entity\DataStreamNotification;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class EmailDeliveryTest extends DataStreamTestBase {
 
   use AssertMailTrait;

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/NotificationTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/NotificationTest.php
@@ -8,6 +8,7 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Tests\data_stream\Kernel\DataStreamTestBase;
 use Drupal\Tests\data_stream\Traits\DataStreamCreationTrait;
 use Drupal\data_stream_notification\Entity\DataStreamNotification;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -16,6 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class NotificationTest extends DataStreamTestBase {
 
   use DataStreamCreationTrait;

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/NumericConditionTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/NumericConditionTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\data_stream_notification\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the numeric notification condition.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class NumericConditionTest extends KernelTestBase {
 
   /**

--- a/modules/core/data_stream/tests/src/Kernel/DataStreamTest.php
+++ b/modules/core/data_stream/tests/src/Kernel/DataStreamTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\data_stream\Kernel;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Tests\data_stream\Traits\DataStreamCreationTrait;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -13,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class DataStreamTest extends DataStreamTestBase {
 
   use DataStreamCreationTrait;

--- a/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_entity\Functional;
 
 use Drupal\Core\Entity\Sql\SqlEntityStorageInterface;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests that bundle fields are created during a postponed install.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_entity\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test expected farmOS entity revision behavior.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmEntityRevisionsTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_entity\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS entity fields.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmEntityFieldTest extends KernelTestBase {
 
   /**

--- a/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_entity\Kernel;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS entity revisions.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmEntityRevisionsTest extends KernelTestBase {
 
   /**

--- a/modules/core/flag/tests/src/Kernel/FlagTest.php
+++ b/modules/core/flag/tests/src/Kernel/FlagTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_flag\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\farm_flag\Entity\FarmFlag;
 use Drupal\farm_flag\FarmFlagHelper;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farm_flag logic.
  *
  * @group farm_flag
  */
+#[RunTestsInSeparateProcesses]
 class FlagTest extends KernelTestBase {
 
   /**

--- a/modules/core/id_tag/tests/src/Kernel/IdTagTest.php
+++ b/modules/core/id_tag/tests/src/Kernel/IdTagTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_id_tag\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test ID tag field.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class IdTagTest extends KernelTestBase {
 
   /**

--- a/modules/core/image/tests/src/Functional/ImageEffectsTest.php
+++ b/modules/core/image/tests/src/Functional/ImageEffectsTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_image\Functional;
 use Drupal\Core\File\FileExists;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\image\Entity\ImageStyle;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for the farm_image image effects.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class ImageEffectsTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_import_csv\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS CSV importers.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class CsvImportTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
@@ -8,12 +8,14 @@ use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for asset CSV importers.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class AssetCsvImportTest extends CsvImportTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/ConfigCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/ConfigCsvImportTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for config CSV importers.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class ConfigCsvImportTest extends CsvImportTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportDatabaseTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportDatabaseTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for CSV import database table.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class CsvImportDatabaseTest extends CsvImportTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportMigrationGroupTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportMigrationGroupTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\farm_import_csv\Kernel;
 
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
 /**
  * Tests for CSV import migration group.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class CsvImportMigrationGroupTest extends CsvImportTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
@@ -14,7 +14,7 @@ use Drupal\file\Entity\File;
  *
  * @group farm
  */
-class CsvImportTestBase extends MigrateTestBase {
+abstract class CsvImportTestBase extends MigrateTestBase {
 
   use UserCreationTrait;
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/LogCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/LogCsvImportTest.php
@@ -8,12 +8,14 @@ use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for log CSV importers.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LogCsvImportTest extends CsvImportTestBase {
 
   /**

--- a/modules/core/import/modules/csv/tests/src/Kernel/TermCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/TermCsvImportTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for taxonomy term CSV importers.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class TermCsvImportTest extends CsvImportTestBase {
 
   /**

--- a/modules/core/inventory/tests/src/Functional/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Functional/InventoryTest.php
@@ -10,12 +10,14 @@ use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS inventory logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class InventoryTest extends FarmBrowserTestBase {
 
   use JsonApiRequestTestTrait;

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -12,12 +12,14 @@ use Drupal\fraction\Fraction;
 use Drupal\log\Entity\Log;
 use Drupal\quantity\Entity\Quantity;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS inventory logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class InventoryTest extends KernelTestBase {
 
   use FarmEntityCacheTestTrait;

--- a/modules/core/l10n/tests/src/Kernel/FarmLocalizationApiTest.php
+++ b/modules/core/l10n/tests/src/Kernel/FarmLocalizationApiTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_l10n\Kernel;
 
 use Drupal\Tests\farm_api\Kernel\FarmApiTest;
 use Drupal\language\Entity\ConfigurableLanguage;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS API features.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmLocalizationApiTest extends FarmApiTest {
 
   /**

--- a/modules/core/location/tests/src/Functional/LocationAPITest.php
+++ b/modules/core/location/tests/src/Functional/LocationAPITest.php
@@ -10,12 +10,14 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\farm_geo\Traits\WktTrait;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for the location api.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LocationAPITest extends FarmBrowserTestBase {
 
   use WktTrait;

--- a/modules/core/location/tests/src/FunctionalJavascript/LocationTest.php
+++ b/modules/core/location/tests/src/FunctionalJavascript/LocationTest.php
@@ -9,12 +9,14 @@ use Drupal\Tests\farm_location\Functional\LocationFunctionalTestTrait;
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\farm_geo\Traits\WktTrait;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS location logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LocationTest extends FarmWebDriverTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -12,12 +12,14 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS location logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LocationTest extends KernelTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
+++ b/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
@@ -8,12 +8,14 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\log\Entity\Log;
 use Drupal\log\Event\LogEvent;
 use Drupal\quantity\Entity\Quantity;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS log quantity module.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LogQuantityTest extends KernelTestBase {
 
   /**

--- a/modules/core/log/tests/src/Kernel/LogTest.php
+++ b/modules/core/log/tests/src/Kernel/LogTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS log module.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LogTest extends KernelTestBase {
 
   /**

--- a/modules/core/login/tests/src/Functional/OauthPasswordTest.php
+++ b/modules/core/login/tests/src/Functional/OauthPasswordTest.php
@@ -6,6 +6,7 @@ namespace Drupal\tests\farm_login\Functional;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Tests\farm_api_oauth\Functional\OauthTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests using an email with OAuth Password Grant.
@@ -16,6 +17,7 @@ use Drupal\Tests\farm_api_oauth\Functional\OauthTestBase;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class OauthPasswordTest extends OauthTestBase {
 
   /**

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test using an email in the UserLoginForm.
@@ -19,6 +20,7 @@ use Drupal\user\UserInterface;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class UserLoginTest extends FarmBrowserTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
+++ b/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
@@ -9,12 +9,14 @@ use Drupal\Tests\field\Functional\FieldTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS Geofield widget.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class GeofieldWidgetTest extends FieldTestBase {
 
   /**

--- a/modules/core/map/tests/src/Functional/MapFormTest.php
+++ b/modules/core/map/tests/src/Functional/MapFormTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_map\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS map form element.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class MapFormTest extends FarmBrowserTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/organization/tests/src/Functional/OrganizationCRUDTest.php
+++ b/modules/core/organization/tests/src/Functional/OrganizationCRUDTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\organization\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\organization\Entity\Organization;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the organization CRUD.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class OrganizationCRUDTest extends OrganizationTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/owner/tests/src/Kernel/LogOwnerTest.php
+++ b/modules/core/owner/tests/src/Kernel/LogOwnerTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_owner\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS log owner logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class LogOwnerTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
+++ b/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\plan\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\plan\Entity\Plan;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the plan CRUD.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class PlanCRUDTest extends PlanTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
+++ b/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\plan\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\plan\Entity\Plan;
 use Drupal\plan\Entity\PlanRecord;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for plan_record entities.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class PlanRecordTest extends KernelTestBase {
 
   /**

--- a/modules/core/quick/tests/src/Functional/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Functional/QuickFormTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_quick\Functional;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\farm_quick\Entity\QuickFormInstance;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the quick form framework.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickFormTest extends FarmBrowserTestBase {
 
   use StringTranslationTrait;

--- a/modules/core/quick/tests/src/Kernel/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTest.php
@@ -9,12 +9,14 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\farm_quick\Form\QuickFormEntityForm;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS quick forms.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickFormTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/modules/core/quick/tests/src/Kernel/QuickStringTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickStringTest.php
@@ -8,12 +8,14 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\asset\Entity\AssetType;
 use Drupal\farm_quick\Traits\QuickStringTrait;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for quick string trait methods.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickStringTest extends KernelTestBase {
 
   use QuickStringTrait;

--- a/modules/core/role/tests/src/Kernel/FarmApiOauthRoleTest.php
+++ b/modules/core/role/tests/src/Kernel/FarmApiOauthRoleTest.php
@@ -7,6 +7,7 @@ namespace Drupal\Tests\farm_role\Kernel;
 use Drupal\Tests\farm_api_oauth\Kernel\FarmApiOauthTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -14,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmApiOauthRoleTest extends FarmApiOauthTestBase {
 
   /**

--- a/modules/core/role/tests/src/Kernel/ManagedRolePermissionsTest.php
+++ b/modules/core/role/tests/src/Kernel/ManagedRolePermissionsTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_role\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for Managed Role permissions.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class ManagedRolePermissionsTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/modules/core/role/tests/src/Kernel/ScopeGranularityTest.php
+++ b/modules/core/role/tests/src/Kernel/ScopeGranularityTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_role\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simple_oauth\Entity\Oauth2Scope;
 use Drupal\simple_oauth\Oauth2ScopeProviderInterface;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the managed role permissions scope granularity.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class ScopeGranularityTest extends KernelTestBase {
 
   /**

--- a/modules/core/setup/tests/src/Functional/SetupWizardTest.php
+++ b/modules/core/setup/tests/src/Functional/SetupWizardTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_setup\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for the farmOS setup wizard.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class SetupWizardTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/setup/tests/src/FunctionalJavascript/ModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/ModulesFormTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\farm_setup\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\JSWebAssert;
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests installing modules via the module settings form.
@@ -14,6 +15,7 @@ use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
  *
  * @see \Drupal\farm_setup\Form\FarmModulesForm
  */
+#[RunTestsInSeparateProcesses]
 class ModulesFormTest extends FarmWebDriverTestBase {
 
   /**

--- a/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_setup\FunctionalJavascript;
 
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests installing modules via the setup wizard modules form.
@@ -13,6 +14,7 @@ use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
  *
  * @see \Drupal\farm_setup\Plugin\SetupForm\SetupModulesForm
  */
+#[RunTestsInSeparateProcesses]
 class SetupModulesFormTest extends FarmWebDriverTestBase {
 
   /**

--- a/modules/core/ui/action/tests/src/Functional/ActionsTest.php
+++ b/modules/core/ui/action/tests/src/Functional/ActionsTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_ui_action\Functional;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS action functionality.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class ActionsTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
+++ b/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_ui_dashboard\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS dashboard functionality.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class DashboardTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/ui/menu/tests/src/Kernel/FarmSecondaryTaskTest.php
+++ b/modules/core/ui/menu/tests/src/Kernel/FarmSecondaryTaskTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_ui_menu\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\farm_ui_menu\Menu\EntityTypeLabelLocalTask;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS secondary task links.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmSecondaryTaskTest extends KernelTestBase {
 
   /**

--- a/modules/core/ui/theme/tests/src/Functional/FarmBlockTest.php
+++ b/modules/core/ui/theme/tests/src/Functional/FarmBlockTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_ui_theme\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the "Powered by farmOS" block.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmBlockTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_ui_views\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm_ui_views dashboard panes.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class DashboardTasksTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
+++ b/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
@@ -9,12 +9,14 @@ use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\organization\Entity\Organization;
 use Drupal\quantity\Entity\Quantity;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm_ui_views Views.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmUiViewsTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_ui_views\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm_ui_views taxonomy views routes.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class TaxonomyTermTasksTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/core/update/tests/src/Kernel/FarmUpdateTest.php
+++ b/modules/core/update/tests/src/Kernel/FarmUpdateTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_update\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS Update module.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmUpdateTest extends KernelTestBase {
 
   /**

--- a/modules/log/birth/tests/src/Kernel/BirthTest.php
+++ b/modules/log/birth/tests/src/Kernel/BirthTest.php
@@ -10,12 +10,14 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS birth log logic.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class BirthTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
+++ b/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
@@ -8,6 +8,7 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\log\Entity\Log;
 use Drupal\quantity\Entity\Quantity;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test material type filter functionality.
@@ -16,6 +17,7 @@ use Drupal\taxonomy\Entity\Term;
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class InputViewMaterialTypeTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/organization/farm/tests/src/Functional/FarmFieldTest.php
+++ b/modules/organization/farm/tests/src/Functional/FarmFieldTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_farm\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm reference field.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FarmFieldTest extends FarmBrowserTestBase {
 
   use StringTranslationTrait;

--- a/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
+++ b/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
@@ -11,12 +11,14 @@ use Drupal\farm_farm\Plugin\Validation\Constraint\AssetMovementFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\AssetParentFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\LogGroupAssignmentFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\LogMovementFarm;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Field constraint tests for Farm organization module.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class FieldConstraintsTest extends KernelTestBase {
 
   use UserCreationTrait;

--- a/modules/quick/birth/tests/src/Kernel/QuickBirthTest.php
+++ b/modules/quick/birth/tests/src/Kernel/QuickBirthTest.php
@@ -10,12 +10,14 @@ use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS birth quick form.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickBirthTest extends QuickFormTestBase {
 
   /**

--- a/modules/quick/group/tests/src/Kernel/QuickGroupTest.php
+++ b/modules/quick/group/tests/src/Kernel/QuickGroupTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_quick_group\Kernel;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS group quick form.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickGroupTest extends QuickFormTestBase {
 
   /**

--- a/modules/quick/inventory/tests/src/Kernel/QuickInventoryTest.php
+++ b/modules/quick/inventory/tests/src/Kernel/QuickInventoryTest.php
@@ -8,12 +8,14 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS inventory quick form.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickInventoryTest extends QuickFormTestBase {
 
   /**

--- a/modules/quick/movement/tests/src/Kernel/QuickMovementTest.php
+++ b/modules/quick/movement/tests/src/Kernel/QuickMovementTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_quick_movement\Kernel;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS movement quick form.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickMovementTest extends QuickFormTestBase {
 
   /**

--- a/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
@@ -7,12 +7,14 @@ namespace Drupal\Tests\farm_quick_planting\Kernel;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS planting quick form.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class QuickPlantingTest extends QuickFormTestBase {
 
   /**

--- a/modules/role/account_admin/tests/src/Functional/UserAccessTest.php
+++ b/modules/role/account_admin/tests/src/Functional/UserAccessTest.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_account_admin\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests access to user 1.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class UserAccessTest extends FarmBrowserTestBase {
 
   /**

--- a/modules/role/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
+++ b/modules/role/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
@@ -6,12 +6,14 @@ namespace Drupal\Tests\farm_account_admin\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for Account Admin role permissions.
  *
  * @group farm
  */
+#[RunTestsInSeparateProcesses]
 class AccountAdminPermissionsTest extends KernelTestBase {
 
   use UserCreationTrait;


### PR DESCRIPTION
See https://www.drupal.org/node/3548485

These deprecation warnings are appearing in our tests:

```
1) /opt/drupal/web/core/tests/Drupal/Tests/BrowserTestBase.php:334
Functional/FunctionalJavascript test classes must specify the #[RunTestsInSeparateProcesses] attribute, not doing so is deprecated in drupal:11.3.0 and is throwing an exception in drupal:12.0.0. See https://www.drupal.org/node/3548485
```

```
77) /opt/drupal/web/core/tests/Drupal/KernelTests/KernelTestBase.php:237
Kernel test classes must specify the #[RunTestsInSeparateProcesses] attribute, not doing so is deprecated in drupal:11.3.0 and will throw an exception in drupal:12.0.0. See https://www.drupal.org/node/3548485
```

This change reduces the overall number of PHPUnit deprecations reported...

**Before:**

`Tests: 125, Assertions: 4422, Deprecations: 489, PHPUnit Deprecations: 272.`

Source: https://github.com/mstenta/farmOS/actions/runs/22943082369/job/66591778140

**After:**

`Tests: 125, Assertions: 4422, Deprecations: 502, PHPUnit Deprecations: 5.`

Source: https://github.com/farmOS/farmOS/actions/runs/22957506701/job/66642767116