### PR TITLE
Require plan records to reference a plan

### DIFF
--- a/modules/core/plan/src/Entity/PlanRecord.php
+++ b/modules/core/plan/src/Entity/PlanRecord.php
@@ -76,6 +76,7 @@ class PlanRecord extends ContentEntityBase implements PlanRecordInterface {
       ->setDescription(t('Associate this plan record relationship with a plan entity.'))
       ->setTranslatable(FALSE)
       ->setCardinality(1)
+      ->setRequired(TRUE)
       ->setSetting('target_type', 'plan')
       ->setDisplayOptions('form', [
         'type' => 'entity_reference',


### PR DESCRIPTION
Currently, `plan_record` entities have a `plan` reference field for linking them to a `plan`. This field is currently optional, which was not intentional. It should have been required, and we describe it as such in the data model docs:

> Every Plan Record must specify a single [Plan](https://farmos.org/model/type/plan) that it is associated with.

https://farmos.org/model/type/plan_record/

This PR makes it required.

Note: this is probably also a prerequisite for fixing: https://github.com/farmOS/farmOS/issues/875

See @paul121's comment about this specifically:

> As a side note, I think we should make the plan record required? Not sure why this isn't already the case, but maybe there is something we thought of?

https://github.com/farmOS/farmOS/issues/875#issuecomment-2362416235

And my response:

> I don't recall any reason that it was not required. I agree that it should be.

https://github.com/farmOS/farmOS/issues/875#issuecomment-2363671763

One could argue that making it required in 4.x is a breaking change, but I think we should do it. I'm not aware of any modules that are using this field optionally, and the intention for these entities is that they are always tied to a plan.