### PR TITLE
Add a unified asset+log search

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_tools": "^6.1.2",
         "drupal/role_delegation": "^1.3",
+        "drupal/search_api": "^1.41",
         "drupal/simple_oauth": "^6.1.1",
         "drupal/simple_oauth_password_grant": "^2.1",
         "drupal/state_machine": "^1.12",
@@ -72,6 +73,9 @@
             },
             "drupal/gin": {
                 "Issue #3342164: Remove implicit dependency on node module for gin content form.": "https://www.drupal.org/files/issues/2024-01-15/3342164-6.patch"
+            },
+            "drupal/search_api": {
+                "Issue #3598014: PluginNotFoundException when creating index for entity type with no bundles installed": "https://www.drupal.org/files/issues/2026-06-11/3598014-6.patch"
             },
             "drupal/subrequests": {
                 "Issue #3524429: PHP 8.4 deprecation: Implicitly marking parameter as nullable": "https://git.drupalcode.org/issue/subrequests-3524429/-/commit/784ccfe8af7d803f392263d2dbf7dcd89f9566d5.patch"

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_tools": "^6.1.2",
         "drupal/role_delegation": "^1.3",
-        "drupal/search_api": "^1.41",
+        "drupal/search_api": "1.41",
         "drupal/simple_oauth": "^6.1.1",
         "drupal/simple_oauth_password_grant": "^2.1",
         "drupal/state_machine": "^1.12",

--- a/modules/core/ui/farm_ui.info.yml
+++ b/modules/core/ui/farm_ui.info.yml
@@ -12,6 +12,7 @@ dependencies:
   - farm:farm_ui_map
   - farm:farm_ui_menu
   - farm:farm_ui_metrics
+  - farm:farm_ui_search
   - farm:farm_ui_term
   - farm:farm_ui_theme
   - farm:farm_ui_user

--- a/modules/core/ui/farm_ui.post_update.php
+++ b/modules/core/ui/farm_ui.post_update.php
@@ -15,3 +15,12 @@ function farm_ui_post_update_install_farm_ui_term() {
     \Drupal::service('module_installer')->install(['farm_ui_term']);
   }
 }
+
+/**
+ * Install the farm_ui_search module.
+ */
+function farm_ui_post_update_install_farm_ui_search() {
+  if (!\Drupal::service('module_handler')->moduleExists('farm_ui_search')) {
+    \Drupal::service('module_installer')->install(['farm_ui_search']);
+  }
+}

