### PR TITLE
Add an asset search block to the dashboard

### DIFF
--- a/modules/core/ui/farm_ui.info.yml
+++ b/modules/core/ui/farm_ui.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - farm:farm_ui_map
   - farm:farm_ui_menu
   - farm:farm_ui_metrics
+  - farm:farm_ui_search
   - farm:farm_ui_term
   - farm:farm_ui_theme
   - farm:farm_ui_user

--- a/modules/core/ui/farm_ui.post_update.php
+++ b/modules/core/ui/farm_ui.post_update.php
@@ -15,3 +15,12 @@ function farm_ui_post_update_install_farm_ui_term() {
     \Drupal::service('module_installer')->install(['farm_ui_term']);
   }
 }
+
+/**
+ * Install the farm_ui_search module.
+ */
+function farm_ui_post_update_install_farm_ui_search() {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_ui_search')) {
+    \Drupal::service('module_installer')->install(['farm_ui_search']);
+  }
+}

--- a/modules/core/ui/search/farm_ui_search.info.yml
+++ b/modules/core/ui/search/farm_ui_search.info.yml
@@ -1,0 +1,8 @@
+name: farmOS UI Search
+description: Adds a dashboard pane with search features.
+type: module
+package: farmOS UI
+core_version_requirement: ^11
+dependencies:
+  - farm:farm_ui_dashboard
+  - farm:farm_ui_views

--- a/modules/core/ui/search/src/Form/AssetSearchForm.php
+++ b/modules/core/ui/search/src/Form/AssetSearchForm.php
@@ -29,6 +29,7 @@ class AssetSearchForm extends FormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Asset search'),
       '#title_display' => 'invisible',
+      '#placeholder' => $this->t('Search assets'),
     ];
 
     // Search submit button.

--- a/modules/core/ui/search/src/Form/AssetSearchForm.php
+++ b/modules/core/ui/search/src/Form/AssetSearchForm.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_search\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Asset search form.
+ */
+class AssetSearchForm extends FormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_ui_search_asset_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // Asset search textfield.
+    $form['asset_search'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Asset search'),
+      '#title_display' => 'invisible',
+    ];
+
+    // Search submit button.
+    $form['actions'] = [
+      '#type' => 'actions',
+      '#weight' => 1000,
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Search'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // Redirect to the farm_asset View page display with the name exposed filter
+    // pre-populated.
+    $form_state->setRedirect('view.farm_asset.page', [], ['query' => ['name' => $form_state->getValue('asset_search')]]);
+  }
+
+}

--- a/modules/core/ui/search/src/Form/AssetSearchForm.php
+++ b/modules/core/ui/search/src/Form/AssetSearchForm.php
@@ -24,8 +24,17 @@ class AssetSearchForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
+    $form['search'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'class' => [
+          'inline-container',
+        ],
+      ],
+    ];
+
     // Asset search textfield.
