### PR TITLE
Remove AutowireTrait usage from hook classes

### DIFF
--- a/modules/asset/equipment/src/Hook/FieldHooks.php
+++ b/modules/asset/equipment/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_equipment\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/asset/group/src/Hook/FieldHooks.php
+++ b/modules/asset/group/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_group\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Drupal\farm_group\Field\AssetGroupItemList;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/asset/land/src/Hook/ViewsExecutionHooks.php
+++ b/modules/asset/land/src/Hook/ViewsExecutionHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_land\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\farm_land\Entity\FarmLandType;
@@ -16,7 +15,6 @@ use Drupal\views\ViewExecutable;
  */
 class ViewsExecutionHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/asset/sensor/modules/listener/src/Hook/FieldHooks.php
+++ b/modules/asset/sensor/modules/listener/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_sensor_listener\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/asset/sensor/src/Hook/ThemeHooks.php
+++ b/modules/asset/sensor/src/Hook/ThemeHooks.php
@@ -6,7 +6,6 @@ namespace Drupal\farm_sensor\Hook;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -19,7 +18,6 @@ use Drupal\data_stream\Entity\DataStreamInterface;
  */
 class ThemeHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/asset/structure/src/Hook/ViewsExecutionHooks.php
+++ b/modules/asset/structure/src/Hook/ViewsExecutionHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_structure\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\farm_map\LayerStyleLoaderInterface;
@@ -16,7 +15,6 @@ use Drupal\views\ViewExecutable;
  */
 class ViewsExecutionHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/asset/src/Hook/EntityHooks.php
+++ b/modules/core/asset/src/Hook/EntityHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\asset\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\asset\Entity\AssetInterface;
 use Drupal\asset\Event\AssetEvent;
@@ -15,8 +14,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Entity hook implementations for asset.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     #[Autowire(service: 'event_dispatcher')]

--- a/modules/core/data_stream/src/Hook/EntityHooks.php
+++ b/modules/core/data_stream/src/Hook/EntityHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\data_stream\Hook;
 
 use Drupal\Core\Database\Connection;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\data_stream\Entity\DataStreamInterface;
 
@@ -13,8 +12,6 @@ use Drupal\data_stream\Entity\DataStreamInterface;
  * Entity hook implementations for data_stream.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected Connection $connection,

--- a/modules/core/data_stream/src/Hook/ThemeHooks.php
+++ b/modules/core/data_stream/src/Hook/ThemeHooks.php
@@ -6,7 +6,6 @@ namespace Drupal\data_stream\Hook;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -18,7 +17,6 @@ use Drupal\data_stream\Entity\DataStreamInterface;
  */
 class ThemeHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/data_stream/src/Hook/ViewsHooks.php
+++ b/modules/core/data_stream/src/Hook/ViewsHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\data_stream\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\data_stream\DataStreamTypeManager;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -13,8 +12,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * Views hook implementations for data_stream.
  */
 class ViewsHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     #[Autowire(service: 'plugin.manager.data_stream_type')]

--- a/modules/core/entity/modules/fields/src/Hook/FieldHooks.php
+++ b/modules/core/entity/modules/fields/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_fields\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/entity/modules/views/src/Hook/ModuleHooks.php
+++ b/modules/core/entity/modules/views/src/Hook/ModuleHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_views\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Hook\Order\OrderAfter;
 use Drupal\views\ViewsData;
@@ -13,8 +12,6 @@ use Drupal\views\ViewsData;
  * Module hook implementations for farm_entity_views.
  */
 class ModuleHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ViewsData $viewsData,

--- a/modules/core/entity/src/Hook/EntityHooks.php
+++ b/modules/core/entity/src/Hook/EntityHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_entity\Hook;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
@@ -24,8 +23,6 @@ use Drupal\farm_entity\Routing\EntityRouteProvider;
  * Entity hook implementations for farm_entity.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected AccountInterface $currentUser,

--- a/modules/core/entity/src/Hook/FieldHooks.php
+++ b/modules/core/entity/src/Hook/FieldHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_entity\Hook;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -16,8 +15,6 @@ use Drupal\Core\Session\AccountInterface;
  * Field hook implementations for farm_entity.
  */
 class FieldHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,

--- a/modules/core/entity/tests/modules/farm_entity_contrib_test/src/Hook/FieldHooks.php
+++ b/modules/core/entity/tests/modules/farm_entity_contrib_test/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_contrib_test\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/entity/tests/modules/farm_entity_test/src/Hook/FieldHooks.php
+++ b/modules/core/entity/tests/modules/farm_entity_test/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_entity_test\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/flag/src/Hook/FieldHooks.php
+++ b/modules/core/flag/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_flag\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Drupal\farm_flag\FarmFlagHelper;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/id_tag/src/Hook/FieldHooks.php
+++ b/modules/core/id_tag/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_id_tag\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/import/modules/csv/src/Hook/EntityHooks.php
+++ b/modules/core/import/modules/csv/src/Hook/EntityHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_import_csv\Hook;
 
 use Drupal\Core\Database\Connection;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -13,8 +12,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * Entity hook implementations for farm_import_csv.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected Connection $database,