--- a/modules/core/ui/search/config/install/search_api.index.default.yml
+++ b/modules/core/ui/search/config/install/search_api.index.default.yml
@@ -1,0 +1,156 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.server.default
+  module:
+    - asset
+    - farm_entity_fields
+    - log
+  enforced:
+    module:
+      - farm_ui_search
+id: default
+name: Default
+description: ''
+read_only: false
+field_settings:
+  asset_name:
+    label: Name
+    datasource_id: 'entity:asset'
+    property_path: name
+    type: text
+    boost: 2.0
+    dependencies:
+      module:
+        - asset
+  asset_notes:
+    label: Notes
+    datasource_id: 'entity:asset'
+    property_path: notes
+    type: text
+    dependencies:
+      module:
+        - farm_entity_fields
+  asset_type:
+    label: 'Asset type'
+    datasource_id: 'entity:asset'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - asset
+  entity_type:
+    label: 'Entity type'
+    property_path: search_api_entity_type
+    type: string
+  log_name:
+    label: Name
+    datasource_id: 'entity:log'
+    property_path: name
+    type: text
+    boost: 2.0
+    dependencies:
+      module:
+        - log
+  log_notes:
+    label: Notes
+    datasource_id: 'entity:log'
+    property_path: notes
+    type: text
+    dependencies:
+      module:
+        - farm_entity_fields
+  log_type:
+    label: 'Log type'
+    datasource_id: 'entity:log'
+    property_path: type
+    type: string
+    dependencies:
+      module:
+        - log
+datasource_settings:
+  'entity:asset':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+  'entity:log':
+    bundles:
+      default: true
+      selected: {  }
+    languages:
+      default: true
+      selected: {  }
+processor_settings:
+  add_url: {  }
+  aggregated_field: {  }
+  custom_value: {  }
+  entity_type: {  }
+  highlight:
+    weights:
+      postprocess_query: 0
+    prefix: '<strong>'
+    suffix: '</strong>'
+    excerpt: true
+    excerpt_always: false
+    excerpt_length: 256
+    exclude_fields: {  }
+    highlight: always
+    highlight_partial: true
+  html_filter:
+    weights:
+      preprocess_index: -15
+      preprocess_query: -15
+    all_fields: false
+    fields:
+      - asset_name
+      - asset_notes
+      - log_name
+      - log_notes
+    title: true
+    alt: true
+    tags:
+      b: 2.0
+      em: 1.5
+      h1: 5.0
+      h2: 3.0
+      h3: 2.0
+      strong: 2.0
+      u: 1.5
+  ignorecase:
+    weights:
+      preprocess_index: -20
+      preprocess_query: -20
+    all_fields: false
+    fields:
+      - asset_name
+      - asset_notes
+      - log_name
+      - log_notes
+  language_with_fallback: {  }
+  rendered_item: {  }
+  stemmer:
+    weights:
+      preprocess_index: 0
+      preprocess_query: 0
+    all_fields: false
+    fields:
+      - asset_name
+      - asset_notes
+      - log_name
+      - log_notes
+    exceptions:
+      mexican: mexic
+      texan: texa
+tracker_settings:
+  default:
+    indexing_order: fifo
+options:
+  cron_limit: 50
+  delete_on_fail: true
+  index_directly: true
+  track_changes_in_references: true
+server: default

--- a/modules/core/ui/search/config/install/search_api.server.default.yml
+++ b/modules/core/ui/search/config/install/search_api.server.default.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - search_api_db
+  enforced:
+    module:
+      - farm_ui_search
+id: default
+name: Default
+description: ''
+backend: search_api_db
+backend_config:
+  database: 'default:default'
+  min_chars: 3
+  matching: partial
+  phrase: bigram

