### PR TITLE
Fix dropbutton margin in local actions block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [Issue #3567613: Show sidebar toggle is not usable](https://www.drupal.org/project/gin/issues/3567613)).
 - [Use Drupal core RevisionHtmlRouteProvider #1087](https://github.com/farmOS/farmOS/pull/1087)
 
+### Fixed
+
+- [Fix dropbutton margin in local actions block #1086](https://github.com/farmOS/farmOS/pull/1086)
+
 ## [4.0.2] 2026-05-20
 
 ### Deprecated

--- a/modules/core/ui/theme/css/menu-local-action.css
+++ b/modules/core/ui/theme/css/menu-local-action.css
@@ -1,0 +1,4 @@
+/* Fix dropbutton margin in local actions block. */
+#block-gin-local-actions .dropbutton--multiple > .dropbutton__item:first-of-type {
+  margin-inline-end: var(--gin-spacing-xxl) !important;
+}

--- a/modules/core/ui/theme/farm_ui_theme.libraries.yml
+++ b/modules/core/ui/theme/farm_ui_theme.libraries.yml
@@ -40,6 +40,10 @@ map:
       css/map.css: { }
   dependencies:
     - farm_map/farm_map
+menu_local_action:
+  css:
+    theme:
+      css/menu-local-action.css: { }
 menu_local_task:
   css:
     theme:

--- a/modules/core/ui/theme/src/Hook/ThemeHooks.php
+++ b/modules/core/ui/theme/src/Hook/ThemeHooks.php
@@ -88,7 +88,10 @@ class ThemeHooks {
    */
   #[Hook('preprocess_block')]
   public function preprocessBlock(&$variables) {
-    if ($variables['plugin_id'] == 'help_block') {
+    if ($variables['plugin_id'] == 'farm_local_actions_block') {
+      $variables['#attached']['library'][] = 'farm_ui_theme/menu_local_action';
+    }
+    elseif ($variables['plugin_id'] == 'help_block') {
       $variables['#attached']['library'][] = 'farm_ui_theme/help';
     }
   }


### PR DESCRIPTION
This fixes a minor CSS issue that was introduced in [Gin 5.0.13](https://www.drupal.org/project/gin/releases/5.0.13).

Before 5.0.13, the dropbutton for local actions with multiple items looked like this:

<img width="198" height="118" alt="Screenshot from 2026-06-12 12-08-28" src="https://github.com/user-attachments/assets/511b54e0-2aeb-4db1-bab0-77d758adef98" />

After 5.0.13, it looks like this:

<img width="198" height="118" alt="image" src="https://github.com/user-attachments/assets/b602cd8e-c558-46e0-a18b-43f848bd4b1a" />

Here is the commit that broke it: https://git.drupalcode.org/project/gin/-/commit/2883a1903be15eb63c0602df7035c34fa8339652

The commit message (and 5.0.13 release notes) just says "Fix dropbutton double border" - and doesn't give any other context. :-(

This PR fixes it by adding a CSS rule in our `farm_ui_theme` module that overrides and reverts the rule that was changed, specifically within the `#block-gin-local-actions` selector (the local actions block).

We are intentionally hacking the local actions block to merge all actions into a dropbutton, so even if it's Gin's fault, it's mostly our problem.

Given that we may consider refactoring the way we handle action links in the future (see: https://www.drupal.org/node/2513056, https://www.drupal.org/project/farm/issues/3576215, and https://www.drupal.org/project/farm/issues/3586746) I am OK with including this minor "hack" in `farm_ui_theme` for now... with the hope and expectation that we'll be able to drop it in the future.