### PR TITLE
Update Drupal core to 11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Update Drupal core to 11.4 #1096](https://github.com/farmOS/farmOS/pull/1096)
+
 ## [4.0.4] 2026-07-16
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release updates Drupal core to 11.4, which introduces a change to some
+normalization method signatures. If you maintain a module that extends any of
+the Drupal core or farmOS normalization classes, you may need to update your
+method signatures and declare compatibility with Drupal <11.4 or >=11.4
+accordingly. Drupal core's
+[backwards compatibility policy](https://www.drupal.org/about/core/policies/core-change-policies/bc-policy)
+does not consider this a breaking change, and farmOS follows this upstream
+pattern. farmOS core's CSV normalization methods were updated to make them
+compatible with Drupal 11.4+.
+
 ### Changed
 
 - [Update Drupal core to 11.4 #1096](https://github.com/farmOS/farmOS/pull/1096)

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,6 @@
         "patches": {
             "drupal/core": {
                 "Issue #2339235: Remove taxonomy hard dependency on node module": "https://www.drupal.org/files/issues/2025-12-23/2339235-96.patch",
-                "Issue #1874838: Allow exposed blocks to use 'Link display' settings": "https://www.drupal.org/files/issues/2021-11-11/1874838-26.patch",
                 "Issue #2909128: Autocomplete not working on Chrome Android": "https://www.drupal.org/files/issues/2023-07-11/2909128-92.patch"
             },
             "drupal/entity": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "cweagans/composer-patches": "^1.6",
         "drupal/admin_toolbar": "^3.5",
-        "drupal/core": "11.3.14",
+        "drupal/core": "11.4.4",
         "drupal/config_update": "^2.0@alpha",
         "drupal/consumers": "^1.22",
         "drupal/csv_serialization": "^4.0.1",

--- a/composer.project.json
+++ b/composer.project.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "cweagans/composer-patches": "^1.7",
-        "drupal/core-composer-scaffold": "11.3.14"
+        "drupal/core-composer-scaffold": "11.4.4"
     },
     "require-dev": {
         "behat/mink": "^1.11",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ##
 # Alias the Drupal base image for use in other build stages.
 # We do this so that the Drupal image version only needs to be updated here.
-FROM drupal:11.3-php8.4-apache-trixie AS baseimage
+FROM drupal:11.4-php8.4-apache-trixie AS baseimage
 
 # Define common paths.
 # BUILD_PATH is where the farmOS codebase will be built.

--- a/docker/build-farmOS.sh
+++ b/docker/build-farmOS.sh
@@ -58,6 +58,7 @@ allowedPlugins=(
   "drupal/core-composer-scaffold"
   "oomphinc/composer-installers-extender"
   "phpstan/extension-installer"
+  "symfony/runtime"
   "wikimedia/composer-merge-plugin"
 )
 for plugin in ${allowedPlugins[@]}; do

--- a/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
+++ b/modules/asset/equipment/tests/src/Functional/EquipmentFieldTest.php
@@ -21,7 +21,7 @@ class EquipmentFieldTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/core/api/tests/src/Functional/EntryPointTest.php
+++ b/modules/core/api/tests/src/Functional/EntryPointTest.php
@@ -74,14 +74,14 @@ class EntryPointTest extends FarmBrowserTestBase {
 
     // A `me` link must be present for authenticated users.
     $user = $this->createUser();
-    // PHPStan level 2+ throws the following errors when we try to use
-    // $user->name and $user->passRaw:
-    // Cannot access property $name on Drupal\user\UserInterface|false.
-    // Cannot access property $passRaw on Drupal\user\UserInterface|false.
+    // PHPStan throws the following errors when we try to use $user->name and
+    // $user->passRaw:
+    // Access to an undefined property Drupal\user\UserInterface::$name.
+    // Access to an undefined property Drupal\user\UserInterface::$passRaw.
     // We ignore these because we are following Drupal core's pattern.
-    // @phpstan-ignore property.nonObject
+    // @phpstan-ignore property.notFound
     $username = $user->name->value;
-    // @phpstan-ignore property.nonObject
+    // @phpstan-ignore property.notFound
     $userpass = $user->passRaw;
     $request_options[RequestOptions::HEADERS]['Authorization'] = 'Basic ' . base64_encode($username . ':' . $userpass);
     $response = $this->request('GET', Url::fromUri('base://api'), $request_options);

--- a/modules/core/comment/src/FarmCommentHelper.php
+++ b/modules/core/comment/src/FarmCommentHelper.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\farm_comment;
 
-use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
+use Drupal\comment\CommentingStatus;
 use Drupal\entity\BundleFieldDefinition;
 
 /**
@@ -27,8 +27,8 @@ class FarmCommentHelper {
     // We use BundleFieldDefinition instead of BaseFieldDefinition to force
     // Drupal to create a separate database table for this field. Otherwise, if
     // it is added to the base table then the comment field default value is
-    // always 0 (CommentItemInterface::HIDDEN) instead of 2
-    // (CommentItemInterface::OPEN), because the
+    // always 0 (CommentingStatus::Hidden->value) instead of 2
+    // (CommentingStatus::Open->value), because the
     // Drupal\comment\Plugin\Field\FieldType\CommentItem::schema() default is 0.
     $field = BundleFieldDefinition::create('comment');
 
@@ -45,7 +45,7 @@ class FarmCommentHelper {
     // Enable comments on entities by default.
     $default_value = [
       [
-        'status' => CommentItemInterface::OPEN,
+        'status' => CommentingStatus::Open->value,
         'cid' => 0,
         'last_comment_timestamp' => 0,
         'last_comment_name' => '',

--- a/modules/core/csv/src/Normalizer/ContentEntityNormalizer.php
+++ b/modules/core/csv/src/Normalizer/ContentEntityNormalizer.php
@@ -20,7 +20,7 @@ class ContentEntityNormalizer extends CoreContentEntityNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($entity, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($entity, $format = NULL, array $context = []): array {
     $data = parent::normalize($entity, $format, $context);
 
     // If columns were explicitly included, remove others.

--- a/modules/core/csv/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -22,19 +22,19 @@ class EntityReferenceFieldItemNormalizer extends CoreEntityReferenceFieldItemNor
   /**
    * {@inheritdoc}
    */
-  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($field_item, $format = NULL, array $context = []): array {
 
     // Attempt to load the referenced entity.
     if ($entity = $field_item->get('entity')->getValue()) {
 
       // Return content entity labels, if desired.
       if ($entity instanceof ContentEntityInterface && isset($context['content_entity_labels']) && $context['content_entity_labels'] === TRUE) {
-        return $entity->label();
+        return ['value' => $entity->label()];
       }
 
       // Return config entity IDs, if desired.
       if ($entity instanceof ConfigEntityInterface && isset($context['config_entity_ids']) && $context['config_entity_ids'] === TRUE) {
-        return $entity->id();
+        return ['value' => $entity->id()];
       }
     }
 

--- a/modules/core/csv/src/Normalizer/FractionFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/FractionFieldItemNormalizer.php
@@ -20,9 +20,9 @@ class FractionFieldItemNormalizer extends FieldItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($field_item, $format = NULL, array $context = []): array {
     /** @var \Drupal\fraction\Plugin\Field\FieldType\FractionItem $field_item */
-    return $field_item->get('decimal')->getValue();
+    return ['value' => $field_item->get('decimal')->getValue()];
   }
 
   /**

--- a/modules/core/csv/src/Normalizer/GeofieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/GeofieldItemNormalizer.php
@@ -20,12 +20,12 @@ class GeofieldItemNormalizer extends FieldItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($object, $format = NULL, array $context = []): array {
     $data = parent::normalize($object, $format, $context);
 
     // Return the WKT value, if desired.
     if (isset($context['wkt']) && $context['wkt'] === TRUE) {
-      return $data['value'];
+      return ['value' => $data['value']];
     }
 
     return $data;

--- a/modules/core/csv/src/Normalizer/QuantityNormalizer.php
+++ b/modules/core/csv/src/Normalizer/QuantityNormalizer.php
@@ -14,7 +14,7 @@ class QuantityNormalizer extends ContentEntityNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($entity, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($entity, $format = NULL, array $context = []): array {
     $data = parent::normalize($entity, $format, $context);
 
     // Query the log associated with the quantity.

--- a/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TextLongFieldItemNormalizer.php
@@ -20,7 +20,7 @@ class TextLongFieldItemNormalizer extends FieldItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($field_item, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($field_item, $format = NULL, array $context = []): array {
     /** @var \Drupal\text\Plugin\Field\FieldType\TextLongItem $field_item */
 
     // If processed_text is explicitly set, return processed or raw user input
@@ -29,10 +29,10 @@ class TextLongFieldItemNormalizer extends FieldItemNormalizer {
       if ($context['processed_text']) {
         /** @var \Drupal\filter\Render\FilteredMarkup $processed_text */
         $processed_text = $field_item->get('processed')->getValue();
-        return (string) $processed_text;
+        return ['value' => (string) $processed_text];
       }
       else {
-        return $field_item->get('value')->getValue();
+        return ['value' => $field_item->get('value')->getValue()];
       }
     }
 

--- a/modules/core/csv/src/Normalizer/TimestampItemNormalizer.php
+++ b/modules/core/csv/src/Normalizer/TimestampItemNormalizer.php
@@ -19,12 +19,12 @@ class TimestampItemNormalizer extends CoreTimestampItemNormalizer {
   /**
    * {@inheritdoc}
    */
-  public function normalize($object, $format = NULL, array $context = []): array|string|int|float|bool|\ArrayObject|null {
+  public function normalize($object, $format = NULL, array $context = []): array {
     $data = parent::normalize($object, $format, $context);
 
     // Return the RFC3339 formatted date, if desired.
     if (isset($context['rfc3339_dates']) && $context['rfc3339_dates'] === TRUE) {
-      return $data['value'];
+      return ['value' => $data['value']];
     }
 
     return $data;

--- a/modules/core/data_stream/src/Hook/ThemeHooks.php
+++ b/modules/core/data_stream/src/Hook/ThemeHooks.php
@@ -88,7 +88,12 @@ class ThemeHooks {
     }
 
     // Add the basic data block view.
-    $build['views']['data'] = views_embed_view('data_stream_basic_data', 'block', $data_stream->id());
+    $build['views']['data'] = [
+      '#type' => 'view',
+      '#name' => 'data_stream_basic_data',
+      '#display_id' => 'block',
+      '#arguments' => [$data_stream->id()],
+    ];
   }
 
 }

--- a/modules/core/import/modules/csv/src/Controller/CsvImportController.php
+++ b/modules/core/import/modules/csv/src/Controller/CsvImportController.php
@@ -183,7 +183,12 @@ class CsvImportController extends ControllerBase {
         '#open' => TRUE,
         '#weight' => 100,
       ];
-      $build['imported']['view'] = views_embed_view('farm_import_csv_' . $entity_type, 'default', $migration_id);
+      $build['imported']['view'] = [
+        '#type' => 'view',
+        '#name' => 'farm_import_csv_' . $entity_type,
+        '#display_id' => 'default',
+        '#arguments' => [$migration_id],
+      ];
     }
 
     return $build;

--- a/modules/core/inventory/tests/src/Functional/InventoryTest.php
+++ b/modules/core/inventory/tests/src/Functional/InventoryTest.php
@@ -25,7 +25,7 @@ class InventoryTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/core/location/tests/src/Functional/LocationAPITest.php
+++ b/modules/core/location/tests/src/Functional/LocationAPITest.php
@@ -47,12 +47,15 @@ class LocationAPITest extends FarmBrowserTestBase {
     // Setup the request.
     $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
     $request_options[RequestOptions::HEADERS]['Content-Type'] = 'application/vnd.api+json';
-    // PHPStan level 2+ throws the following error on the next line:
-    // Binary operation "." between non-falsy-string and
-    // Drupal\Core\Field\FieldItemListInterface results in an error.
+    // PHPStan throws the following errors on the next lines:
+    // Cannot access property $name on bool|Drupal\user\UserInterface.
+    // Cannot access property $passRaw on bool|Drupal\user\UserInterface.
     // We ignore this because we are following Drupal core's pattern.
-    // @phpstan-ignore binaryOp.invalid
-    $request_options[RequestOptions::HEADERS]['Authorization'] = 'Basic ' . base64_encode($this->user->name->value . ':' . $this->user->passRaw);
+    // @phpstan-ignore property.nonObject
+    $user_name = $this->user->name->value;
+    // @phpstan-ignore property.nonObject
+    $user_pass = $this->user->passRaw;
+    $request_options[RequestOptions::HEADERS]['Authorization'] = 'Basic ' . base64_encode($user_name . ':' . $user_pass);
     $asset_uri = "base://api/asset/object";
 
     // Create an asset with no intrinsic geometry.

--- a/modules/core/location/tests/src/Functional/LocationFunctionalTestTrait.php
+++ b/modules/core/location/tests/src/Functional/LocationFunctionalTestTrait.php
@@ -12,7 +12,7 @@ trait LocationFunctionalTestTrait {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/core/login/src/Hook/FormHooks.php
+++ b/modules/core/login/src/Hook/FormHooks.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Drupal\farm_login\Hook;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Hook\Attribute\Hook;
 use Drupal\Core\Render\Element\Email;
@@ -19,6 +20,7 @@ class FormHooks {
 
   public function __construct(
     protected ConfigFactoryInterface $configFactory,
+    protected EntityTypeManagerInterface $entityTypeManager,
   ) {}
 
   /**
@@ -55,7 +57,9 @@ class FormHooks {
 
       // If the email address is associated with a user, use their account name
       // for later validation.
-      if ($user = user_load_by_mail($mail)) {
+      $users = \Drupal::entityTypeManager()->getStorage('user')->loadByProperties(['mail' => $mail]);
+      if (!empty($users)) {
+        $user = reset($users);
         $form_state->setValue('name', $user->getAccountName());
       }
     }

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -53,6 +53,10 @@ class UserLoginTest extends FarmBrowserTestBase {
     // 2. Login the user using their username.
     $user = $this->drupalCreateUser([]);
     $this->drupalGet('user/login', ['query' => ['destination' => 'foo']]);
+    // PHPStan throws the following errors on the next line:
+    // Cannot access property $passRaw on bool|Drupal\user\UserInterface.
+    // We ignore this because we are following Drupal core's pattern.
+    // @phpstan-ignore property.notFound
     $edit = ['name' => $user->getAccountName(), 'pass' => $user->passRaw];
     $this->submitForm($edit, 'Log in');
     $this->assertSession()->addressEquals('foo');
@@ -61,6 +65,10 @@ class UserLoginTest extends FarmBrowserTestBase {
     // 3. Login the user using their email.
     $user = $this->drupalCreateUser([]);
     $this->drupalGet('user/login', ['query' => ['destination' => 'foo']]);
+    // PHPStan throws the following errors on the next line:
+    // Cannot access property $passRaw on bool|Drupal\user\UserInterface.
+    // We ignore this because we are following Drupal core's pattern.
+    // @phpstan-ignore property.notFound
     $edit = ['name' => $user->getEmail(), 'pass' => $user->passRaw];
     $this->submitForm($edit, 'Log in');
     $this->assertSession()->addressEquals('foo');
@@ -69,6 +77,10 @@ class UserLoginTest extends FarmBrowserTestBase {
     // 4. Login with an invalid username/email.
     $user = $this->drupalCreateUser([]);
     $this->drupalGet('user/login', ['query' => ['destination' => 'foo']]);
+    // PHPStan throws the following errors on the next line:
+    // Cannot access property $passRaw on bool|Drupal\user\UserInterface.
+    // We ignore this because we are following Drupal core's pattern.
+    // @phpstan-ignore property.notFound
     $edit = ['name' => 'invalid@email.com', 'pass' => $user->passRaw];
     $this->submitForm($edit, 'Log in');
     $this->assertSession()->statusCodeEquals(200);
@@ -95,11 +107,10 @@ class UserLoginTest extends FarmBrowserTestBase {
 
     $user1 = $this->drupalCreateUser([]);
     $incorrect_user1 = clone $user1;
-    // PHPStan level 2+ throws the following error on the next line:
-    // Binary operation ".=" between Drupal\Core\Field\FieldItemListInterface
-    // and 'incorrect' results in an error.
+    // PHPStan throws the following error on the next line:
+    // Access to an undefined property Drupal\user\UserInterface::$passRaw.
     // We ignore this because we are following Drupal core's pattern.
-    // @phpstan-ignore assignOp.invalid
+    // @phpstan-ignore property.notFound
     $incorrect_user1->passRaw .= 'incorrect';
 
     $user2 = $this->drupalCreateUser([]);
@@ -152,6 +163,10 @@ class UserLoginTest extends FarmBrowserTestBase {
     $this->drupalGet(Url::fromRoute('user.login'));
     $this->submitForm([
       'name' => $account->getEmail(),
+      // PHPStan throws the following error on the next line:
+      // Access to an undefined property Drupal\user\UserInterface::$passRaw.
+      // We ignore this because we are following Drupal core's pattern.
+      // @phpstan-ignore property.notFound
       'pass' => $account->passRaw,
     ], 'Log in');
     if (isset($flood_trigger)) {

--- a/modules/core/login/tests/src/Functional/UserLoginTest.php
+++ b/modules/core/login/tests/src/Functional/UserLoginTest.php
@@ -7,7 +7,6 @@ namespace Drupal\Tests\farm_login\Functional;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\Url;
 use Drupal\Tests\farm_test\Functional\FarmBrowserTestBase;
-use Drupal\user\Entity\User;
 use Drupal\user\UserInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
@@ -144,7 +143,7 @@ class UserLoginTest extends FarmBrowserTestBase {
    *
    * A copy of the core assertFailedLogin() method, but that uses email instead.
    *
-   * @param \Drupal\user\Entity\User $account
+   * @param \Drupal\user\UserInterface $account
    *   A user object with name and passRaw attributes for the login attempt.
    * @param mixed $flood_trigger
    *   (optional) Whether or not to expect that the flood control mechanism
@@ -158,7 +157,7 @@ class UserLoginTest extends FarmBrowserTestBase {
    *
    * @see UserLoginTest::assertFailedLogin()
    */
-  public function assertFailedLoginUsingEmail(User $account, $flood_trigger = NULL) {
+  public function assertFailedLoginUsingEmail(UserInterface $account, $flood_trigger = NULL) {
     $database = \Drupal::database();
     $this->drupalGet(Url::fromRoute('user.login'));
     $this->submitForm([

--- a/modules/core/ui/action/tests/src/Functional/ActionsTest.php
+++ b/modules/core/ui/action/tests/src/Functional/ActionsTest.php
@@ -20,7 +20,7 @@ class ActionsTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
+++ b/modules/core/ui/dashboard/tests/src/Functional/DashboardTest.php
@@ -18,7 +18,7 @@ class DashboardTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/core/ui/views/config/optional/views.view.farm_organization_log.yml
+++ b/modules/core/ui/views/config/optional/views.view.farm_organization_log.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - organization.type.farm
+    - taxonomy.vocabulary.log_category
   module:
     - entity_reference_revisions
     - farm_entity_access
@@ -10,6 +11,7 @@ dependencies:
     - log
     - options
     - state_machine
+    - taxonomy
   enforced:
     module:
       - farm_ui_views

--- a/modules/core/ui/views/src/Plugin/views/argument/AssetOrLocationArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/AssetOrLocationArgument.php
@@ -5,15 +5,26 @@ declare(strict_types=1);
 namespace Drupal\farm_ui_views\Plugin\views\argument;
 
 use Drupal\views\Attribute\ViewsArgument;
+use Drupal\views\Plugin\ViewsHandlerManager;
 use Drupal\views\Plugin\views\argument\ArgumentPluginBase;
 use Drupal\views\Plugin\views\query\Sql;
-use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Argument handler for both the asset and location fields on logs.
  */
 #[ViewsArgument("asset_or_location")]
 class AssetOrLocationArgument extends ArgumentPluginBase {
+
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    #[Autowire(service: 'plugin.manager.views.join')]
+    protected ViewsHandlerManager $viewsJoinPluginManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
 
   /**
    * {@inheritdoc}
@@ -28,7 +39,7 @@ class AssetOrLocationArgument extends ArgumentPluginBase {
     // Join the log__asset table with a condition to match the asset ID.
     $this->ensureMyTable();
     /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
-    $join = Views::pluginManager('join')->createInstance('standard', [
+    $join = $this->viewsJoinPluginManager->createInstance('standard', [
       'table' => 'log__asset',
       'field' => 'entity_id',
       'left_table' => $this->table,
@@ -48,7 +59,7 @@ class AssetOrLocationArgument extends ArgumentPluginBase {
 
     // Join the log__location table with a condition to match the asset ID.
     /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
-    $join = Views::pluginManager('join')->createInstance('standard', [
+    $join = $this->viewsJoinPluginManager->createInstance('standard', [
       'table' => 'log__location',
       'field' => 'entity_id',
       'left_table' => $this->table,

--- a/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
+++ b/modules/core/ui/views/src/Plugin/views/argument/EntityTaxonomyTermReferenceArgument.php
@@ -9,9 +9,10 @@ use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
 use Drupal\views\Attribute\ViewsArgument;
+use Drupal\views\Plugin\ViewsHandlerManager;
 use Drupal\views\Plugin\views\argument\NumericArgument;
 use Drupal\views\Plugin\views\query\Sql;
-use Drupal\views\Views;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Argument handler for taxonomy term references from an arbitrary entity field.
@@ -28,6 +29,8 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
     protected EntityTypeManagerInterface $entityTypeManager,
     protected EntityTypeBundleInfoInterface $entityTypeBundleInfo,
     protected EntityFieldManagerInterface $entityFieldManager,
+    #[Autowire(service: 'plugin.manager.views.join')]
+    protected ViewsHandlerManager $viewsJoinPluginManager,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -106,7 +109,7 @@ class EntityTaxonomyTermReferenceArgument extends NumericArgument {
 
               // Join the taxonomy reference field table with the entity.
               /** @var \Drupal\views\Plugin\views\join\JoinPluginBase $join */
-              $join = Views::pluginManager('join')->createInstance('standard', [
+              $join = $this->viewsJoinPluginManager->createInstance('standard', [
                 'table' => $field_table_name,
                 'field' => 'entity_id',
                 'left_table' => $entity_data_table,

--- a/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/DashboardTasksTest.php
@@ -19,7 +19,7 @@ class DashboardTasksTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
+++ b/modules/core/ui/views/tests/src/Functional/TaxonomyTermTasksTest.php
@@ -19,7 +19,7 @@ class TaxonomyTermTasksTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
+++ b/modules/log/input/tests/src/Functional/InputViewMaterialTypeTest.php
@@ -23,7 +23,7 @@ class InputViewMaterialTypeTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 

--- a/modules/organization/farm/tests/src/Functional/FarmFieldTest.php
+++ b/modules/organization/farm/tests/src/Functional/FarmFieldTest.php
@@ -21,7 +21,7 @@ class FarmFieldTest extends FarmBrowserTestBase {
   /**
    * Test user.
    *
-   * @var \Drupal\user\Entity\User|bool
+   * @var \Drupal\user\UserInterface|bool
    */
   protected $user;
 


### PR DESCRIPTION
- [x] Update to Drupal core 11.4.x.
- [x] Allow `symfony/runtime` Composer plugin (see https://www.drupal.org/node/3553275)
- [x] Remove merged `drupal/core` patch for [Issue #1874838: Allow exposed blocks to use 'Link display' settings](https://www.drupal.org/node/1874838)
- [x] Fix PHPStan errors.
- [x] Fix failing tests.