### PR TITLE
Unpin rector/rector

### DIFF
--- a/composer.project.json
+++ b/composer.project.json
@@ -18,7 +18,6 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpunit/phpunit": "^11.5.3",
         "phpspec/prophecy-phpunit": "^2",
-        "rector/rector": "2.5.9",
         "sebastian/diff": "^6.0.2"
     },
     "conflict": {


### PR DESCRIPTION
This reverts commit acf132432d4503623eafe1d086c5e810f7027b61.

This is a follow-up to #1098, which pinned `rector/rector` to `2.5.9` while we wait for upstream `palantirnet/drupal-rector` fix for this issue: https://git.drupalcode.org/project/rector/-/work_items/3600967