### PR TITLE
Issue #3590314: Add CSV import support for organization entities

### DIFF
--- a/modules/core/import/modules/csv/migrations/csv_organization.yml
+++ b/modules/core/import/modules/csv/migrations/csv_organization.yml
@@ -1,0 +1,28 @@
+id: csv_organization
+label: farmOS Organization CSV Importers
+migration_group: farm_import_csv
+source:
+  plugin: csv_file
+destination:
+  plugin: entity:organization
+process:
+
+  # Organization name.
+  name: name
+
+  # Organization notes with default format.
+  notes/0/value: notes
+  notes/0/format:
+    plugin: default_value
+    default_value: default
+
+# Describe the base columns.
+third_party_settings:
+  farm_import_csv:
+    columns:
+      - name: name
+        description: Name of the organization. Required.
+      - name: notes
+        description: Notes about the organization.
+
+deriver: \Drupal\farm_import_csv\Plugin\Derivative\CsvImportMigrationOrganization

--- a/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationOrganization.php
+++ b/modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationOrganization.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_import_csv\Plugin\Derivative;
+
+/**
+ * Organization CSV import migration derivatives.
+ *
+ * @internal
+ */
+class CsvImportMigrationOrganization extends CsvImportMigrationBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected string $entityType = 'organization';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getCreatePermission(string $bundle): string {
+    return 'create ' . $bundle . ' organization';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterProcessMapping(array &$mapping, string $bundle): void {
+    parent::alterProcessMapping($mapping, $bundle);
+
+    // Set the organization type.
+    $mapping['type'] = [
+      'plugin' => 'default_value',
+      'default_value' => $bundle,
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDerivativeDefinitions($base_plugin_definition): array {
+
+    // The `organization` entity type is provided by the optional farmOS
+    // `organization` module. If that module is not installed, the entity
+    // type isn't registered and the derivative should be inert rather
+    // than throwing during plugin discovery.
+    if (!$this->entityTypeManager->hasDefinition($this->entityType)) {
+      return [];
+    }
+    return parent::getDerivativeDefinitions($base_plugin_definition);
+  }
+
+}

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/organizations.csv
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/organizations.csv
@@ -1,0 +1,4 @@
+name,notes
+Green Acres Farm,A small organic vegetable farm in the valley.
+Sunrise Dairy,"Dairy operation specializing in raw milk and cheese, established 1987."
+Old River Ranch,Large cattle ranch.

--- a/modules/core/import/modules/csv/tests/src/Kernel/OrganizationCsvImportTest.php
+++ b/modules/core/import/modules/csv/tests/src/Kernel/OrganizationCsvImportTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_import_csv\Kernel;
+
+use Drupal\organization\Entity\Organization;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for organization CSV importers.
+ */
+#[Group('farm')]
+#[RunTestsInSeparateProcesses]
+class OrganizationCsvImportTest extends CsvImportTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'organization',
+    'organization_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->installEntitySchema('organization');
+    $this->installConfig(['organization_test']);
+  }
+
+  /**
+   * Test organization CSV importer.
+   */
+  public function testOrganizationCsvImport(): void {
+
+    // Run the CSV import against the default bundle.
+    $this->importCsv('organizations.csv', 'csv_organization:default');
+
+    // Confirm that organizations have been created with the expected
+    // values.
+    $orgs = Organization::loadMultiple();
+    $this->assertCount(3, $orgs);
+
+    $expected_values = [
+      1 => [
+        'name' => 'Green Acres Farm',
+        'notes' => 'A small organic vegetable farm in the valley.',
+      ],
+      2 => [
+        'name' => 'Sunrise Dairy',
+        'notes' => 'Dairy operation specializing in raw milk and cheese, established 1987.',
+      ],
+      3 => [
+        'name' => 'Old River Ranch',
+        'notes' => 'Large cattle ranch.',
+      ],
+    ];
+
+    foreach ($orgs as $id => $org) {
+      $this->assertEquals('default', $org->bundle());
+      $this->assertEquals($expected_values[$id]['name'], $org->label());
+      $this->assertEquals($expected_values[$id]['notes'], $org->get('notes')->value);
+      $this->assertEquals('default', $org->get('notes')->format);
+    }
+  }
+
+}


### PR DESCRIPTION
Drupal.org issue: [#3590314 — Add CSV import support for organization entities](https://www.drupal.org/project/farm/issues/3590314)

## Summary

Adds the `organization` entity type to the family already supported by `farm_import_csv` (asset, log, taxonomy_term). Symmetric extension following the existing `CsvImportMigrationBase` pattern — no new dependencies, no `info.yml` changes.

## Approach

Organization derivative as a sibling of the existing Asset / Log / Term derivatives inside `farm_import_csv` (not a separate submodule).

**Defensive against missing entity type:** `CsvImportMigrationOrganization::getDerivativeDefinitions()` early-returns when the optional `organization` entity type isn't registered, so installs without the organization module don't see broken migration plugins at discovery time.

## Files (+157 lines)

- `modules/core/import/modules/csv/src/Plugin/Derivative/CsvImportMigrationOrganization.php` — derivative; bundles sourced from the `organization_type` entity. Per-bundle `type` field set via `alterProcessMapping()`.
- `modules/core/import/modules/csv/migrations/csv_organization.yml` — `name` + `notes` columns. Process pipeline matches the term migration.
- `modules/core/import/modules/csv/tests/modules/farm_import_csv_test/artifacts/organizations.csv` — 3-row sample fixture.
- `modules/core/import/modules/csv/tests/src/Kernel/OrganizationCsvImportTest.php` — exercises `csv_organization:default` end-to-end via the default org bundle shipped by `organization_test`.

## Use case

Multi-tenant farmOS deployments — extension services, agricultural co-ops, NGO bootstrapping — regularly need to bulk-import tenants programmatically. Hand-entry in the UI is currently the only option for the organization entity type.

## Test plan

- [x] New kernel test `OrganizationCsvImportTest` — 1 test / 64 assertions, passes locally
- [x] Full upstream `farm_import_csv` kernel suite — 7/7 tests, 571 assertions, still passes
- [ ] CI runs the broader test matrix on PR open

## Attribution

Branch and patch authored by Claude (Anthropic) with direction and oversight from Greg Austic (@gbathree). Reviewed and verified locally before push.
