### PR TITLE
Fix doc header outline for OAuth section in hosting/install

### DIFF
--- a/docs/hosting/install.md
+++ b/docs/hosting/install.md
@@ -101,7 +101,7 @@ host system does not have the ability to configure cron jobs. It can cause
 random requests to farmOS to be very slow, as the cron tasks are tacked onto
 the normal page loading process.
 
-# OAuth2 keys
+### OAuth2 keys
 
 If you need to connect to the farmOS API from an outside source, you will need
 to install the farmOS API OAuth2 Server module (`farm_api_oauth`) and generate


### PR DESCRIPTION
This is a very minor tweak, and feel free to ignore if I'm mistaken.  But it seemed to me the "OAuth2 keys" section was not behaving somehow.  In particular it did not appear in the table of contents (top right) at least on my screen..  I think this will fix, but didn't attempt to actually "build" the docs site, so not 100% sure.

<img width="930" height="790" alt="Screenshot from 2026-03-11 19-43-37" src="https://github.com/user-attachments/assets/90559fa3-640d-4584-8c9e-1aec4bc72bfe" />