--- a/modules/core/ui/search/config/install/views.view.farm_search.yml
+++ b/modules/core/ui/search/config/install/views.view.farm_search.yml
@@ -1,0 +1,820 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default
+  module:
+    - farm_entity_access
+    - search_api
+  enforced:
+    module:
+      - farm_ui_search
+id: farm_search
+label: 'Farm Search'
+module: views
+description: ''
+tag: ''
+base_table: search_api_index_default
+base_field: search_api_id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: Search
+      fields:
+        asset_name:
+          id: asset_name
+          table: search_api_index_default
+          field: asset_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: 'Name (indexed field)'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            delta_limit: 0
+            delta_offset: 0
+            delta_reversed: false
+            delta_first_last: false
+        log_name:
+          id: log_name
+          table: search_api_index_default
+          field: log_name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: 'Name (indexed field)'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            delta_limit: 0
+            delta_offset: 0
+            delta_reversed: false
+            delta_first_last: false
+        nothing:
+          id: nothing
+          table: views
+          field: nothing
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: custom
+          label: Name
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ asset_name }}{{ log_name }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: false
+        asset_type:
+          id: asset_type
+          table: search_api_index_default
+          field: asset_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: 'Asset type (indexed field)'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            delta_limit: 0
+            delta_offset: 0
+            delta_reversed: false
+            delta_first_last: false
+            display_methods:
+              asset_type:
+                display_method: label
+        log_type:
+          id: log_type
+          table: search_api_index_default
+          field: log_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_field
+          label: 'Log type (indexed field)'
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            delta_limit: 0
+            delta_offset: 0
+            delta_reversed: false
+            delta_first_last: false
+            display_methods:
+              log_type:
+                display_method: label
+        entity_type:
+          id: entity_type
+          table: search_api_index_default
+          field: entity_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          label: Type
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{ asset_type }}{{ log_type }} {{ entity_type }}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+        search_api_excerpt:
+          id: search_api_excerpt
+          table: search_api_index_default
+          field: search_api_excerpt
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_text
+          label: Excerpt
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: true
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          link_to_item: false
+          use_highlighting: false
+          multi_type: separator
+          multi_separator: ', '
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          filter_type: xss
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_default
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          label: Relevance
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ','
+          format_plural: false
+          format_plural_string: !!binary MQNAY291bnQ=
+          prefix: ''
+          suffix: ''
+      pager:
+        type: full
+        options:
+          offset: 0
+          pagination_heading_level: h4
+          items_per_page: 25
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
+      exposed_form:
+        type: input_required
+        options:
+          submit_button: Search
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+          text_input_required: ''
+          text_input_required_format: default
+      access:
+        type: farm_entity_collection
+        options:
+          entity_type:
+            asset: asset
+            log: log
+      cache:
+        type: search_api_none
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No assets or logs found.'
+          tokenize: false
+      sorts:
+        search_api_relevance:
+          id: search_api_relevance
+          table: search_api_index_default
+          field: search_api_relevance
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        search_api_fulltext:
+          id: search_api_fulltext
+          table: search_api_index_default
+          field: search_api_fulltext
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: search_api_fulltext
+          operator: and
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: search_api_fulltext_op
+            label: ''
+            description: ''
+            use_operator: false
+            operator: search_api_fulltext_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: query
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            expose_fields: false
+            placeholder: 'Search assets and logs'
+            searched_fields_id: search_api_fulltext_searched_fields
+            value_maxlength: 128
+            value_max_words: null
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          parse_mode: terms
+          min_length: null
+          fields: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            asset_name: asset_name
+            log_name: log_name
+            nothing: nothing
+            asset_type: asset_type
+            log_type: log_type
+            entity_type: entity_type
+            search_api_excerpt: search_api_excerpt
+            search_api_relevance: search_api_relevance
+          default: '-1'
+          info:
+            asset_name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            log_name:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            nothing:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            asset_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            log_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            entity_type:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            search_api_excerpt:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            search_api_relevance:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+          class: ''
+      row:
+        type: fields
+      query:
+        type: search_api_query
+        options:
+          bypass_access: false
+          skip_access: false
+          preserve_facet_query_args: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'Displaying @start - @end of @total'
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:search_api.index.default'
+        - 'search_api_list:default'
+  block:
+    id: block
+    display_title: Block
+    display_plugin: block
+    position: 2
+    display_options:
+      title: ''
+      defaults:
+        title: false
+      display_extenders: {  }
+      block_category: Search
+      allow:
+        items_per_page: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:search_api.index.default'
+        - 'search_api_list:default'
+  page:
+    id: page
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: search
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags:
+        - 'config:search_api.index.default'
+        - 'search_api_list:default'

--- a/modules/core/ui/search/config/install/views.view.farm_search.yml
+++ b/modules/core/ui/search/config/install/views.view.farm_search.yml
@@ -752,17 +752,7 @@ display:
           query_tags: {  }
       relationships: {  }
       header: {  }
-      footer:
-        result:
-          id: result
-          table: views
-          field: result
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: result
-          empty: false
-          content: 'Displaying @start - @end of @total'
+      footer: {  }
       display_extenders: {  }
     cache_metadata:
       max-age: -1

--- a/modules/core/ui/search/farm_ui_search.info.yml
+++ b/modules/core/ui/search/farm_ui_search.info.yml
@@ -1,0 +1,8 @@
+name: farmOS UI Search
+description: Adds a dashboard pane with search features.
+type: module
+package: farmOS UI
+core_version_requirement: ^11
+dependencies:
+  - farm:farm_ui_dashboard
+  - search_api:search_api_db

