### PR TITLE
Add a bulk action for abandoning logs

### DIFF
--- a/modules/core/log/config/optional/system.action.log_mark_as_abandoned_action.yml
+++ b/modules/core/log/config/optional/system.action.log_mark_as_abandoned_action.yml
@@ -1,0 +1,11 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - farm_log
+    - log
+id: log_mark_as_abandoned_action
+label: 'Mark as abandoned'
+type: log
+plugin: log_mark_as_abandoned_action
+configuration: {  }

--- a/modules/core/log/config/schema/farm_log.schema.yml
+++ b/modules/core/log/config/schema/farm_log.schema.yml
@@ -1,0 +1,3 @@
+action.configuration.log_mark_as_abandoned_action:
+  type: action_configuration_default
+  label: 'Configuration for the log mark as abandoned action'

--- a/modules/core/log/farm_log.post_update.php
+++ b/modules/core/log/farm_log.post_update.php
@@ -35,3 +35,25 @@ function farm_log_post_update_move_asset_add_log_action(&$sandbox) {
     }
   }
 }
+
+/**
+ * Add 'Mark As Abandoned' option to actions.
+ */
+function farm_log_post_update_add_abandoned_status_action(&$sandbox) {
+
+  // Create action for assigning abandoned status to logs.
+  $action = Action::create([
+    'id' => 'log_mark_as_abandoned_action',
+    'label' => t('Mark as abandoned'),
+    'type' => 'log',
+    'plugin' => 'log_mark_as_abandoned_action',
+    'configuration' => [],
+    'dependencies' => [
+      'module' => [
+        'farm_log',
+        'log',
+      ],
+    ],
+  ]);
+  $action->save();
+}

--- a/modules/core/log/src/Plugin/Action/LogMarkAsAbandoned.php
+++ b/modules/core/log/src/Plugin/Action/LogMarkAsAbandoned.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_log\Plugin\Action;
+
+use Drupal\Core\Action\Attribute\Action;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\log\Plugin\Action\LogStateChangeBase;
+
+/**
+ * Action that marks a log as abandoned.
+ */
+#[Action(
+  id: 'log_mark_as_abandoned_action',
+  label: new TranslatableMarkup('Sets a Log as abandoned'),
+  type: 'log',
+)]
+
+class LogMarkAsAbandoned extends LogStateChangeBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $targetState = 'abandoned';
+
+}


### PR DESCRIPTION
Adds a "MarkAsAbandoned” action to the Logs View to support the new “Abandoned” status.