### PR TITLE
Add a Farm reference field to plans

### DIFF
--- a/modules/organization/farm/src/Hook/FieldHooks.php
+++ b/modules/organization/farm/src/Hook/FieldHooks.php
@@ -29,20 +29,22 @@ class FieldHooks {
   public function entityBaseFieldInfo(EntityTypeInterface $entity_type) {
     $fields = [];
 
+    // Define common Farm reference field options.
+    $options = [
+      'type' => 'entity_reference',
+      'label' => $this->t('Farm'),
+      'description' => $this->t('What farm is this associated with?'),
+      'target_type' => 'organization',
+      'target_bundle' => 'farm',
+      'multiple' => FALSE,
+      'weight' => [
+        'form' => 55,
+        'view' => -5,
+      ],
+    ];
+
     // Add a Farm reference field to assets.
     if ($entity_type->id() == 'asset') {
-      $options = [
-        'type' => 'entity_reference',
-        'label' => $this->t('Farm'),
-        'description' => $this->t('What farm is this associated with?'),
-        'target_type' => 'organization',
-        'target_bundle' => 'farm',
-        'multiple' => FALSE,
-        'weight' => [
-          'form' => 55,
-          'view' => -5,
-        ],
-      ];
       $fields['farm'] = $this->farmFieldFactory->baseFieldDefinition($options);
 
       // Add a constraint to ensure that assets are in the same farm as their
@@ -61,6 +63,12 @@ class FieldHooks {
         $fields['farm']->addConstraint('AssetGroupAssignmentFarm');
       }
     }
+
+    // Add a Farm reference field to plans.
+    elseif ($entity_type->id() == 'plan') {
+      $fields['farm'] = $this->farmFieldFactory->baseFieldDefinition($options);
+    }
+
     return $fields;
   }
 


### PR DESCRIPTION
This adds a `farm` reference field to `plan` entities, for referencing `organization` entities of type `farm`. This is identical to the way that we add a `farm` reference field to `asset` entities. These reference fields are only added if the `farm_farm` module is installed (which provides the `farm` `organization` bundle).

The reason to do this is so that modules like `farm_multitenant` (https://www.drupal.org/project/farm_multitenant) can add access control to `plan` entities based on the `farm` they are associated with.

See this comment (and surrounding discussion) for more context and reasoning: https://farmos.discourse.group/t/question-about-moving-intake-process-into-multi-tenant-infrastructure/2547/6

Notably, this PR does NOT currently add any field constraint validation logic to this new reference field like we do already for `asset` entities. This is worth discussing and considering the ramifications in more depth before merging this. To summarize both sides of thinking: a) it is technically challenging to add constraint validation because we don't know what reference fields downstream modules will add to their `plan` and `plan_record` bundles, but b) if we don't, then it opens the possibility for data to cross the line between different farm organizations. Perhaps that should be the responsibility of the downstream modules to maintain that separation (or not). But if we allow it to start then there's no going back. This is why we decided to be conservative in #849 and add the constraints to asset `farm` reference fields, to prevent any cross-farm relationships.