### PR TITLE
Build ARM Docker images separately

### DIFF
--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -19,19 +19,63 @@ env:
 jobs:
 
   build:
-    name: Build Docker images
+    name: Build Docker AMD64 images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+      - name: Set default FARMOS_REPO and FARMOS_VERSION
+        run: |
+          echo "FARMOS_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          echo "FARMOS_VERSION=${FARMOS_DEV_BRANCH}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for branch push event
+        if: github.event_name == 'push' && github.ref_type == 'branch'
+        run: echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for tag push event
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: echo "FARMOS_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION and FARMOS_REPO for pull request event
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+      # This builds the production/dev Docker images using the specified FARMOS_VERSION,
+      # but notably it does NOT override the default PROJECT_VERSION, so the
+      # farmOS Composer project dev branch is always used.
+      - name: Build and save the farmOS Docker image
+        run: |
+          COMMON_BUILD_ARGS="--build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION}"
+          PROD_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-amd64
+          DEV_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-amd64
+          docker build ${COMMON_BUILD_ARGS} -t ${PROD_IMG_NAME} docker
+          docker build ${COMMON_BUILD_ARGS} -t ${DEV_IMG_NAME} --target dev docker
+          docker save ${PROD_IMG_NAME} > /tmp/farmos-amd64.tar
+          docker save ${DEV_IMG_NAME} > /tmp/farmos-dev-amd64.tar
+      - name: Cache the farmOS Docker image
+        uses: actions/cache@v5
+        with:
+          path: /tmp/farmos-amd64.tar
+          key: farmos-amd64-${{ github.run_id }}
+      - name: Cache the farmOS dev Docker image
+        uses: actions/cache@v5
+        with:
+          path: /tmp/farmos-dev-amd64.tar
+          key: farmos-dev-amd64-${{ github.run_id }}
+    outputs:
+      farmos_version: ${{ env.FARMOS_VERSION }}
+      farmos_dev_branch: ${{ env.FARMOS_DEV_BRANCH }}
+
+  build-arm:
+    name: Build Docker ARM images
     # Pin to Ubuntu 22.04 to work around upstream issue with QEMU and binfmt.
     # @see https://github.com/tonistiigi/binfmt/issues/215
     runs-on: ubuntu-22.04
     strategy:
       matrix:
         platform:
-         - amd64
          - arm32v7
          - arm64v8
         include:
-          - platform: amd64
-            DOCKER_PLATFORM_NAME: linux/amd64
           - platform: arm32v7
             DOCKER_PLATFORM_NAME: linux/arm/v7
           - platform: arm64v8
@@ -82,9 +126,6 @@ jobs:
         with:
           path: /tmp/farmos-dev-${{ matrix.platform }}.tar
           key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
-    outputs:
-      farmos_version: ${{ env.FARMOS_VERSION }}
-      farmos_dev_branch: ${{ env.FARMOS_DEV_BRANCH }}
 
   phpcs:
     name: PHP Codesniffer
@@ -254,6 +295,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      # ARM images are built separately.
+      - build-arm
       - phpcs
       - phpstan
       - rector

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -65,21 +65,55 @@ jobs:
       farmos_version: ${{ env.FARMOS_VERSION }}
       farmos_dev_branch: ${{ env.FARMOS_DEV_BRANCH }}
 
-  build-arm:
-    name: Build Docker ARM images
+  build-arm64:
+    name: Build Docker ARM64 images
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+      - name: Set default FARMOS_REPO and FARMOS_VERSION
+        run: |
+          echo "FARMOS_REPO=${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+          echo "FARMOS_VERSION=${FARMOS_DEV_BRANCH}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for branch push event
+        if: github.event_name == 'push' && github.ref_type == 'branch'
+        run: echo "FARMOS_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION for tag push event
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        run: echo "FARMOS_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
+      - name: Set FARMOS_VERSION and FARMOS_REPO for pull request event
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "FARMOS_VERSION=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          echo "FARMOS_REPO=${{ github.event.pull_request.head.repo.full_name }}" >> $GITHUB_ENV
+      # This builds the production/dev Docker images using the specified FARMOS_VERSION,
+      # but notably it does NOT override the default PROJECT_VERSION, so the
+      # farmOS Composer project dev branch is always used.
+      - name: Build and save the farmOS Docker image
+        run: |
+          COMMON_BUILD_ARGS="--build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION}"
+          PROD_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-arm64v8
+          DEV_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-arm64v8
+          docker build ${COMMON_BUILD_ARGS} -t ${PROD_IMG_NAME} docker
+          docker build ${COMMON_BUILD_ARGS} -t ${DEV_IMG_NAME} --target dev docker
+          docker save ${PROD_IMG_NAME} > /tmp/farmos-arm64v8.tar
+          docker save ${DEV_IMG_NAME} > /tmp/farmos-dev-arm64v8.tar
+      - name: Cache the farmOS Docker image
+        uses: actions/cache@v5
+        with:
+          path: /tmp/farmos-arm64v8.tar
+          key: farmos-arm64v8-${{ github.run_id }}
+      - name: Cache the farmOS dev Docker image
+        uses: actions/cache@v5
+        with:
+          path: /tmp/farmos-dev-arm64v8.tar
+          key: farmos-dev-arm64v8-${{ github.run_id }}
+
+  build-arm32:
+    name: Build Docker ARM32 images
     # Pin to Ubuntu 22.04 to work around upstream issue with QEMU and binfmt.
     # @see https://github.com/tonistiigi/binfmt/issues/215
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        platform:
-         - arm32v7
-         - arm64v8
-        include:
-          - platform: arm32v7
-            DOCKER_PLATFORM_NAME: linux/arm/v7
-          - platform: arm64v8
-            DOCKER_PLATFORM_NAME: linux/arm64/v8
     steps:
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
@@ -109,23 +143,23 @@ jobs:
       # farmOS Composer project dev branch is always used.
       - name: Build and save the farmOS Docker image
         run: |