-    $form['asset_search'] = [
+    $form['search']['asset_search'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Asset search'),
       '#title_display' => 'invisible',
@@ -33,11 +42,7 @@ class AssetSearchForm extends FormBase {
     ];
 
     // Search submit button.
-    $form['actions'] = [
-      '#type' => 'actions',
-      '#weight' => 1000,
-    ];
-    $form['actions']['submit'] = [
+    $form['search']['submit'] = [
       '#type' => 'submit',
       '#value' => $this->t('Search'),
     ];

--- a/modules/core/ui/search/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/search/src/Hook/ThemeHooks.php
@@ -22,7 +22,6 @@ class ThemeHooks {
     return [
       'asset_search' => [
         'block' => 'farm_asset_search_block',
-        'title' => $this->t('Search assets'),
         'region' => 'top',
         'weight' => -100,
       ],

--- a/modules/core/ui/search/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/search/src/Hook/ThemeHooks.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_search\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Theme hook implementations for farm_ui_search.
+ */
+class ThemeHooks {
+
+  use StringTranslationTrait;
+
+  /**
+   * Implements hook_farm_dashboard_panes().
+   */
+  #[Hook('farm_dashboard_panes')]
+  public function farmDashboardPanes() {
+    return [
+      'asset_search' => [
+        'block' => 'farm_asset_search_block',
+        'title' => $this->t('Search assets'),
+        'region' => 'second',
+        'weight' => -100,
+      ],
+    ];
+  }
+
+}

--- a/modules/core/ui/search/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/search/src/Hook/ThemeHooks.php
@@ -23,7 +23,7 @@ class ThemeHooks {
       'asset_search' => [
         'block' => 'farm_asset_search_block',
         'title' => $this->t('Search assets'),
-        'region' => 'second',
+        'region' => 'top',
         'weight' => -100,
       ],
     ];

--- a/modules/core/ui/search/src/Plugin/Block/AssetSearchBlock.php
+++ b/modules/core/ui/search/src/Plugin/Block/AssetSearchBlock.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_search\Plugin\Block;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Block\Attribute\Block;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+/**
+ * Provides a 'Search assets' block.
+ */
+#[Block(
+  id: 'farm_asset_search_block',
+  admin_label: new TranslatableMarkup('Asset Search'),
+)]
+class AssetSearchBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    protected FormBuilderInterface $formBuilder,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function blockAccess(AccountInterface $account) {
+    return AccessResult::allowedIfHasPermissions($account, ['access asset collection']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      'asset_search' => $this->formBuilder->getForm('Drupal\farm_ui_search\Form\AssetSearchForm'),
+    ];
+  }
+
+}

--- a/modules/core/ui/search/tests/src/Functional/DashboardSearchTest.php
+++ b/modules/core/ui/search/tests/src/Functional/DashboardSearchTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_ui_search\Functional;
+
+use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use Drupal\asset\Entity\Asset;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the farm_ui_search dashboard panes.
+ */
+#[Group('farm')]
+#[RunTestsInSeparateProcesses]
+class DashboardSearchTest extends FarmBrowserTestBase {
+
+  /**
+   * Test user.
+   *
+   * @var \Drupal\user\Entity\User|bool
+   */
+  protected $user;
+
+  /**
+   * Test role ID.
+   *
+   * @var string
+   */
+  protected $role;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_equipment',
+    'farm_ui_dashboard',
+    'farm_ui_search',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create and login a user with permission to access the dashboard.
+    $this->user = $this->createUser(['access farm dashboard']);
+    $this->drupalLogin($this->user);
+
+    // Create a role that has permission to view assets.
+    $this->role = $this->drupalCreateRole(['access farm dashboard', 'access asset collection', 'view any asset']);
+
+    // Create two equipment assets.
+    $asset1 = Asset::create([
+      'name' => 'Foo',
+      'type' => 'equipment',
+    ]);
+    $asset1->save();
+    $asset2 = Asset::create([
+      'name' => 'Bar',
+      'type' => 'equipment',
+    ]);
+    $asset2->save();
+  }
+
+  /**
+   * Test the search form on the dashboard.
+   */
+  public function testDashboardSearch() {
+
+    // Load the dashboard.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Assert that the asset search form was not added.
+    $this->assertSession()->pageTextNotContains('Search assets');
+
+    // Grant the user permission to view any asset.
+    $this->user->addRole($this->role);
+    $this->user->save();
+
+    // Assert that the asset search was added.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Search assets');
+
+    // Search for "foo".
+    $this->getSession()->getPage()->fillField('asset_search', 'foo');
+    $this->getSession()->getPage()->pressButton('Search');
+
+    // Assert that we are redirected to /assets, "Foo" is listed, but "Bar" is
+    // not.
+    $this->assertSession()->addressEquals('assets?name=foo');
+    $this->assertSession()->pageTextContains('Foo');
+    $this->assertSession()->pageTextNotContains('Bar');
+
+    // Search for "bar".
+    // Assert that we are redirected to /assets, "Bar" is listed, but "Bar" is
+    // not.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->getSession()->getPage()->fillField('asset_search', 'bar');
+    $this->getSession()->getPage()->pressButton('Search');
+    $this->assertSession()->addressEquals('assets?name=bar');
+    $this->assertSession()->pageTextNotContains('Foo');
+    $this->assertSession()->pageTextContains('Bar');
+  }
+
+}

--- a/modules/core/ui/theme/css/search.css
+++ b/modules/core/ui/theme/css/search.css
@@ -1,0 +1,9 @@
+form.farm-ui-search-asset-form .inline-container {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1em;
+}
+form.farm-ui-search-asset-form .form-item,
+form.farm-ui-search-asset-form .button {
+  margin: 0;
+}

--- a/modules/core/ui/theme/farm_ui_theme.libraries.yml
+++ b/modules/core/ui/theme/farm_ui_theme.libraries.yml
@@ -52,6 +52,10 @@ regions:
   css:
     theme:
       css/regions.css: { }
+search:
+  css:
+    theme:
+      css/search.css: { }
 toolbar:
   css:
     theme:

--- a/modules/core/ui/theme/src/Hook/FormHooks.php
+++ b/modules/core/ui/theme/src/Hook/FormHooks.php
@@ -48,6 +48,14 @@ class FormHooks {
   /**
    * Implements hook_form_FORM_ID_alter().
    */
+  #[Hook('form_farm_ui_search_asset_form_alter')]
+  public function formFarmUiSearchAssetFormAlter(&$form, FormStateInterface $form_state, $form_id) {
+    $form['#attached']['library'][] = 'farm_ui_theme/search';
+  }
+
+  /**
+   * Implements hook_form_FORM_ID_alter().
+   */
   #[Hook('form_farm_modules_form_alter')]
   public function formFarmModulesFormAlter(&$form, FormStateInterface $form_state, $form_id) {
 


### PR DESCRIPTION
This adds a simple "Search assets" box to the farmOS dashboard, which redirects to `/assets` with the `?name=...` query parameter set to the search text.

The goal is to make it easier to find assets with fewer clicks/navigation decisions. Currently, to achieve the same thing you must find your way to `/assets` manually (by going to Records > Assets in the main menu, or clicking "Assets" in the "Metrics" block), then you need to open the "Filter" box, type in your search terms, and click "Apply". This is too many steps for such a common need.

This is only a first step. Perhaps future PRs can extend the functionality to provide additional options, or allow searching other entities as well (eg: logs).