### PR TITLE
Fix KML import crash on placemarks containing CDATA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Import KML placemarks with a name or description that contains CDATA
+
 ## [4.0.5] 2026-08-26
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Import KML placemarks with a name or description that contains CDATA
+- [Fix KML import crash on placemarks containing CDATA #1100](https://github.com/farmOS/farmOS/pull/1100)
 
 ## [4.0.5] 2026-08-26
 

--- a/modules/core/kml/src/Normalizer/KmlNormalizer.php
+++ b/modules/core/kml/src/Normalizer/KmlNormalizer.php
@@ -107,10 +107,17 @@ class KmlNormalizer implements NormalizerInterface, DenormalizerInterface {
       }
 
       // Add standard KML properties if included.
+      // Elements that contain a CDATA section, and elements that contain no
+      // text at all, are decoded into SimpleXMLElement objects. Cast them to
+      // strings, otherwise they cannot be serialized (eg: into form state).
       $keys = $this->supportedProperties();
       foreach ($keys as $property_name) {
         if (isset($placemark[$property_name])) {
-          $properties[$property_name] = $placemark[$property_name];
+          $value = $placemark[$property_name];
+          if ($value instanceof \SimpleXMLElement) {
+            $value = (string) $value;
+          }
+          $properties[$property_name] = $value;
         }
       }
 

--- a/modules/core/kml/tests/src/Kernel/KmlTest.php
+++ b/modules/core/kml/tests/src/Kernel/KmlTest.php
@@ -110,8 +110,7 @@ class KmlTest extends KernelTestBase {
       $this->assertEquals($placemark['name'], $geometries[0]->properties['name'], $label);
       $this->assertEquals($placemark['description'], $geometries[0]->properties['description'], $label);
 
-      // Confirm that the properties can be serialized. The KML importer form
-      // puts them into form state, which Drupal serializes.
+      // Confirm that the properties can be serialized.
       // @see \Drupal\farm_import_kml\Form\KmlImporter
       $serialized = PhpSerialize::encode($geometries[0]->properties);
       $this->assertEquals($geometries[0]->properties, PhpSerialize::decode($serialized), $label);

--- a/modules/core/kml/tests/src/Kernel/KmlTest.php
+++ b/modules/core/kml/tests/src/Kernel/KmlTest.php
@@ -87,6 +87,26 @@ class KmlTest extends KernelTestBase {
         'name' => 'Empty description',
         'description' => '',
       ],
+      // An element only keeps the text that is directly inside it. Text that
+      // is inside child elements is dropped. This is a known limitation. All
+      // supported properties are plain scalar values in practice.
+      'nested child elements' => [
+        'kml' => '<name>Nested</name><description>Hello <b>world</b> and more</description>',
+        'name' => 'Nested',
+        // The text of the <b> element is dropped. Two spaces remain.
+        'description' => 'Hello  and more',
+      ],
+      'nested child element only' => [
+        'kml' => '<name>Nested only</name><description><b>world</b></description>',
+        'name' => 'Nested only',
+        // The element holds no direct text, so the result is an empty string.
+        'description' => '',
+      ],
+      'nested child elements in name' => [
+        'kml' => '<name>Field <b>A</b> north</name><description>Nested name</description>',
+        'name' => 'Field  north',
+        'description' => 'Nested name',
+      ],
     ];
 
     foreach ($placemarks as $label => $placemark) {

--- a/modules/core/kml/tests/src/Kernel/KmlTest.php
+++ b/modules/core/kml/tests/src/Kernel/KmlTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\farm_kml\Kernel;
+
+use Drupal\Component\Serialization\PhpSerialize;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\farm_geo\GeometryWrapper;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
+/**
+ * Tests for KML deserialization.
+ */
+#[Group('farm')]
+#[RunTestsInSeparateProcesses]
+class KmlTest extends KernelTestBase {
+
+  /**
+   * The serializer service.
+   *
+   * @var \Symfony\Component\Serializer\SerializerInterface
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'farm_geo',
+    'farm_kml',
+    'geofield',
+    'serialization',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+    $this->serializer = $this->container->get('serializer');
+  }
+
+  /**
+   * Test that placemark name and description are deserialized as strings.
+   */
+  public function testPlacemarkProperties() {
+    $placemarks = [
+      'plain text' => [
+        'kml' => '<name>Plain</name><description>Plain description</description>',
+        'name' => 'Plain',
+        'description' => 'Plain description',
+      ],
+      'CDATA in description' => [
+        'kml' => '<name>CDATA description</name><description><![CDATA[<h4>Layer: Layer2</h4><p>Fix Quality: DGPS</p>]]></description>',
+        'name' => 'CDATA description',
+        'description' => '<h4>Layer: Layer2</h4><p>Fix Quality: DGPS</p>',
+      ],
+      'CDATA in name' => [
+        'kml' => '<name><![CDATA[Field <b>A</b>]]></name><description>CDATA name</description>',
+        'name' => 'Field <b>A</b>',
+        'description' => 'CDATA name',
+      ],
+      'CDATA with surrounding whitespace' => [
+        'kml' => '<name>Whitespace</name><description> <![CDATA[Indented]]> </description>',
+        'name' => 'Whitespace',
+        'description' => ' Indented ',
+      ],
+      'adjacent CDATA sections' => [
+        'kml' => '<name>Adjacent</name><description><![CDATA[<p>one</p>]]><![CDATA[<p>two</p>]]></description>',
+        'name' => 'Adjacent',
+        'description' => '<p>one</p><p>two</p>',
+      ],
+      'CDATA mixed with text' => [
+        'kml' => '<name>Mixed</name><description>before <![CDATA[<i>middle</i>]]> after</description>',
+        'name' => 'Mixed',
+        'description' => 'before <i>middle</i> after',
+      ],
+      'empty CDATA' => [
+        'kml' => '<name>Empty CDATA</name><description><![CDATA[]]></description>',
+        'name' => 'Empty CDATA',
+        'description' => '',
+      ],
+      'empty description' => [
+        'kml' => '<name>Empty description</name><description></description>',
+        'name' => 'Empty description',
+        'description' => '',
+      ],
+    ];
+
+    foreach ($placemarks as $label => $placemark) {
+      $kml = '<?xml version="1.0" encoding="UTF-8"?>'
+        . '<kml xmlns="http://www.opengis.net/kml/2.2"><Document><Placemark>'
+        . $placemark['kml']
+        . '<Point><coordinates>-97.64455901341667,30.530107166625,179.72090000000003</coordinates></Point>'
+        . '</Placemark></Document></kml>';
+
+      /** @var \Drupal\farm_geo\GeometryWrapper[] $geometries */
+      $geometries = $this->serializer->deserialize($kml, GeometryWrapper::class, 'geometry_kml');
+      $this->assertCount(1, $geometries, $label);
+
+      // Confirm that the geometry was parsed.
+      $this->assertEquals('POINT (-97.64455901341667 30.530107166625)', $geometries[0]->geometry->out('wkt'), $label);
+
+      // Confirm that the name and description are strings with the expected
+      // values. CDATA content must be preserved, not dropped.
+      $this->assertIsString($geometries[0]->properties['name'], $label);
+      $this->assertIsString($geometries[0]->properties['description'], $label);
+      $this->assertEquals($placemark['name'], $geometries[0]->properties['name'], $label);
+      $this->assertEquals($placemark['description'], $geometries[0]->properties['description'], $label);
+
+      // Confirm that the properties can be serialized. The KML importer form
+      // puts them into form state, which Drupal serializes.
+      // @see \Drupal\farm_import_kml\Form\KmlImporter
+      $serialized = PhpSerialize::encode($geometries[0]->properties);
+      $this->assertEquals($geometries[0]->properties, PhpSerialize::decode($serialized), $label);
+    }
+  }
+
+}


### PR DESCRIPTION
The bulk KML importer crashes when a placemark's name or description is wrapped in a CDATA section.

## Why

`KmlNormalizer::denormalize()` reads placemark properties straight out of the array that `simplexml_load_string()` produced. For a plain text element that value is a string. For an element containing a CDATA section, or an element with no text at all, PHP hands back a `SimpleXMLElement` object instead.

That object is then stored in form state. `SimpleXMLElement` cannot be serialized, so the import fails.

## How

Cast the value to a string when it is a `SimpleXMLElement`. CDATA text and empty elements then arrive as ordinary strings, which is what every consumer already expects. Plain text elements are unaffected.

## Tests

Adds `KmlTest`, a kernel test covering four cases: plain text, CDATA in the name, CDATA in the description, and an empty element. Each asserts the resulting property is a string and survives serialization.