### PR TITLE
Use #[Group('farm')] attribute instead of "@group farm" annotation in tests

### DIFF
--- a/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
+++ b/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_equipment\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the equipment used field.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class EquipmentFieldTest extends FarmBrowserTestBase {
 

--- a/modules/asset/group/tests/src/FunctionalJavascript/GroupTest.php
+++ b/modules/asset/group/tests/src/FunctionalJavascript/GroupTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_group\FunctionalJavascript;
 
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS group membership logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class GroupTest extends FarmWebDriverTestBase {
 

--- a/modules/asset/group/tests/src/Kernel/GroupTest.php
+++ b/modules/asset/group/tests/src/Kernel/GroupTest.php
@@ -12,13 +12,13 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS group membership logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class GroupTest extends KernelTestBase {
 

--- a/modules/asset/sensor/modules/listener/tests/src/Functional/SensorListenerApiTest.php
+++ b/modules/asset/sensor/modules/listener/tests/src/Functional/SensorListenerApiTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_sensor_listener\Functional;
 
 use Drupal\Tests\farm_sensor\Functional\SensorDataApiTest;
 use Drupal\asset\Entity\AssetInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test the sensor listener (legacy) API.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class SensorListenerApiTest extends SensorDataApiTest {
 

--- a/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
+++ b/modules/asset/sensor/tests/src/Functional/SensorDataApiTest.php
@@ -10,13 +10,13 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\asset\Entity\AssetInterface;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test the Sensor data API.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class SensorDataApiTest extends FarmBrowserTestBase {
 

--- a/modules/core/api/modules/farm_api_oauth/tests/src/Functional/CorsResponseEventSubscriberTest.php
+++ b/modules/core/api/modules/farm_api_oauth/tests/src/Functional/CorsResponseEventSubscriberTest.php
@@ -9,14 +9,14 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\consumers\Entity\Consumer;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * Tests that CORS headers are properly added.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class CorsResponseEventSubscriberTest extends FarmBrowserTestBase {
 

--- a/modules/core/api/modules/farm_api_oauth/tests/src/Functional/OauthTestBase.php
+++ b/modules/core/api/modules/farm_api_oauth/tests/src/Functional/OauthTestBase.php
@@ -8,8 +8,6 @@ use Drupal\Tests\simple_oauth\Functional\TokenBearerFunctionalTestBase;
 
 /**
  * Base class that handles common logic for OAuth tests.
- *
- * @group farm
  */
 abstract class OauthTestBase extends TokenBearerFunctionalTestBase {
 

--- a/modules/core/api/modules/farm_api_oauth/tests/src/Kernel/FarmApiOauthTestBase.php
+++ b/modules/core/api/modules/farm_api_oauth/tests/src/Kernel/FarmApiOauthTestBase.php
@@ -16,8 +16,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests farmOS API OAuth features.
- *
- * @group farm
  */
 abstract class FarmApiOauthTestBase extends FarmApiTest {
 

--- a/modules/core/api/tests/src/Functional/EntryPointTest.php
+++ b/modules/core/api/tests/src/Functional/EntryPointTest.php
@@ -9,13 +9,13 @@ use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the API entry point functionality.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class EntryPointTest extends FarmBrowserTestBase {
 

--- a/modules/core/api/tests/src/Kernel/FarmApiTest.php
+++ b/modules/core/api/tests/src/Kernel/FarmApiTest.php
@@ -9,15 +9,15 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\AssetInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests farmOS API features.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmApiTest extends KernelTestBase {
 

--- a/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
+++ b/modules/core/asset/tests/src/Functional/AssetCRUDTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\asset\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the asset CRUD.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class AssetCRUDTest extends AssetTestBase {
 

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/EmailDeliveryTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/EmailDeliveryTest.php
@@ -9,14 +9,14 @@ use Drupal\Core\Test\AssertMailTrait;
 use Drupal\Tests\data_stream\Kernel\DataStreamTestBase;
 use Drupal\Tests\data_stream\Traits\DataStreamCreationTrait;
 use Drupal\data_stream_notification\Entity\DataStreamNotification;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests email notification delivery.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class EmailDeliveryTest extends DataStreamTestBase {
 

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/NotificationTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/NotificationTest.php
@@ -8,15 +8,15 @@ use Drupal\Component\Serialization\Json;
 use Drupal\Tests\data_stream\Kernel\DataStreamTestBase;
 use Drupal\Tests\data_stream\Traits\DataStreamCreationTrait;
 use Drupal\data_stream_notification\Entity\DataStreamNotification;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Test functionality of data stream notification execution.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class NotificationTest extends DataStreamTestBase {
 

--- a/modules/core/data_stream/modules/notification/tests/src/Kernel/NumericConditionTest.php
+++ b/modules/core/data_stream/modules/notification/tests/src/Kernel/NumericConditionTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\data_stream_notification\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the numeric notification condition.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class NumericConditionTest extends KernelTestBase {
 

--- a/modules/core/data_stream/tests/src/Kernel/DataStreamTest.php
+++ b/modules/core/data_stream/tests/src/Kernel/DataStreamTest.php
@@ -6,14 +6,14 @@ namespace Drupal\Tests\data_stream\Kernel;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Tests\data_stream\Traits\DataStreamCreationTrait;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Test the basic data stream type.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class DataStreamTest extends DataStreamTestBase {
 

--- a/modules/core/data_stream/tests/src/Kernel/DataStreamTestBase.php
+++ b/modules/core/data_stream/tests/src/Kernel/DataStreamTestBase.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\data_stream\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Tests for Data Streams.
- *
- * @group farm
  */
+#[Group('farm')]
 abstract class DataStreamTestBase extends KernelTestBase {
 
   /**

--- a/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_entity\Functional;
 
 use Drupal\Core\Entity\Sql\SqlEntityStorageInterface;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests that bundle fields are created during a postponed install.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
 

--- a/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityRevisionsTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_entity\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test expected farmOS entity revision behavior.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmEntityRevisionsTest extends FarmBrowserTestBase {
 

--- a/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityFieldTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_entity\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS entity fields.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmEntityFieldTest extends KernelTestBase {
 

--- a/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
+++ b/modules/core/entity/tests/src/Kernel/FarmEntityRevisionsTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_entity\Kernel;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS entity revisions.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmEntityRevisionsTest extends KernelTestBase {
 

--- a/modules/core/flag/tests/src/Kernel/FlagTest.php
+++ b/modules/core/flag/tests/src/Kernel/FlagTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_flag\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\farm_flag\Entity\FarmFlag;
 use Drupal\farm_flag\FarmFlagHelper;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farm_flag logic.
- *
- * @group farm_flag
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FlagTest extends KernelTestBase {
 

--- a/modules/core/id_tag/tests/src/Kernel/IdTagTest.php
+++ b/modules/core/id_tag/tests/src/Kernel/IdTagTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_id_tag\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test ID tag field.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class IdTagTest extends KernelTestBase {
 

--- a/modules/core/image/tests/src/Functional/ImageEffectsTest.php
+++ b/modules/core/image/tests/src/Functional/ImageEffectsTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_image\Functional;
 use Drupal\Core\File\FileExists;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\image\Entity\ImageStyle;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for the farm_image image effects.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class ImageEffectsTest extends FarmBrowserTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Functional/CsvImportTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_import_csv\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS CSV importers.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class CsvImportTest extends FarmBrowserTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/AssetCsvImportTest.php
@@ -8,13 +8,13 @@ use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for asset CSV importers.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class AssetCsvImportTest extends CsvImportTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/ConfigCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/ConfigCsvImportTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for config CSV importers.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class ConfigCsvImportTest extends CsvImportTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportDatabaseTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportDatabaseTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for CSV import database table.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class CsvImportDatabaseTest extends CsvImportTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportMigrationGroupTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportMigrationGroupTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Drupal\Tests\farm_import_csv\Kernel;
 
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for CSV import migration group.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class CsvImportMigrationGroupTest extends CsvImportTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/CsvImportTestBase.php
@@ -11,8 +11,6 @@ use Drupal\file\Entity\File;
 
 /**
  * Base class for farmOS CSV importer kernel tests.
- *
- * @group farm
  */
 abstract class CsvImportTestBase extends MigrateTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/LogCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/LogCsvImportTest.php
@@ -8,13 +8,13 @@ use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for log CSV importers.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LogCsvImportTest extends CsvImportTestBase {
 

--- a/modules/core/import/modules/csv/tests/src/Kernel/TermCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/TermCsvImportTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_import_csv\Kernel;
 
 use Drupal\taxonomy\Entity\Term;
 use Drupal\text\Plugin\Field\FieldType\TextLongItem;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for taxonomy term CSV importers.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class TermCsvImportTest extends CsvImportTestBase {
 

--- a/modules/core/inventory/tests/src/Functional/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Functional/InventoryTest.php
@@ -10,13 +10,13 @@ use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS inventory logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class InventoryTest extends FarmBrowserTestBase {
 

--- a/modules/core/inventory/tests/src/Kernel/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Kernel/InventoryTest.php
@@ -12,13 +12,13 @@ use Drupal\fraction\Fraction;
 use Drupal\log\Entity\Log;
 use Drupal\quantity\Entity\Quantity;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS inventory logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class InventoryTest extends KernelTestBase {
 

--- a/modules/core/l10n/tests/src/Kernel/FarmLocalizationApiTest.php
+++ b/modules/core/l10n/tests/src/Kernel/FarmLocalizationApiTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_l10n\Kernel;
 
 use Drupal\Tests\farm_api\Kernel\FarmApiTest;
 use Drupal\language\Entity\ConfigurableLanguage;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS API features.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmLocalizationApiTest extends FarmApiTest {
 

--- a/modules/core/location/tests/src/Functional/LocationAPITest.php
+++ b/modules/core/location/tests/src/Functional/LocationAPITest.php
@@ -10,13 +10,13 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\farm_geo\Traits\WktTrait;
 use GuzzleHttp\RequestOptions;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for the location api.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LocationAPITest extends FarmBrowserTestBase {
 

--- a/modules/core/location/tests/src/FunctionalJavascript/LocationTest.php
+++ b/modules/core/location/tests/src/FunctionalJavascript/LocationTest.php
@@ -9,13 +9,13 @@ use Drupal\Tests\farm_location\Functional\LocationFunctionalTestTrait;
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
 use Drupal\Tests\jsonapi\Functional\JsonApiRequestTestTrait;
 use Drupal\farm_geo\Traits\WktTrait;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS location logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LocationTest extends FarmWebDriverTestBase {
 

--- a/modules/core/location/tests/src/Kernel/LocationTest.php
+++ b/modules/core/location/tests/src/Kernel/LocationTest.php
@@ -12,13 +12,13 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\farm_geo\Traits\WktTrait;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS location logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LocationTest extends KernelTestBase {
 

--- a/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
+++ b/modules/core/log/modules/quantity/tests/src/Kernel/LogQuantityTest.php
@@ -8,13 +8,13 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\log\Entity\Log;
 use Drupal\log\Event\LogEvent;
 use Drupal\quantity\Entity\Quantity;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS log quantity module.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LogQuantityTest extends KernelTestBase {
 

--- a/modules/core/log/tests/src/Kernel/LogTest.php
+++ b/modules/core/log/tests/src/Kernel/LogTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_log\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS log module.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LogTest extends KernelTestBase {
 

--- a/modules/core/login/tests/src/Functional/OauthPasswordTest.php
+++ b/modules/core/login/tests/src/Functional/OauthPasswordTest.php
@@ -6,6 +6,7 @@ namespace Drupal\tests\farm_login\Functional;
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Tests\farm_api_oauth\Functional\OauthTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
@@ -14,9 +15,8 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * These tests are based on the simple_oauth PasswordFunctionalTests.
  *
  * @see \Drupal\Tests\simple_oauth\Functional\PasswordFunctionalTest
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class OauthPasswordTest extends OauthTestBase {
 

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -9,6 +9,7 @@ use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
@@ -17,9 +18,8 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
  * These tests are based on the core UserLoginTests.
  *
  * @see \Drupal\Tests\farm_login\Functional\UserLoginTest
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class UserLoginTest extends FarmBrowserTestBase {
 

--- a/modules/core/map/src/Event/MapRenderEvent.php
+++ b/modules/core/map/src/Event/MapRenderEvent.php
@@ -10,8 +10,6 @@ use Drupal\farm_map\Entity\MapTypeInterface;
 
 /**
  * An event that is dispatched before rendering a map on the page.
- *
- * @group farm
  */
 class MapRenderEvent extends Event {
 

--- a/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
+++ b/modules/core/map/tests/src/Functional/GeofieldWidgetTest.php
@@ -9,13 +9,13 @@ use Drupal\Tests\field\Functional\FieldTestBase;
 use Drupal\entity_test\Entity\EntityTest;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS Geofield widget.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class GeofieldWidgetTest extends FieldTestBase {
 

--- a/modules/core/map/tests/src/Functional/MapFormTest.php
+++ b/modules/core/map/tests/src/Functional/MapFormTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_map\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS map form element.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class MapFormTest extends FarmBrowserTestBase {
 

--- a/modules/core/organization/tests/src/Functional/OrganizationCRUDTest.php
+++ b/modules/core/organization/tests/src/Functional/OrganizationCRUDTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\organization\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\organization\Entity\Organization;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the organization CRUD.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class OrganizationCRUDTest extends OrganizationTestBase {
 

--- a/modules/core/owner/tests/src/Kernel/LogOwnerTest.php
+++ b/modules/core/owner/tests/src/Kernel/LogOwnerTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_owner\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS log owner logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class LogOwnerTest extends KernelTestBase {
 

--- a/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
+++ b/modules/core/plan/tests/src/Functional/PlanCRUDTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\plan\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\plan\Entity\Plan;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the plan CRUD.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class PlanCRUDTest extends PlanTestBase {
 

--- a/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
+++ b/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\plan\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\plan\Entity\Plan;
 use Drupal\plan\Entity\PlanRecord;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for plan_record entities.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class PlanRecordTest extends KernelTestBase {
 

--- a/modules/core/quick/tests/src/Functional/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Functional/QuickFormTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_quick\Functional;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\farm_quick\Entity\QuickFormInstance;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the quick form framework.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickFormTest extends FarmBrowserTestBase {
 

--- a/modules/core/quick/tests/src/Kernel/QuickFormTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTest.php
@@ -9,13 +9,13 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\farm_quick\Form\QuickFormEntityForm;
 use Drupal\farm_quick\Plugin\QuickForm\ConfigurableQuickFormInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS quick forms.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickFormTest extends KernelTestBase {
 

--- a/modules/core/quick/tests/src/Kernel/QuickFormTestBase.php
+++ b/modules/core/quick/tests/src/Kernel/QuickFormTestBase.php
@@ -11,8 +11,6 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 /**
  * Base class that modules can use to test their quick forms.
  *
- * @group farm
- *
  * @internal
  */
 abstract class QuickFormTestBase extends KernelTestBase {

--- a/modules/core/quick/tests/src/Kernel/QuickStringTest.php
+++ b/modules/core/quick/tests/src/Kernel/QuickStringTest.php
@@ -8,13 +8,13 @@ use Drupal\KernelTests\KernelTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\asset\Entity\AssetType;
 use Drupal\farm_quick\Traits\QuickStringTrait;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for quick string trait methods.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickStringTest extends KernelTestBase {
 

--- a/modules/core/role/tests/src/Kernel/FarmApiOauthRoleTest.php
+++ b/modules/core/role/tests/src/Kernel/FarmApiOauthRoleTest.php
@@ -7,14 +7,14 @@ namespace Drupal\Tests\farm_role\Kernel;
 use Drupal\Tests\farm_api_oauth\Kernel\FarmApiOauthTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Tests farmOS API OAuth features.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmApiOauthRoleTest extends FarmApiOauthTestBase {
 

--- a/modules/core/role/tests/src/Kernel/ManagedRolePermissionsTest.php
+++ b/modules/core/role/tests/src/Kernel/ManagedRolePermissionsTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_role\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\user\Entity\Role;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for Managed Role permissions.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class ManagedRolePermissionsTest extends KernelTestBase {
 

--- a/modules/core/role/tests/src/Kernel/ScopeGranularityTest.php
+++ b/modules/core/role/tests/src/Kernel/ScopeGranularityTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_role\Kernel;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\simple_oauth\Entity\Oauth2Scope;
 use Drupal\simple_oauth\Oauth2ScopeProviderInterface;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the managed role permissions scope granularity.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class ScopeGranularityTest extends KernelTestBase {
 

--- a/modules/core/setup/tests/src/Functional/SetupWizardTest.php
+++ b/modules/core/setup/tests/src/Functional/SetupWizardTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_setup\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for the farmOS setup wizard.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class SetupWizardTest extends FarmBrowserTestBase {
 

--- a/modules/core/setup/tests/src/FunctionalJavascript/ModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/ModulesFormTest.php
@@ -6,15 +6,15 @@ namespace Drupal\Tests\farm_setup\FunctionalJavascript;
 
 use Drupal\FunctionalJavascriptTests\JSWebAssert;
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests installing modules via the module settings form.
  *
- * @group farm
- *
  * @see \Drupal\farm_setup\Form\FarmModulesForm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class ModulesFormTest extends FarmWebDriverTestBase {
 

--- a/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
+++ b/modules/core/setup/tests/src/FunctionalJavascript/SetupModulesFormTest.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_setup\FunctionalJavascript;
 
 use Drupal\Tests\farm_test\FunctionalJavascript\FarmWebDriverTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests installing modules via the setup wizard modules form.
  *
- * @group farm
- *
  * @see \Drupal\farm_setup\Plugin\SetupForm\SetupModulesForm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class SetupModulesFormTest extends FarmWebDriverTestBase {
 

--- a/modules/core/ui/action/tests/src/Functional/ActionsTest.php
+++ b/modules/core/ui/action/tests/src/Functional/ActionsTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_ui_action\Functional;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS action functionality.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class ActionsTest extends FarmBrowserTestBase {
 

--- a/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
+++ b/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_ui_dashboard\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farmOS dashboard functionality.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class DashboardTest extends FarmBrowserTestBase {
 

--- a/modules/core/ui/menu/tests/src/Kernel/FarmSecondaryTaskTest.php
+++ b/modules/core/ui/menu/tests/src/Kernel/FarmSecondaryTaskTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_ui_menu\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\farm_ui_menu\Menu\EntityTypeLabelLocalTask;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests farmOS secondary task links.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmSecondaryTaskTest extends KernelTestBase {
 

--- a/modules/core/ui/theme/tests/src/Functional/FarmBlockTest.php
+++ b/modules/core/ui/theme/tests/src/Functional/FarmBlockTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_ui_theme\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the "Powered by farmOS" block.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmBlockTest extends FarmBrowserTestBase {
 

--- a/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_ui_views\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\log\Entity\Log;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm_ui_views dashboard panes.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class DashboardTasksTest extends FarmBrowserTestBase {
 

--- a/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
+++ b/modules/core/ui/views/tests/src/Functional/FarmUiViewsTest.php
@@ -9,13 +9,13 @@ use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\organization\Entity\Organization;
 use Drupal\quantity\Entity\Quantity;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm_ui_views Views.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmUiViewsTest extends FarmBrowserTestBase {
 

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_ui_views\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm_ui_views taxonomy views routes.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class TaxonomyTermTasksTest extends FarmBrowserTestBase {
 

--- a/modules/core/update/tests/src/Kernel/FarmUpdateTest.php
+++ b/modules/core/update/tests/src/Kernel/FarmUpdateTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_update\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS Update module.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmUpdateTest extends KernelTestBase {
 

--- a/modules/log/birth/tests/src/Kernel/BirthTest.php
+++ b/modules/log/birth/tests/src/Kernel/BirthTest.php
@@ -10,13 +10,13 @@ use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\asset\Entity\Asset;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS birth log logic.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class BirthTest extends KernelTestBase {
 

--- a/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
+++ b/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
@@ -8,15 +8,15 @@ use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
 use Drupal\log\Entity\Log;
 use Drupal\quantity\Entity\Quantity;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Test material type filter functionality.
  *
  * @see \Drupal\farm_input\Plugin\views\filter\LogQuantityMaterialType
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class InputViewMaterialTypeTest extends FarmBrowserTestBase {
 

--- a/modules/organization/farm/tests/src/Functional/FarmFieldTest.php
+++ b/modules/organization/farm/tests/src/Functional/FarmFieldTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_farm\Functional;
 
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests the farm reference field.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FarmFieldTest extends FarmBrowserTestBase {
 

--- a/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
+++ b/modules/organization/farm/tests/src/Kernel/FieldConstraintsTest.php
@@ -11,13 +11,13 @@ use Drupal\farm_farm\Plugin\Validation\Constraint\AssetMovementFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\AssetParentFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\LogGroupAssignmentFarm;
 use Drupal\farm_farm\Plugin\Validation\Constraint\LogMovementFarm;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Field constraint tests for Farm organization module.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class FieldConstraintsTest extends KernelTestBase {
 

--- a/modules/quick/birth/tests/src/Kernel/QuickBirthTest.php
+++ b/modules/quick/birth/tests/src/Kernel/QuickBirthTest.php
@@ -10,13 +10,13 @@ use Drupal\asset\Entity\Asset;
 use Drupal\farm_id_tag\Plugin\Field\FieldType\IdTagItem;
 use Drupal\log\Entity\Log;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS birth quick form.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickBirthTest extends QuickFormTestBase {
 

--- a/modules/quick/group/tests/src/Kernel/QuickGroupTest.php
+++ b/modules/quick/group/tests/src/Kernel/QuickGroupTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_quick_group\Kernel;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS group quick form.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickGroupTest extends QuickFormTestBase {
 

--- a/modules/quick/inventory/tests/src/Kernel/QuickInventoryTest.php
+++ b/modules/quick/inventory/tests/src/Kernel/QuickInventoryTest.php
@@ -8,13 +8,13 @@ use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS inventory quick form.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickInventoryTest extends QuickFormTestBase {
 

--- a/modules/quick/movement/tests/src/Kernel/QuickMovementTest.php
+++ b/modules/quick/movement/tests/src/Kernel/QuickMovementTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_quick_movement\Kernel;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS movement quick form.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickMovementTest extends QuickFormTestBase {
 

--- a/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
+++ b/modules/quick/planting/tests/src/Kernel/QuickPlantingTest.php
@@ -7,13 +7,13 @@ namespace Drupal\Tests\farm_quick_planting\Kernel;
 use Drupal\Tests\farm_quick\Kernel\QuickFormTestBase;
 use Drupal\asset\Entity\Asset;
 use Drupal\taxonomy\Entity\Term;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for farmOS planting quick form.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class QuickPlantingTest extends QuickFormTestBase {
 

--- a/modules/role/account_admin/tests/src/Functional/UserAccessTest.php
+++ b/modules/role/account_admin/tests/src/Functional/UserAccessTest.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Drupal\Tests\farm_account_admin\Functional;
 
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests access to user 1.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class UserAccessTest extends FarmBrowserTestBase {
 

--- a/modules/role/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
+++ b/modules/role/account_admin/tests/src/Kernel/AccountAdminPermissionsTest.php
@@ -6,13 +6,13 @@ namespace Drupal\Tests\farm_account_admin\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\Tests\user\Traits\UserCreationTrait;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
 /**
  * Tests for Account Admin role permissions.
- *
- * @group farm
  */
+#[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class AccountAdminPermissionsTest extends KernelTestBase {
 


### PR DESCRIPTION
Follow up to #1065... this converts the `@group farm` annotation in all of our tests to use the `#[Group('farm')]` attribute instead. It also removes `@group` annotations from classes that shouldn't have it (like abstract base classes).