-          COMMON_BUILD_ARGS="--load --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --platform ${{ matrix.DOCKER_PLATFORM_NAME }}"
-          PROD_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-${{ matrix.platform }}
-          DEV_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-${{ matrix.platform }}
+          COMMON_BUILD_ARGS="--load --build-arg FARMOS_REPO=https://github.com/${FARMOS_REPO} --build-arg FARMOS_VERSION=${FARMOS_VERSION} --platform linux/arm/v7"
+          PROD_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-arm32v7
+          DEV_IMG_NAME=${DOCKER_IMG_PREFIX}:${FARMOS_DEV_BRANCH}-dev-arm32v7
           docker buildx build ${COMMON_BUILD_ARGS} -t ${PROD_IMG_NAME} docker
           docker buildx build ${COMMON_BUILD_ARGS} -t ${DEV_IMG_NAME} --target dev docker
-          docker save ${PROD_IMG_NAME} > /tmp/farmos-${{ matrix.platform }}.tar
-          docker save ${DEV_IMG_NAME} > /tmp/farmos-dev-${{ matrix.platform }}.tar
+          docker save ${PROD_IMG_NAME} > /tmp/farmos-arm32v7.tar
+          docker save ${DEV_IMG_NAME} > /tmp/farmos-dev-arm32v7.tar
       - name: Cache the farmOS Docker image
         uses: actions/cache@v5
         with:
-          path: /tmp/farmos-${{ matrix.platform }}.tar
-          key: farmos-${{ matrix.platform }}-${{ github.run_id }}
+          path: /tmp/farmos-arm32v7.tar
+          key: farmos-arm32v7-${{ github.run_id }}
       - name: Cache the farmOS dev Docker image
         uses: actions/cache@v5
         with:
-          path: /tmp/farmos-dev-${{ matrix.platform }}.tar
-          key: farmos-dev-${{ matrix.platform }}-${{ github.run_id }}
+          path: /tmp/farmos-dev-arm32v7.tar
+          key: farmos-dev-arm32v7-${{ github.run_id }}
 
   phpcs:
     name: PHP Codesniffer
@@ -296,7 +330,8 @@ jobs:
     needs:
       - build
       # ARM images are built separately.
-      - build-arm
+      - build-arm64
+      - build-arm32
       - phpcs
       - phpstan
       - rector

--- a/.github/workflows/deliver.yml
+++ b/.github/workflows/deliver.yml
@@ -113,7 +113,7 @@ jobs:
     name: Build Docker ARM32 images
     # Pin to Ubuntu 22.04 to work around upstream issue with QEMU and binfmt.
     # @see https://github.com/tonistiigi/binfmt/issues/215
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     steps:
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU


### PR DESCRIPTION
This PR changes the way that we build the AMD64 vs ARM Docker images. Previously, they were all built in parallel as a prerequisite to running tests. The AMD64 image takes ~2.5 minutes to build, but the ARM images take ~20 minutes, so this is a long time to wait before tests start running. This splits the AMD64 `build` step out, so it runs by itself, and renames the ARM step to `build-arm`. Most other steps depend on the AMD64 image, but not the ARM images, so they can continue depending on `build`. Then, down in the `publish-multi-arch-images` step, this adds an additional dependency on the new `build-arm` step, since it is responsible for pushing all of the images to Docker Hub.