### PR TITLE
Add the Diff module for comparing entity revisions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "drupal/consumers": "^1.22",
         "drupal/csv_serialization": "^4.0.1",
         "drupal/date_popup": "^2.0",
+        "drupal/diff": "^2.1.0",
         "drupal/entity": "1.6",
         "drupal/entity_browser": "^2.12",
         "drupal/entity_reference_integrity": "^2.0",

--- a/modules/core/entity/farm_entity.info.yml
+++ b/modules/core/entity/farm_entity.info.yml
@@ -4,6 +4,7 @@ type: module
 package: farmOS
 core_version_requirement: ^11
 dependencies:
+  - diff:diff
   - entity:entity
   - entity_reference_integrity:entity_reference_integrity_enforce
   - farm:farm_entity_access

--- a/modules/core/entity/farm_entity.post_update.php
+++ b/modules/core/entity/farm_entity.post_update.php
@@ -37,6 +37,15 @@ function farm_entity_post_update_revision_translations_affected(&$sandbox) {
 }
 
 /**
+ * Install the diff module.
+ */
+function farm_entity_post_update_install_diff(&$sandbox) {
+  if (!\Drupal::service('module_handler')->moduleExists('diff')) {
+    \Drupal::service('module_installer')->install(['diff']);
+  }
+}
+
+/**
  * Implements hook_removed_post_updates().
  */
 function farm_entity_removed_post_updates() {


### PR DESCRIPTION
The Drupal [Diff](https://www.drupal.org/project/diff) module recently merged a long-awaited feature request: [Offer a revisions tab for all entities](https://www.drupal.org/project/diff/issues/2452523)

This adds UI for comparing the differences between entity revisions. Previously this was only available for `node` entities.