--- a/modules/core/import/modules/csv/src/Hook/FileHooks.php
+++ b/modules/core/import/modules/csv/src/Hook/FileHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_import_csv\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Session\AccountInterface;
@@ -16,8 +15,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  * File hook implementations for farm_import_csv.
  */
 class FileHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,

--- a/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/src/Hook/FieldHooks.php
+++ b/modules/core/import/modules/csv/tests/modules/farm_import_csv_test/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_import_csv_test\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/inventory/src/Hook/FieldHooks.php
+++ b/modules/core/inventory/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_inventory\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Drupal\farm_inventory\Field\AssetInventoryItemList;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/l10n/src/Hook/EntityHooks.php
+++ b/modules/core/l10n/src/Hook/EntityHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_l10n\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -12,8 +11,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * Entity hook implementations for farm_l10n.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleHandlerInterface $moduleHandler,

--- a/modules/core/l10n/src/Hook/FormHooks.php
+++ b/modules/core/l10n/src/Hook/FormHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_l10n\Hook;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Messenger\MessengerInterface;
@@ -18,7 +17,6 @@ use Drupal\Core\Url;
  */
 class FormHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/location/src/Hook/FieldHooks.php
+++ b/modules/core/location/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_location\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -18,7 +17,6 @@ use Drupal\farm_location\LocationDefaultValues;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/log/modules/asset/src/Hook/FieldHooks.php
+++ b/modules/core/log/modules/asset/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log_asset\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/log/modules/asset/src/Hook/FormHooks.php
+++ b/modules/core/log/modules/asset/src/Hook/FormHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log_asset\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
@@ -17,8 +16,6 @@ use Symfony\Component\HttpFoundation\RequestStack;
  * Form hook implementations for farm_log_asset.
  */
 class FormHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,

--- a/modules/core/log/modules/quantity/src/Hook/FieldHooks.php
+++ b/modules/core/log/modules/quantity/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log_quantity\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/login/src/Hook/FormHooks.php
+++ b/modules/core/login/src/Hook/FormHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_login\Hook;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Render\Element\Email;
@@ -16,7 +15,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  */
 class FormHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/organization/src/Hook/EntityHooks.php
+++ b/modules/core/organization/src/Hook/EntityHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\organization\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\organization\Entity\OrganizationInterface;
 use Drupal\organization\Event\OrganizationEvent;
@@ -15,8 +14,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Entity hook implementations for organization.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     #[Autowire(service: 'event_dispatcher')]

--- a/modules/core/owner/src/Hook/FieldHooks.php
+++ b/modules/core/owner/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_owner\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/parent/src/Hook/FieldHooks.php
+++ b/modules/core/parent/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_parent\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/plan/src/Hook/EntityHooks.php
+++ b/modules/core/plan/src/Hook/EntityHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\plan\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\plan\Entity\PlanInterface;
@@ -13,8 +12,6 @@ use Drupal\plan\Entity\PlanInterface;
  * Entity hook implementations for plan.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,

--- a/modules/core/quantity/src/Hook/ApiHooks.php
+++ b/modules/core/quantity/src/Hook/ApiHooks.php
@@ -5,15 +5,12 @@ declare(strict_types=1);
 namespace Drupal\quantity\Hook;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 
 /**
  * API hook implementations for quantity.
  */
 class ApiHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ConfigFactoryInterface $configFactory,

--- a/modules/core/quantity/src/Hook/EntityHooks.php
+++ b/modules/core/quantity/src/Hook/EntityHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\quantity\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\quantity\Entity\QuantityInterface;
 use Drupal\quantity\Event\QuantityEvent;
@@ -15,8 +14,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * Entity hook implementations for quantity.
  */
 class EntityHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     #[Autowire(service: 'event_dispatcher')]

--- a/modules/core/quick/src/Hook/FieldHooks.php
+++ b/modules/core/quick/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/quick/src/Hook/FormHooks.php
+++ b/modules/core/quick/src/Hook/FormHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_quick\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
@@ -13,8 +12,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * Form hook implementations for farm_quick.
  */
 class FormHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,

--- a/modules/core/quick/src/Hook/HelpHooks.php
+++ b/modules/core/quick/src/Hook/HelpHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_quick\Hook;
 
 use Drupal\Component\Utility\Html;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Drupal\farm_quick\QuickFormInstanceManagerInterface;
  */
 class HelpHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/role/src/Hook/FormHooks.php
+++ b/modules/core/role/src/Hook/FormHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_role\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Drupal\user\PermissionHandlerInterface;
  */
 class FormHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/setup/src/Hook/HelpHooks.php
+++ b/modules/core/setup/src/Hook/HelpHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_setup\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -16,7 +15,6 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  */
 class HelpHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/ui/action/src/Hook/MenuHooks.php
