### PR TITLE
Remove Drupal core patch that adds EntityFieldManager::rebuildBundleFieldMap()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- [EntityFieldManager::rebuildBundleFieldMap() is deprecated](https://www.drupal.org/node/3591108)
+
 ### Fixed
 
 - [Fix dashboard block title access #1075](https://github.com/farmOS/farmOS/pull/1075)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.5",
-        "drupal/core": "11.3.8",
+        "drupal/core": "11.3.9",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.22",
         "drupal/csv_serialization": "^4.0.1",

--- a/composer.json
+++ b/composer.json
@@ -62,8 +62,7 @@
             "drupal/core": {
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2025-12-23/2339235-96.patch",
                 "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
-                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch",
-                "Issue #3129179: Provide some way to rebuild the persistent bundle field map": "https://www.drupal.org/files/issues/2025-06-25/3129179-55.patch"
+                "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch"
             },
             "drupal/entity": {
                 "Issue #3206703: Provide reverse relationships for bundle plugin entity_reference fields.": "https://www.drupal.org/files/issues/2024-08-30/3206703-12.patch"

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "11.3.8"
+        "drupal/core-composer-scaffold": "11.3.9"
     },
     "require-dev": {
         "behat/mink": "^1.11",

--- a/docs/development/module/fields.md
+++ b/docs/development/module/fields.md
@@ -193,7 +193,6 @@ function mymodule_post_update_add_myfield(&$sandbox) {
   ];
   $field_definition = \Drupal::service('farm_field.factory')->bundleFieldDefinition($options);
   \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition('myfield', 'log', 'mymodule', $field_definition);
-  \Drupal::service('entity_field.manager')->rebuildBundleFieldMap();
 }
 ```
 
@@ -212,11 +211,6 @@ There are a few things to make note of in this example:
    the field can be used on.
 3. This example installs a bundle field. To install a base field, replace
    `->bundleFieldDefinition($options)` with `->baseFieldDefinition($options)`.
-4. The last line (which calls `rebuildBundleFieldMap()`) is technically only
-   necessary when installing bundle fields, but it doesn't hurt to include it
-   for base fields as well. The reason this is necessary is to work around an
-   outstanding Drupal core issue:
-   [Issue #3045509: EntityFieldManager::getFieldMap() doesn't show bundle fields](https://www.drupal.org/project/drupal/issues/3045509)
 
 ### Views and CSV Importers
 

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -1,11 +1,6 @@
 services:
   _defaults:
     autowire: true
-  farm_entity.entity_field_manager:
-    class: Drupal\farm_entity\Entity\EntityFieldManager
-    arguments: [ '@entity_type.manager', '@entity_type.bundle.info', '@entity_display.repository', '@typed_data_manager', '@language_manager', '@keyvalue', '@module_handler', '@cache.discovery', '@entity.last_installed_schema.repository' ]
-    decorates: entity_field.manager
-    decoration_priority: -100
   farm_entity.bundle_plugin_installer:
     class: Drupal\farm_entity\BundlePlugin\BundlePluginInstaller
     decorates: entity.bundle_plugin_installer

--- a/modules/core/entity/farm_entity.services.yml
+++ b/modules/core/entity/farm_entity.services.yml
@@ -1,6 +1,11 @@
 services:
   _defaults:
     autowire: true
+  farm_entity.entity_field_manager:
+    class: Drupal\farm_entity\Entity\EntityFieldManager
+    arguments: [ '@entity_type.manager', '@entity_type.bundle.info', '@entity_display.repository', '@typed_data_manager', '@language_manager', '@keyvalue', '@module_handler', '@cache.discovery', '@entity.last_installed_schema.repository' ]
+    decorates: entity_field.manager
+    decoration_priority: -100
   farm_entity.bundle_plugin_installer:
     class: Drupal\farm_entity\BundlePlugin\BundlePluginInstaller
     decorates: entity.bundle_plugin_installer

--- a/modules/core/entity/src/Entity/EntityFieldManager.php
+++ b/modules/core/entity/src/Entity/EntityFieldManager.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity\Entity;
+
+use Drupal\Core\Entity\EntityFieldManager as CoreEntityFieldManager;
+
+/**
+ * Extends the Drupal core EntityFieldManager service.
+ *
+ * Temporarily adds the rebuildBundleFieldMap() method until farmOS 5.x.
+ *
+ * @deprecated in farm:4.0.2 and is removed from farm:5.0.0. No replacement is
+ *   necessary.
+ * @see https://www.drupal.org/node/3591108
+ */
+class EntityFieldManager extends CoreEntityFieldManager {
+
+  /**
+   * This is a no-op method to maintain backwards compatibility in farmOS 4.x.
+   *
+   * @deprecated in farm:4.0.2 and is removed from farm:5.0.0. No replacement is
+   *   necessary.
+   * @see https://www.drupal.org/node/3591108
+   */
+  public function rebuildBundleFieldMap() {
+    @trigger_error('EntityFieldManager::rebuildBundleFieldMap() is deprecated in farm:4.0.2 and is removed from farm:5.0.0. No replacement is necessary. See https://www.drupal.org/node/3591108', E_USER_DEPRECATED);
+  }
+
+}

--- a/modules/core/entity/src/FarmEntityServiceProvider.php
+++ b/modules/core/entity/src/FarmEntityServiceProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_entity;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+/**
+ * Overrides the entity_field.manager service.
+ *
+ * @deprecated in farm:4.0.2 and is removed from farm:5.0.0. No replacement is
+ *   necessary.
+ * @see https://www.drupal.org/node/3591108
+ */
+class FarmEntityServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    if ($container->hasDefinition('entity_field.manager')) {
+      $definition = $container->getDefinition('entity_field.manager');
+      $definition->setClass('Drupal\farm_entity\Entity\EntityFieldManager');
+    }
+  }
+
+}

--- a/modules/core/entity/src/Hook/FieldHooks.php
+++ b/modules/core/entity/src/Hook/FieldHooks.php
@@ -6,7 +6,6 @@ namespace Drupal\farm_entity\Hook;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\DependencyInjection\AutowireTrait;
-use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -21,32 +20,11 @@ class FieldHooks {
   use AutowireTrait;
 
   public function __construct(
-    protected EntityFieldManagerInterface $entityFieldManager,
     protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
     protected ModuleHandlerInterface $moduleHandler,
     protected AccountInterface $currentUser,
     protected TimeInterface $time,
   ) {}
-
-  /**
-   * Implements hook_modules_installed().
-   */
-  #[Hook('modules_installed')]
-  public function modulesInstalled($modules, $is_syncing) {
-
-    // Rebuild bundle field map when modules are installed.
-    $this->entityFieldManager->rebuildBundleFieldMap();
-  }
-
-  /**
-   * Implements hook_modules_uninstalled().
-   */
-  #[Hook('modules_uninstalled')]
-  public function modulesUninstalled($modules, $is_syncing) {
-
-    // Rebuild bundle field map when modules are uninstalled.
-    $this->entityFieldManager->rebuildBundleFieldMap();
-  }
 
   /**
    * Implements hook_entity_field_storage_info_alter().

--- a/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
+++ b/modules/core/entity/tests/src/Functional/FarmEntityBundleFieldTest.php
@@ -130,6 +130,11 @@ class FarmEntityBundleFieldTest extends FarmBrowserTestBase {
     // Must clear the cache for the test environment.
     $this->entityFieldManager->clearCachedFieldDefinitions();
 
+    // Reload the entity field map. We need to get a new instance of the
+    // entity_field.manager service from the container without old state.
+    $this->container->set('entity_field.manager', NULL);
+    $this->entityFieldManager = $this->container->get('entity_field.manager');
+
     // Test bundle field definition exists.
     $fields = $this->entityFieldManager->getFieldDefinitions('log', 'test');
     $this->assertArrayHasKey('test_contrib_hook_bundle_field', $fields);


### PR DESCRIPTION
This was originally added to fix the following bug: https://www.drupal.org/project/farm/issues/3314741

It introduced a Drupal core patch from this issue: https://www.drupal.org/project/drupal/issues/3129179

This is no longer necessary because of this Drupal core change: https://www.drupal.org/project/drupal/issues/3045509