### PR TITLE
Preserve parent plan access cacheability in plan_record access #1089

### DIFF
--- a/modules/core/plan/src/Access/PlanRecordAccess.php
+++ b/modules/core/plan/src/Access/PlanRecordAccess.php
@@ -22,7 +22,15 @@ class PlanRecordAccess extends EntityAccessControlHandler {
 
     // If a plan is referenced, access is based on access to the plan.
     if ($entity instanceof PlanRecordInterface && $plan = $entity->getPlan()) {
-      return AccessResult::allowedIf($plan->access($operation, $account));
+      // Request the access result as an object ($return_as_object = TRUE) and
+      // depend on it, so the plan access handler's cacheability propagates to
+      // the plan_record (e.g. the user.permissions context, plus any membership
+      // or group dependencies a contrib access handler adds). The bool form
+      // would discard it, leaving the record grant cached without the
+      // dependencies that should invalidate it. Allowed/neutral semantics are
+      // unchanged. See https://github.com/farmOS/farmOS/issues/1089.
+      $plan_access = $plan->access($operation, $account, TRUE);
+      return AccessResult::allowedIf($plan_access->isAllowed())->addCacheableDependency($plan_access);
     }
 
     // Otherwise, delegate to the parent method.

--- a/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
+++ b/modules/core/plan/tests/src/Kernel/PlanRecordTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\Tests\plan\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\user\Traits\UserCreationTrait;
 use Drupal\plan\Entity\Plan;
 use Drupal\plan\Entity\PlanRecord;
 use PHPUnit\Framework\Attributes\Group;
@@ -16,6 +17,8 @@ use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 #[Group('farm')]
 #[RunTestsInSeparateProcesses]
 class PlanRecordTest extends KernelTestBase {
+
+  use UserCreationTrait;
 
   /**
    * {@inheritdoc}
@@ -35,6 +38,7 @@ class PlanRecordTest extends KernelTestBase {
     parent::setUp();
     $this->installEntitySchema('plan');
     $this->installEntitySchema('plan_record');
+    $this->installEntitySchema('user');
     $this->installConfig(['plan_test']);
   }
 
@@ -82,6 +86,41 @@ class PlanRecordTest extends KernelTestBase {
     $this->assertCount(0, $plans);
     $plan_records = $plan_record_storage->loadMultiple();
     $this->assertCount(0, $plan_records);
+  }
+
+  /**
+   * Test that plan_record access inherits the parent plan's cacheability.
+   *
+   * @see https://github.com/farmOS/farmOS/issues/1089
+   */
+  public function testPlanRecordAccessCacheability() {
+
+    // Create a plan and a plan_record that references it.
+    $plan = Plan::create([
+      'name' => 'Test plan',
+      'type' => 'default',
+    ]);
+    $plan->save();
+    $plan_record = PlanRecord::create([
+      'plan' => $plan,
+      'type' => 'default',
+    ]);
+    $plan_record->save();
+
+    // Create a user to perform access checks as.
+    $account = $this->createUser();
+
+    // The plan's access result carries cacheability metadata (the plan uses the
+    // entity API uncacheable access handler, which varies access by the current
+    // user's permissions). The plan_record's access result must inherit that
+    // same cacheability, so it is invalidated whenever the plan's access is.
+    foreach (['view', 'update', 'delete'] as $operation) {
+      $plan_access = $plan->access($operation, $account, TRUE);
+      $record_access = $plan_record->access($operation, $account, TRUE);
+      $this->assertEqualsCanonicalizing($plan_access->getCacheContexts(), $record_access->getCacheContexts(), "plan_record '$operation' access inherits the plan's cache contexts.");
+      $this->assertEqualsCanonicalizing($plan_access->getCacheTags(), $record_access->getCacheTags(), "plan_record '$operation' access inherits the plan's cache tags.");
+      $this->assertEquals($plan_access->getCacheMaxAge(), $record_access->getCacheMaxAge(), "plan_record '$operation' access inherits the plan's cache max-age.");
+    }
   }
 
 }


### PR DESCRIPTION
Fixes #1089.

## Problem
`PlanRecordAccess::checkAccess()` delegates a record's access to its parent plan but discards the plan access result's cacheability:

```php
return AccessResult::allowedIf($plan->access($operation, $account));
```

`$plan->access($operation, $account)` returns a **bool** (default `$return_as_object = FALSE`), so `AccessResult::allowedIf()` produces a fresh result with **no** cache contexts, tags, or max-age from the plan access handler. The plan_record grant is therefore cached without any dependency on what the plan's access actually varies by — so it can go **stale** (e.g. after a membership/permission change that correctly re-evaluates the plan).

This surfaced downstream in the farmOS soil-health `quickform_plans` module (a contrib plan access handler that scopes plans by org-group membership): plan grants re-evaluate on a membership change, but plan_record grants don't.

## Fix
The "minimal and behavior-preserving" approach from the issue (per @mstenta's preference): keep the existing allowed/neutral semantics, but carry the plan access result's cache metadata.

```php
$plan_access = $plan->access($operation, $account, TRUE);
return AccessResult::allowedIf($plan_access->isAllowed())->addCacheableDependency($plan_access);
```

## Test
Adds `PlanRecordTest::testPlanRecordAccessCacheability()`, asserting that a plan_record's access result carries the same cache contexts/tags/max-age as its parent plan's, for `view`/`update`/`delete`. It **fails on unpatched core** (record contexts empty vs. the plan's `user.permissions`) and **passes with the fix** — verified locally against a farmOS `4.x` install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)