--- a/modules/core/ui/search/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/search/src/Hook/ThemeHooks.php
@@ -2,14 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Drupal\farm_setup\Hook;
+namespace Drupal\farm_ui_search\Hook;
 
 use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 
 /**
- * Theme hook implementations for farm_setup.
+ * Theme hook implementations for farm_ui_search.
  */
 class ThemeHooks {
+
+  use StringTranslationTrait;
 
   /**
    * Implements hook_farm_dashboard_panes().
@@ -17,10 +20,11 @@ class ThemeHooks {
   #[Hook('farm_dashboard_panes')]
   public function farmDashboardPanes() {
     return [
-      'setup' => [
-        'block' => 'farm_setup',
+      'search' => [
+        'view' => 'farm_search',
+        'view_display_id' => 'block',
         'region' => 'top',
-        'weight' => -100,
+        'weight' => -90,
       ],
     ];
   }

--- a/modules/core/ui/search/src/Hook/UpdateHooks.php
+++ b/modules/core/ui/search/src/Hook/UpdateHooks.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\farm_ui_search\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+/**
+ * Update hook implementations for farm_ui_search.
+ */
+class UpdateHooks {
+
+  /**
+   * Implements hook_farm_update_managed_config().
+   */
+  #[Hook('farm_update_managed_config')]
+  public function farmUpdateManagedConfig() {
+    return [
+      'search_api.index.default',
+      'search_api.server.default',
+      'views.view.farm_search',
+    ];
+  }
+
+}

--- a/modules/core/ui/search/tests/src/Functional/SearchTest.php
+++ b/modules/core/ui/search/tests/src/Functional/SearchTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_ui_search\Functional;
+
+use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
+use Drupal\asset\Entity\Asset;
+use Drupal\log\Entity\Log;
+use Drupal\search_api\Entity\Index;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests the farm_ui_search dashboard panes.
+ */
+#[Group('farm')]
+#[RunTestsInSeparateProcesses]
+class SearchTest extends FarmBrowserTestBase {
+
+  /**
+   * Test user.
+   *
+   * @var \Drupal\user\Entity\User|bool
+   */
+  protected $user;
+
+  /**
+   * Test role ID.
+   *
+   * @var string
+   */
+  protected $role;
+
+  /**
+   * Assets created for testing.
+   *
+   * @var \Drupal\asset\Entity\AssetInterface[]
+   */
+  protected array $assets;
+
+  /**
+   * Logs created for testing.
+   *
+   * @var \Drupal\log\Entity\LogInterface[]
+   */
+  protected array $logs;
+
+  /**
+   * Asset and log names.
+   *
+   * @var string[]
+   */
+  protected array $recordNames;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_activity',
+    'farm_equipment',
+    'farm_ui_dashboard',
+    'farm_ui_search',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create and login a user with permission to access the dashboard.
+    $this->user = $this->createUser(['access farm dashboard']);
+    $this->drupalLogin($this->user);
+
+    // Create a role that has permission to view assets and logs.
+    $this->role = $this->drupalCreateRole(['access farm dashboard', 'access asset collection', 'view any asset', 'access log collection', 'view any log']);
+
+    // Create assets.
+    $asset_names = [
+      'Red Tractor',
+      'Root Washer',
+    ];
+    foreach ($asset_names as $name) {
+      $asset = Asset::create([
+        'name' => $name,
+        'type' => 'equipment',
+      ]);
+      $asset->save();
+      $this->assets[] = $asset;
+    }
+
+    // Create logs.
+    $log_names = [
+      'Wash tractor',
+      'Harvest potatoes',
+    ];
+    foreach ($log_names as $name) {
+      $log = Log::create([
+        'name' => $name,
+        'type' => 'activity',
+      ]);
+      $log->save();
+      $this->logs[] = $log;
+    }
+
+    // Make a list of all asset and log names.
+    foreach ($this->assets as $asset) {
+      $this->recordNames[] = $asset->label();
+    }
+    foreach ($this->logs as $log) {
+      $this->recordNames[] = $log->label();
+    }
+
+    // Populate the index.
+    $index = Index::load('default');
+    $index->indexItems();
+  }
+
+  /**
+   * Test the search form on the dashboard.
+   */
+  public function testDashboardSearch() {
+
+    // Load the dashboard.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Assert that the search form was not added.
+    $this->assertSession()->responseNotContains('Search assets and logs');
+
+    // Grant the user permissions to view assets and logs.
+    $this->user->addRole($this->role);
+    $this->user->save();
+
+    // Assert that the search form was added.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->responseContains('Search assets and logs');
+
+    // Search for "tractor" and assert that expected results are shown.
+    $this->assertExpectedSearchResults('tractor', ['Red Tractor', 'Wash tractor']);
+
+    // Search for "wash" and assert that expected results are shown.
+    $this->assertExpectedSearchResults('wash', ['Root Washer', 'Wash tractor']);
+
+    // Search for "potato" and assert that expected results are shown.
+    $this->assertExpectedSearchResults('potato', ['Harvest potatoes']);
+  }
+
+  /**
+   * Assert that only expected results are present in a search.
+   *
+   * @param string $query
+   *   The search query string.
+   * @param array $expected_names
+   *   An array of asset and log names we expect to find in the search results.
+   */
+  protected function assertExpectedSearchResults(string $query, array $expected_names = []) {
+
+    // Load the dashboard and search for the query string.
+    $this->drupalGet('/dashboard');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->getSession()->getPage()->fillField('query', $query);
+    $this->getSession()->getPage()->pressButton('Search');
+    $this->assertSession()->addressEquals('search?query=' . $query);
+
+    // Assert that all the expected names were found.
+    foreach ($expected_names as $name) {
+      $this->assertSession()->pageTextContains($name);
+    }
+
+    // Assert that no unexpected names were found.
+    $unexpected_names = array_diff($this->recordNames, $expected_names);
+    foreach ($unexpected_names as $name) {
+      $this->assertSession()->pageTextNotContains($name);
+    }
+  }
+
+}