+++ b/modules/core/ui/action/src/Hook/MenuHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_action\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -12,8 +11,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * Menu hook implementations for farm_ui_action.
  */
 class MenuHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleHandlerInterface $moduleHandler,

--- a/modules/core/ui/map/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/map/src/Hook/ThemeHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_map\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -15,8 +14,6 @@ use Drupal\Core\Routing\RouteMatchInterface;
  * Theme hook implementations for farm_ui_map.
  */
 class ThemeHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityDisplayRepositoryInterface $entityDisplayRepository,

--- a/modules/core/ui/map/src/Hook/ViewsExecutionHooks.php
+++ b/modules/core/ui/map/src/Hook/ViewsExecutionHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_map\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -23,7 +22,6 @@ use Drupal\views\ViewExecutable;
  */
 class ViewsExecutionHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/ui/menu/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/menu/src/Hook/ThemeHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_menu\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_ui_menu\Render\Element\FarmAdminToolbar;
  */
 class ThemeHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/ui/theme/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/theme/src/Hook/ThemeHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_theme\Hook;
 
 use Drupal\Core\Block\BlockPluginInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\Display\EntityFormDisplayInterface;
 use Drupal\Core\Extension\ModuleExtensionList;
 use Drupal\Core\Extension\ModuleHandlerInterface;
@@ -19,8 +18,6 @@ use Drupal\plan\Entity\PlanInterface;
  * Theme hook implementations for farm_ui_theme.
  */
 class ThemeHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleExtensionList $moduleExtensionList,

--- a/modules/core/ui/views/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/views/src/Hook/ThemeHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_views\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -12,8 +11,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * Theme hook implementations for farm_ui_views.
  */
 class ThemeHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleHandlerInterface $moduleHandler,

--- a/modules/core/ui/views/src/Hook/ViewsExecutionHooks.php
+++ b/modules/core/ui/views/src/Hook/ViewsExecutionHooks.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_views\Hook;
 
 use Drupal\Component\Datetime\TimeInterface;
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -20,7 +19,6 @@ use Drupal\views\ViewExecutable;
  */
 class ViewsExecutionHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/ui/views/src/Hook/ViewsHooks.php
+++ b/modules/core/ui/views/src/Hook/ViewsHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_views\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -14,7 +13,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  */
 class ViewsHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/ui/views/tests/modules/farm_ui_views_test/src/Hook/FieldHooks.php
+++ b/modules/core/ui/views/tests/modules/farm_ui_views_test/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_ui_views_test\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/core/update/src/Hook/UpdateHooks.php
+++ b/modules/core/update/src/Hook/UpdateHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_update\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\farm_update\FarmUpdateInterface;
 
@@ -12,8 +11,6 @@ use Drupal\farm_update\FarmUpdateInterface;
  * Update hook implementations for farm_update.
  */
 class UpdateHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected FarmUpdateInterface $farmUpdate,

--- a/modules/log/birth/src/Hook/ThemeHooks.php
+++ b/modules/log/birth/src/Hook/ThemeHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_birth\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
@@ -15,8 +14,6 @@ use Drupal\asset\Entity\AssetInterface;
  * Theme hook implementations for farm_birth.
  */
 class ThemeHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected EntityTypeManagerInterface $entityTypeManager,

--- a/modules/organization/farm/src/Hook/FieldHooks.php
+++ b/modules/organization/farm/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_farm\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
@@ -16,7 +15,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(

--- a/modules/role/manager/src/Hook/ApiHooks.php
+++ b/modules/role/manager/src/Hook/ApiHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_manager\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -12,8 +11,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * API hook implementations for farm_manager.
  */
 class ApiHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleHandlerInterface $moduleHandler,

--- a/modules/role/viewer/src/Hook/ApiHooks.php
+++ b/modules/role/viewer/src/Hook/ApiHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_viewer\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -12,8 +11,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * API hook implementations for farm_viewer.
  */
 class ApiHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleHandlerInterface $moduleHandler,

--- a/modules/role/worker/src/Hook/ApiHooks.php
+++ b/modules/role/worker/src/Hook/ApiHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_worker\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 
@@ -12,8 +11,6 @@ use Drupal\Core\Hook\Attribute\Hook;
  * API hook implementations for farm_worker.
  */
 class ApiHooks {
-
-  use AutowireTrait;
 
   public function __construct(
     protected ModuleHandlerInterface $moduleHandler,

--- a/modules/taxonomy/log_category/src/Hook/FieldHooks.php
+++ b/modules/taxonomy/log_category/src/Hook/FieldHooks.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\farm_log_category\Hook;
 
-use Drupal\Core\DependencyInjection\AutowireTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -15,7 +14,6 @@ use Drupal\farm_field\FarmFieldFactoryInterface;
  */
 class FieldHooks {
 
-  use AutowireTrait;
   use StringTranslationTrait;
 
   public function __construct(


### PR DESCRIPTION
`AutowireTrait` only implements the `::create` method which is not needed in hook classes. There is some other magic in core that wires these dependencies just using the class constructor.