### PR TITLE
Use Drupal core RevisionHtmlRouteProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update [drupal/gin](https://www.drupal.org/project/gin) to
   [5.0.13](https://www.drupal.org/project/gin/releases/5.0.13) (fixes
   [Issue #3567613: Show sidebar toggle is not usable](https://www.drupal.org/project/gin/issues/3567613)).
+- [Use Drupal core RevisionHtmlRouteProvider #1087](https://github.com/farmOS/farmOS/pull/1087)
 
 ## [4.0.2] 2026-05-20
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "drupal/inline_entity_form": "^3.0@RC",
         "drupal/inspire_tree": "^1.0.6",
         "drupal/jsonapi_schema": "^1.0",
-        "drupal/log": "^4.0",
+        "drupal/log": "^4.0.2",
         "drupal/migrate_plus": "^6.0.8",
         "drupal/migrate_source_csv": "^3.6",
         "drupal/migrate_tools": "^6.1.2",

--- a/modules/core/asset/asset.post_update.php
+++ b/modules/core/asset/asset.post_update.php
@@ -94,3 +94,13 @@ function asset_post_update_remove_admin_view(&$sandbox) {
   $view = View::load('asset_admin');
   $view->delete();
 }
+
+/**
+ * Add revision_data_table to asset entity type definition.
+ */
+function asset_post_update_revision_data_table(&$sandbox) {
+  $manager = \Drupal::service('entity.definition_update_manager');
+  $entity_type = $manager->getEntityType('asset');
+  $entity_type->set('revision_data_table', 'asset_field_revision');
+  $manager->updateEntityType($entity_type);
+}

--- a/modules/core/asset/src/Entity/Asset.php
+++ b/modules/core/asset/src/Entity/Asset.php
@@ -10,7 +10,9 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
 use Drupal\Core\Entity\Form\DeleteMultipleForm;
+use Drupal\Core\Entity\Form\RevisionRevertForm;
 use Drupal\Core\Entity\RevisionLogEntityTrait;
+use Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\asset\AssetListBuilder;
@@ -20,7 +22,6 @@ use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
 use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
-use Drupal\entity\Routing\RevisionRouteProvider;
 use Drupal\entity\UncacheableEntityAccessControlHandler;
 use Drupal\entity\UncacheableEntityPermissionProvider;
 use Drupal\user\EntityOwnerTrait;
@@ -59,10 +60,11 @@ use Drupal\views\EntityViewsData;
       'edit' => AssetForm::class,
       'delete' => ContentEntityDeleteForm::class,
       'delete-multiple-confirm' => DeleteMultipleForm::class,
+      'revision-revert' => RevisionRevertForm::class,
     ],
     'route_provider' => [
       'default' => AdminHtmlRouteProvider::class,
-      'revision' => RevisionRouteProvider::class,
+      'revision' => RevisionHtmlRouteProvider::class,
     ],
     'local_task_provider' => [
       'default' => DefaultEntityLocalTaskProvider::class,

--- a/modules/core/asset/src/Entity/Asset.php
+++ b/modules/core/asset/src/Entity/Asset.php
@@ -87,6 +87,7 @@ use Drupal\views\EntityViewsData;
   base_table: 'asset',
   data_table: 'asset_field_data',
   revision_table: 'asset_revision',
+  revision_data_table: 'asset_field_revision',
   translatable: TRUE,
   show_revision_ui: TRUE,
   label_count: [

--- a/modules/core/asset/src/Hook/AccessHooks.php
+++ b/modules/core/asset/src/Hook/AccessHooks.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\asset\Hook;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access hook implementations for asset.
+ */
+class AccessHooks {
+
+  /**
+   * Implements hook_entity_access().
+   */
+  #[Hook('entity_access')]
+  public function entityAccess(EntityInterface $entity, $operation, AccountInterface $account): AccessResultInterface {
+
+    // Default to neutral.
+    $access = AccessResult::neutral();
+
+    // We only care about asset entities.
+    if ($entity->getEntityTypeId() !== 'asset') {
+      return $access;
+    }
+
+    // Allow access to view revisions if the user has "view all asset revisions"
+    // permission.
+    if (in_array($operation, ['view revision', 'view all revisions'])) {
+      $access = AccessResult::allowedIfHasPermission($account, 'view all asset revisions');
+    }
+
+    // Allow access to revert revisions if the user has "revert all asset
+    // revisions" permission.
+    if ($operation === 'revert') {
+      $access = AccessResult::allowedIfHasPermission($account, 'revert all asset revisions');
+    }
+
+    // Return the access result.
+    return $access;
+  }
+
+}

--- a/modules/core/organization/organization.post_update.php
+++ b/modules/core/organization/organization.post_update.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for organization module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Add revision_data_table to organization entity type definition.
+ */
+function organization_post_update_revision_data_table(&$sandbox) {
+  $manager = \Drupal::service('entity.definition_update_manager');
+  $entity_type = $manager->getEntityType('organization');
+  $entity_type->set('revision_data_table', 'organization_field_revision');
+  $manager->updateEntityType($entity_type);
+}

--- a/modules/core/organization/src/Entity/Organization.php
+++ b/modules/core/organization/src/Entity/Organization.php
@@ -85,6 +85,7 @@ use Drupal\views\EntityViewsData;
   base_table: 'organization',
   data_table: 'organization_field_data',
   revision_table: 'organization_revision',
+  revision_data_table: 'organization_field_revision',
   translatable: TRUE,
   show_revision_ui: TRUE,
   label_count: [

--- a/modules/core/organization/src/Entity/Organization.php
+++ b/modules/core/organization/src/Entity/Organization.php
@@ -10,14 +10,15 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
 use Drupal\Core\Entity\Form\DeleteMultipleForm;
+use Drupal\Core\Entity\Form\RevisionRevertForm;
 use Drupal\Core\Entity\RevisionLogEntityTrait;
+use Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
 use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
-use Drupal\entity\Routing\RevisionRouteProvider;
 use Drupal\entity\UncacheableEntityAccessControlHandler;
 use Drupal\entity\UncacheableEntityPermissionProvider;
 use Drupal\organization\Form\OrganizationForm;
@@ -57,10 +58,11 @@ use Drupal\views\EntityViewsData;
       'edit' => OrganizationForm::class,
       'delete' => ContentEntityDeleteForm::class,
       'delete-multiple-confirm' => DeleteMultipleForm::class,
+      'revision-revert' => RevisionRevertForm::class,
     ],
     'route_provider' => [
       'default' => AdminHtmlRouteProvider::class,
-      'revision' => RevisionRouteProvider::class,
+      'revision' => RevisionHtmlRouteProvider::class,
     ],
     'local_task_provider' => [
       'default' => DefaultEntityLocalTaskProvider::class,

--- a/modules/core/organization/src/Hook/AccessHooks.php
+++ b/modules/core/organization/src/Hook/AccessHooks.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\organization\Hook;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access hook implementations for organization.
+ */
+class AccessHooks {
+
+  /**
+   * Implements hook_entity_access().
+   */
+  #[Hook('entity_access')]
+  public function entityAccess(EntityInterface $entity, $operation, AccountInterface $account): AccessResultInterface {
+
+    // Default to neutral.
+    $access = AccessResult::neutral();
+
+    // We only care about organization entities.
+    if ($entity->getEntityTypeId() !== 'organization') {
+      return $access;
+    }
+
+    // Allow access to view revisions if the user has "view all organization
+    // revisions" permission.
+    if (in_array($operation, ['view revision', 'view all revisions'])) {
+      $access = AccessResult::allowedIfHasPermission($account, 'view all organization revisions');
+    }
+
+    // Allow access to revert revisions if the user has "revert all organization
+    // revisions" permission.
+    if ($operation === 'revert') {
+      $access = AccessResult::allowedIfHasPermission($account, 'revert all organization revisions');
+    }
+
+    // Return the access result.
+    return $access;
+  }
+
+}

--- a/modules/core/plan/plan.post_update.php
+++ b/modules/core/plan/plan.post_update.php
@@ -79,6 +79,16 @@ function plan_post_update_remove_admin_view(&$sandbox) {
 }
 
 /**
+ * Add revision_data_table to plan entity type definition.
+ */
+function plan_post_update_revision_data_table(&$sandbox) {
+  $manager = \Drupal::service('entity.definition_update_manager');
+  $entity_type = $manager->getEntityType('plan');
+  $entity_type->set('revision_data_table', 'plan_field_revision');
+  $manager->updateEntityType($entity_type);
+}
+
+/**
  * Implements hook_removed_post_updates().
  */
 function plan_removed_post_updates() {

--- a/modules/core/plan/src/Entity/Plan.php
+++ b/modules/core/plan/src/Entity/Plan.php
@@ -85,6 +85,7 @@ use Drupal\views\EntityViewsData;
   base_table: 'plan',
   data_table: 'plan_field_data',
   revision_table: 'plan_revision',
+  revision_data_table: 'plan_field_revision',
   translatable: TRUE,
   show_revision_ui: TRUE,
   label_count: [

--- a/modules/core/plan/src/Entity/Plan.php
+++ b/modules/core/plan/src/Entity/Plan.php
@@ -10,14 +10,15 @@ use Drupal\Core\Entity\EntityChangedTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityViewBuilder;
 use Drupal\Core\Entity\Form\DeleteMultipleForm;
+use Drupal\Core\Entity\Form\RevisionRevertForm;
 use Drupal\Core\Entity\RevisionLogEntityTrait;
+use Drupal\Core\Entity\Routing\RevisionHtmlRouteProvider;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
 use Drupal\entity\QueryAccess\UncacheableQueryAccessHandler;
 use Drupal\entity\Revision\RevisionableContentEntityBase;
 use Drupal\entity\Routing\AdminHtmlRouteProvider;
-use Drupal\entity\Routing\RevisionRouteProvider;
 use Drupal\entity\UncacheableEntityAccessControlHandler;
 use Drupal\entity\UncacheableEntityPermissionProvider;
 use Drupal\plan\Form\PlanForm;
@@ -57,10 +58,11 @@ use Drupal\views\EntityViewsData;
       'edit' => PlanForm::class,
       'delete' => ContentEntityDeleteForm::class,
       'delete-multiple-confirm' => DeleteMultipleForm::class,
+      'revision-revert' => RevisionRevertForm::class,
     ],
     'route_provider' => [
       'default' => AdminHtmlRouteProvider::class,
-      'revision' => RevisionRouteProvider::class,
+      'revision' => RevisionHtmlRouteProvider::class,
     ],
     'local_task_provider' => [
       'default' => DefaultEntityLocalTaskProvider::class,

--- a/modules/core/plan/src/Hook/AccessHooks.php
+++ b/modules/core/plan/src/Hook/AccessHooks.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\plan\Hook;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Access\AccessResultInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Access hook implementations for plan.
+ */
+class AccessHooks {
+
+  /**
+   * Implements hook_entity_access().
+   */
+  #[Hook('entity_access')]
+  public function entityAccess(EntityInterface $entity, $operation, AccountInterface $account): AccessResultInterface {
+
+    // Default to neutral.
+    $access = AccessResult::neutral();
+
+    // We only care about plan entities.
+    if ($entity->getEntityTypeId() !== 'plan') {
+      return $access;
+    }
+
+    // Allow access to view revisions if the user has "view all plan revisions"
+    // permission.
+    if (in_array($operation, ['view revision', 'view all revisions'])) {
+      $access = AccessResult::allowedIfHasPermission($account, 'view all plan revisions');
+    }
+
+    // Allow access to revert revisions if the user has "revert all plan
+    // revisions" permission.
+    if ($operation === 'revert') {
+      $access = AccessResult::allowedIfHasPermission($account, 'revert all plan revisions');
+    }
+
+    // Return the access result.
+    return $access;
+  }
+
+}


### PR DESCRIPTION
This changes the way that we build the routes for viewing and reverting entity revisions in farmOS.

Previously, we relied on the Entity API module's `RevisionRouteProvider` to create the routes and check access to them.

Now, we use Drupal core's `RevisionHtmlRouteProvider`, which was introduced in Drupal 10.1 (see https://www.drupal.org/node/3160443). We weren't in any rush to move to this, but now that the Diff module supports comparing custom entity types (see https://www.drupal.org/project/diff/issues/2452523) we have a good reason to make this change.

This requires a couple of changes:

1. We need to define the `revision_data_table` attribute for our entity types, otherwise a PHP exception is thrown on Drupal core's revisions overview route. This also requires an update hook. For more details, see: https://www.drupal.org/node/3596981
2. We need to change from using Entity API's `RevisionRouteProvider`, to Drupal core's `RevisionHtmlRouteProvider` in our entity definitions. This has two sub-requirements as well:
    1. We need to implement `hook_entity_access()` to check for our custom `view all [entity-type] revisions` and `revert all [entity-type] revisions` permissions. Entity API handled this via its own route access checking, but Drupal core does not. It uses the standard `_entity_access` requirement (which invokes `hook_entity_access()`).
    2. We need to declare the `revision-revert` form class in our entity definitions. Drupal core's revision UI expects this to be set, and throws an error if you try to revert a revision without it.
3. We need to update the Log module to ^4.0.2, which includes all of these same changes.