### PR TITLE
Fix dashboard block title access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Fix dashboard block title access #1075](https://github.com/farmOS/farmOS/pull/1075)
+
 ## [4.0.1] 2026-04-16
 
 ### Security

--- a/modules/core/ui/dashboard/src/Controller/DashboardController.php
+++ b/modules/core/ui/dashboard/src/Controller/DashboardController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_dashboard\Controller;
 
+use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\DependencyInjection\AutowireTrait;
@@ -84,16 +85,22 @@ class DashboardController extends ControllerBase {
       // Or if a block is provided, display the block.
       elseif (!empty($pane['block'])) {
 
-        // Render plugin block if is set.
-        $block = $this->blockManager->createInstance($pane['block'], $args);
+        // Create an instance of the block plugin.
+        // Skip if a plugin exception is thrown.
+        try {
+          $block = $this->blockManager->createInstance($pane['block'], $args);
+        }
+        catch (PluginException $e) {
+          continue;
+        }
 
-        // Check block access.
-        $access_result = $block->access($this->currentUser());
+        // Skip if block access check fails.
+        if (!$block->access($this->currentUser())) {
+          continue;
+        }
 
         // Build renderable array of the block.
-        if ($access_result == TRUE) {
-          $output = $block->build();
-        }
+        $output = $block->build();
       }
 
       // If a specific title was provided, use it.

--- a/modules/core/ui/dashboard/tests/modules/dashboard_test/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/dashboard/tests/modules/dashboard_test/src/Hook/ThemeHooks.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_dashboard_test\Hook;
 
 use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
  * Theme hook implementations for farm_ui_dashboard_test.
  */
 class ThemeHooks {
+
+  use StringTranslationTrait;
 
   /**
    * Implements hook_farm_dashboard_panes().
@@ -18,6 +21,7 @@ class ThemeHooks {
   public function farmDashboardPanes() {
     return [
       'dashboard_block' => [
+        'title' => $this->t('Test block title'),
         'block' => 'dashboard_test_block',
       ],
       'dashboard_view' => [

--- a/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
+++ b/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
@@ -57,6 +57,7 @@ class DashboardTest extends FarmBrowserTestBase {
     $this->assertSession()->statusCodeEquals(200);
 
     // Assert that the test block was not added to the dashboard.
+    $this->assertSession()->pageTextNotContains('Test block title');
     $this->assertSession()->pageTextNotContains('This is the dashboard test block.');
 
     // Grant permission to view the block.
@@ -66,6 +67,7 @@ class DashboardTest extends FarmBrowserTestBase {
     // Assert that the test block was added to the dashboard.
     $this->drupalGet('/dashboard');
     $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Test block title');
     $this->assertSession()->pageTextContains('This is the dashboard test block.');
   }
 


### PR DESCRIPTION
I discovered a minor bug with the way we check access on farmOS dashboard blocks.

Currently, we are checking block access before we build the block content, so the content of the block is not visible to users that don't have access:

https://github.com/farmOS/farmOS/blob/6529ab7569bff35a7160329ad004884642ee41e6/modules/core/ui/dashboard/src/Controller/DashboardController.php#L90-L96

However, we are not stopping the rest of the dashboard pane building process at that point. So a user will still see an empty dashboard pane with the pane title.

By contrast, we do skip building panes for Views if their access check fails: https://github.com/farmOS/farmOS/blob/6529ab7569bff35a7160329ad004884642ee41e6/modules/core/ui/dashboard/src/Controller/DashboardController.php#L69-L72

This PR fixes this issue by stopping skipping the rest of the pane build process if the user doesn't have access to the block. It also adds additional test coverage for this.

Another small tweak I included: if an invalid block ID is provided, it used to throw an exception. Now it will catch that and skip the pane build process in the same way.