### PR TITLE
Pin rector/rector to 2.5.9

### DIFF
--- a/composer.project.json
+++ b/composer.project.json
@@ -18,6 +18,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpunit/phpunit": "^11.5.3",
         "phpspec/prophecy-phpunit": "^2",
+        "rector/rector": "2.5.9",
         "sebastian/diff": "^6.0.2"
     },
     "conflict": {


### PR DESCRIPTION
Something changed in `rector/rector` 2.6+ that breaks `palantirnet/drupal-rector`, which causes our automated tests to fail with:

`[ERROR] Could not detect twig set.`

I opened an upstream issue: https://git.drupalcode.org/project/rector/-/work_items/3600967

This PR simply pins farmOS to `rector/rector` `2.5.9` until that is fixed.