### PR DESCRIPTION
This adds a unified asset+log search, which indexes the `name` and `notes` fields of all assets and logs, making it possible to quickly search records by keywords/phrases.

It accomplishes this with the [Search API](https://www.drupal.org/project/search_api) module, which provides a robust search framework for Drupal entities. Search API has a swappable backend plugin system, which means that it's possible to use Apace Solr, ElasticSearch/OpenSearch, etc as a server backend, or you can use the existing Drupal SQL database. This PR adds a `default` server and index using the existing SQL database.

Very little code is necessary to accomplish this, and this PR is mostly YML configuration for the `default` Search API server and index, and a View for searching assets and logs, with a page display at `/search`, and a block display that is added to the farmOS dashboard.

Screenshots:

<img width="731" height="441" alt="Screenshot from 2026-06-11 20-03-13" src="https://github.com/user-attachments/assets/5f38e31c-a7d8-43f7-8764-f2a45b52b46b" />

<img width="1366" height="646" alt="Screenshot from 2026-06-11 20-03-28" src="https://github.com/user-attachments/assets/06ef8d80-2d67-4d37-ba6f-b9722f515634" />

<img width="1366" height="646" alt="Screenshot from 2026-06-11 20-03-35" src="https://github.com/user-attachments/assets/1e187835-4565-4d42-a494-9d2f0be27406" />

This PR is a replacement for (and improvement over) #1076. I started with that one and modified/simplified it for this PR.

I am opening this as a draft / working proof of concept. There is more to do, including:

- [ ] Review Search API and Views configuration with community
- [x] Test/understand access control considerations
- [ ] Consider whether we should index other fields in this first pass, or wait and see...
- [ ] ...?